### PR TITLE
feat: Preserve extra columns in cluster and subtract UDTFs

### DIFF
--- a/datafusion/bio-function-ranges/src/cluster.rs
+++ b/datafusion/bio-function-ranges/src/cluster.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use datafusion::arrow::array::{Int64Builder, RecordBatch, StringBuilder};
+use datafusion::arrow::array::{Int64Array, Int64Builder, RecordBatch, StringBuilder, UInt32Array};
+use datafusion::arrow::compute::take;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::catalog::Session;
 use datafusion::common::{DataFusionError, Result};
@@ -22,7 +23,7 @@ use datafusion::prelude::{Expr, SessionContext};
 use futures::{Stream, ready};
 
 use crate::filter_op::FilterOp;
-use crate::grouped_stream::StreamCollector;
+use crate::grouped_stream::{FullBatchCollector, IndexedGroups, StreamCollector};
 
 pub struct ClusterProvider {
     session: Arc<SessionContext>,
@@ -31,6 +32,8 @@ pub struct ClusterProvider {
     min_dist: i64,
     filter_op: FilterOp,
     schema: SchemaRef,
+    input_schema: Schema,
+    has_extra_cols: bool,
 }
 
 impl ClusterProvider {
@@ -40,15 +43,29 @@ impl ClusterProvider {
         columns: (String, String, String),
         min_dist: i64,
         filter_op: FilterOp,
+        input_schema: Schema,
     ) -> Self {
-        let schema = Arc::new(Schema::new(vec![
-            Arc::new(Field::new(&columns.0, DataType::Utf8, false)),
-            Arc::new(Field::new(&columns.1, DataType::Int64, false)),
-            Arc::new(Field::new(&columns.2, DataType::Int64, false)),
-            Arc::new(Field::new("cluster", DataType::Int64, false)),
-            Arc::new(Field::new("cluster_start", DataType::Int64, false)),
-            Arc::new(Field::new("cluster_end", DataType::Int64, false)),
-        ]));
+        let has_extra_cols = input_schema.fields().len() > 3;
+
+        let mut fields: Vec<Arc<Field>> = if has_extra_cols {
+            // Preserve all input fields as-is (take kernel returns same types)
+            input_schema.fields().iter().map(Arc::clone).collect()
+        } else {
+            vec![
+                Arc::new(Field::new(&columns.0, DataType::Utf8, false)),
+                Arc::new(Field::new(&columns.1, DataType::Int64, false)),
+                Arc::new(Field::new(&columns.2, DataType::Int64, false)),
+            ]
+        };
+        fields.push(Arc::new(Field::new("cluster", DataType::Int64, false)));
+        fields.push(Arc::new(Field::new(
+            "cluster_start",
+            DataType::Int64,
+            false,
+        )));
+        fields.push(Arc::new(Field::new("cluster_end", DataType::Int64, false)));
+
+        let schema = Arc::new(Schema::new(fields));
         Self {
             session,
             table,
@@ -56,6 +73,8 @@ impl ClusterProvider {
             min_dist,
             filter_op,
             schema,
+            input_schema,
+            has_extra_cols,
         }
     }
 }
@@ -99,18 +118,32 @@ impl TableProvider for ClusterProvider {
             .execution
             .target_partitions;
 
-        let input_df = self.session.table(&self.table).await?.select_columns(&[
-            &self.columns.0,
-            &self.columns.1,
-            &self.columns.2,
-        ])?;
+        let input_df = if self.has_extra_cols {
+            self.session.table(&self.table).await?
+        } else {
+            self.session.table(&self.table).await?.select_columns(&[
+                &self.columns.0,
+                &self.columns.1,
+                &self.columns.2,
+            ])?
+        };
         let input_plan = input_df.create_physical_plan().await?;
+
+        let contig_col_idx = if self.has_extra_cols {
+            self.input_schema.index_of(&self.columns.0)?
+        } else {
+            0
+        };
+
         let input_partitions = input_plan.output_partitioning().partition_count();
         let input_plan: Arc<dyn ExecutionPlan> = if input_partitions > 1 || target_partitions > 1 {
             Arc::new(RepartitionExec::try_new(
                 input_plan,
                 Partitioning::Hash(
-                    vec![Arc::new(Column::new(self.columns.0.as_str(), 0))],
+                    vec![Arc::new(Column::new(
+                        self.columns.0.as_str(),
+                        contig_col_idx,
+                    ))],
                     target_partitions.max(1),
                 ),
             )?)
@@ -126,6 +159,7 @@ impl TableProvider for ClusterProvider {
             columns: Arc::new(self.columns.clone()),
             min_dist: self.min_dist,
             strict: self.filter_op == FilterOp::Strict,
+            has_extra_cols: self.has_extra_cols,
             cache: PlanProperties::new(
                 EquivalenceProperties::new(self.schema.clone()),
                 Partitioning::UnknownPartitioning(output_partitions),
@@ -143,6 +177,7 @@ struct ClusterExec {
     columns: Arc<(String, String, String)>,
     min_dist: i64,
     strict: bool,
+    has_extra_cols: bool,
     cache: PlanProperties,
 }
 
@@ -189,6 +224,7 @@ impl ExecutionPlan for ClusterExec {
             columns: Arc::clone(&self.columns),
             min_dist: self.min_dist,
             strict: self.strict,
+            has_extra_cols: self.has_extra_cols,
             cache: PlanProperties::new(
                 EquivalenceProperties::new(self.schema.clone()),
                 Partitioning::UnknownPartitioning(
@@ -207,28 +243,54 @@ impl ExecutionPlan for ClusterExec {
     ) -> Result<SendableRecordBatchStream> {
         let batch_size = context.session_config().batch_size();
         let input = self.input.execute(partition, context)?;
-        Ok(Box::pin(ClusterStream {
-            schema: self.schema.clone(),
-            collector: StreamCollector::new(input, Arc::clone(&self.columns)),
-            min_dist: self.min_dist,
-            strict: self.strict,
-            phase: ClusterPhase::Collecting,
-            groups: Vec::new(),
-            group_idx: 0,
-            interval_idx: 0,
-            cluster_id: 0,
-            cluster_start: 0,
-            cluster_end: 0,
-            pending_intervals: Vec::new(),
-            contig_builder: StringBuilder::new(),
-            start_builder: Int64Builder::new(),
-            end_builder: Int64Builder::new(),
-            cluster_builder: Int64Builder::new(),
-            cluster_start_builder: Int64Builder::new(),
-            cluster_end_builder: Int64Builder::new(),
-            pending_rows: 0,
-            batch_size,
-        }))
+
+        if self.has_extra_cols {
+            let input_schema = input.schema();
+            Ok(Box::pin(ClusterStreamExtra {
+                schema: self.schema.clone(),
+                collector: FullBatchCollector::new(input, Arc::clone(&self.columns), input_schema),
+                min_dist: self.min_dist,
+                strict: self.strict,
+                phase: ClusterPhase::Collecting,
+                groups: Vec::new(),
+                concatenated: None,
+                group_idx: 0,
+                interval_idx: 0,
+                cluster_id: 0,
+                cluster_start: 0,
+                cluster_end: 0,
+                pending_intervals: Vec::new(),
+                output_row_indices: Vec::new(),
+                output_cluster_ids: Vec::new(),
+                output_cluster_starts: Vec::new(),
+                output_cluster_ends: Vec::new(),
+                pending_rows: 0,
+                batch_size,
+            }))
+        } else {
+            Ok(Box::pin(ClusterStream {
+                schema: self.schema.clone(),
+                collector: StreamCollector::new(input, Arc::clone(&self.columns)),
+                min_dist: self.min_dist,
+                strict: self.strict,
+                phase: ClusterPhase::Collecting,
+                groups: Vec::new(),
+                group_idx: 0,
+                interval_idx: 0,
+                cluster_id: 0,
+                cluster_start: 0,
+                cluster_end: 0,
+                pending_intervals: Vec::new(),
+                contig_builder: StringBuilder::new(),
+                start_builder: Int64Builder::new(),
+                end_builder: Int64Builder::new(),
+                cluster_builder: Int64Builder::new(),
+                cluster_start_builder: Int64Builder::new(),
+                cluster_end_builder: Int64Builder::new(),
+                pending_rows: 0,
+                batch_size,
+            }))
+        }
     }
 }
 
@@ -238,13 +300,14 @@ enum ClusterPhase {
     Done,
 }
 
+// ─── Fast path: 3-column input (no extra columns) ───────────────────────────
+
 struct ClusterStream {
     schema: SchemaRef,
     collector: StreamCollector,
     min_dist: i64,
     strict: bool,
     phase: ClusterPhase,
-    /// Sorted groups: Vec of (contig, intervals) in BTreeMap order.
     groups: Vec<(String, Vec<(i64, i64)>)>,
     group_idx: usize,
     interval_idx: usize,
@@ -320,7 +383,6 @@ impl Stream for ClusterStream {
                 },
                 ClusterPhase::Emitting => {
                     while this.group_idx < this.groups.len() {
-                        // Clone contig name up front to avoid borrow conflicts
                         let contig = this.groups[this.group_idx].0.clone();
                         let interval_count = this.groups[this.group_idx].1.len();
 
@@ -357,7 +419,6 @@ impl Stream for ClusterStream {
                             }
                         }
 
-                        // Contig done — emit final cluster
                         if !this.pending_intervals.is_empty() {
                             this.flush_pending_cluster(&contig);
                         }
@@ -370,7 +431,6 @@ impl Stream for ClusterStream {
                         }
                     }
 
-                    // All groups done
                     this.phase = ClusterPhase::Done;
                     this.groups.clear();
                     if this.pending_rows > 0 {
@@ -387,6 +447,170 @@ impl Stream for ClusterStream {
 }
 
 impl RecordBatchStream for ClusterStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+// ─── Extra-columns path: input has >3 columns ───────────────────────────────
+
+struct ClusterStreamExtra {
+    schema: SchemaRef,
+    collector: FullBatchCollector,
+    min_dist: i64,
+    strict: bool,
+    phase: ClusterPhase,
+    groups: IndexedGroups,
+    concatenated: Option<RecordBatch>,
+    group_idx: usize,
+    interval_idx: usize,
+    cluster_id: i64,
+    cluster_start: i64,
+    cluster_end: i64,
+    pending_intervals: Vec<(i64, i64, usize)>,
+    output_row_indices: Vec<u32>,
+    output_cluster_ids: Vec<i64>,
+    output_cluster_starts: Vec<i64>,
+    output_cluster_ends: Vec<i64>,
+    pending_rows: usize,
+    batch_size: usize,
+}
+
+impl ClusterStreamExtra {
+    fn flush_pending_cluster(&mut self) {
+        let cluster_id = self.cluster_id;
+        let cluster_start = self.cluster_start;
+        let cluster_end = self.cluster_end;
+        for &(_s, _e, row_idx) in &self.pending_intervals {
+            debug_assert!(
+                row_idx <= u32::MAX as usize,
+                "row index {row_idx} exceeds u32::MAX"
+            );
+            self.output_row_indices.push(row_idx as u32);
+            self.output_cluster_ids.push(cluster_id);
+            self.output_cluster_starts.push(cluster_start);
+            self.output_cluster_ends.push(cluster_end);
+        }
+        self.pending_rows += self.pending_intervals.len();
+        self.pending_intervals.clear();
+        self.cluster_id += 1;
+    }
+
+    fn flush_builders(&mut self) -> Result<RecordBatch> {
+        let concatenated = self.concatenated.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("FullBatchCollector: no concatenated batch".to_string())
+        })?;
+
+        let indices = UInt32Array::from(std::mem::take(&mut self.output_row_indices));
+        let mut columns: Vec<Arc<dyn datafusion::arrow::array::Array>> =
+            Vec::with_capacity(concatenated.num_columns() + 3);
+        for col in concatenated.columns() {
+            columns.push(take(col.as_ref(), &indices, None)?);
+        }
+
+        columns.push(Arc::new(Int64Array::from(std::mem::take(
+            &mut self.output_cluster_ids,
+        ))));
+        columns.push(Arc::new(Int64Array::from(std::mem::take(
+            &mut self.output_cluster_starts,
+        ))));
+        columns.push(Arc::new(Int64Array::from(std::mem::take(
+            &mut self.output_cluster_ends,
+        ))));
+
+        self.pending_rows = 0;
+        RecordBatch::try_new(self.schema.clone(), columns)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+}
+
+impl Stream for ClusterStreamExtra {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            match this.phase {
+                ClusterPhase::Collecting => match ready!(this.collector.poll_collect(cx)) {
+                    Ok(true) => {
+                        this.groups = this.collector.take_groups();
+                        this.concatenated = this.collector.take_concatenated();
+                        this.group_idx = 0;
+                        this.interval_idx = 0;
+                        this.phase = ClusterPhase::Emitting;
+                    }
+                    Ok(false) => unreachable!(),
+                    Err(e) => {
+                        this.phase = ClusterPhase::Done;
+                        return Poll::Ready(Some(Err(e)));
+                    }
+                },
+                ClusterPhase::Emitting => {
+                    while this.group_idx < this.groups.len() {
+                        let interval_count = this.groups[this.group_idx].1.len();
+
+                        while this.interval_idx < interval_count {
+                            let (s, e, row_idx) = this.groups[this.group_idx].1[this.interval_idx];
+                            this.interval_idx += 1;
+
+                            if this.pending_intervals.is_empty() {
+                                this.cluster_start = s;
+                                this.cluster_end = e;
+                                this.pending_intervals.push((s, e, row_idx));
+                            } else {
+                                let boundary = this.cluster_end.saturating_add(this.min_dist);
+                                let merge_condition = if this.strict {
+                                    s < boundary
+                                } else {
+                                    s <= boundary
+                                };
+                                if merge_condition {
+                                    if e > this.cluster_end {
+                                        this.cluster_end = e;
+                                    }
+                                    this.pending_intervals.push((s, e, row_idx));
+                                } else {
+                                    this.flush_pending_cluster();
+                                    this.cluster_start = s;
+                                    this.cluster_end = e;
+                                    this.pending_intervals.push((s, e, row_idx));
+                                }
+                            }
+
+                            if this.pending_rows >= this.batch_size {
+                                return Poll::Ready(Some(this.flush_builders()));
+                            }
+                        }
+
+                        if !this.pending_intervals.is_empty() {
+                            this.flush_pending_cluster();
+                        }
+
+                        this.group_idx += 1;
+                        this.interval_idx = 0;
+
+                        if this.pending_rows >= this.batch_size {
+                            return Poll::Ready(Some(this.flush_builders()));
+                        }
+                    }
+
+                    this.phase = ClusterPhase::Done;
+                    this.groups.clear();
+                    if this.pending_rows > 0 {
+                        return Poll::Ready(Some(this.flush_builders()));
+                    }
+                    return Poll::Ready(None);
+                }
+                ClusterPhase::Done => {
+                    return Poll::Ready(None);
+                }
+            }
+        }
+    }
+}
+
+impl RecordBatchStream for ClusterStreamExtra {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/datafusion/bio-function-ranges/src/grouped_stream.rs
+++ b/datafusion/bio-function-ranges/src/grouped_stream.rs
@@ -3,11 +3,18 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use ahash::AHashMap;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::compute::concat_batches;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::{StreamExt, ready};
 
 use crate::array_utils::get_join_col_arrays;
+
+/// Per-contig group with indexed intervals: `(contig_name, sorted_intervals)`.
+/// Each interval carries `(start, end, global_row_idx)`.
+pub type IndexedGroups = Vec<(String, Vec<(i64, i64, usize)>)>;
 
 /// Collects input batches into per-contig interval groups, sorting each group
 /// by (start, end) once the input is exhausted.
@@ -113,5 +120,124 @@ impl StreamCollector {
         self.contig_to_idx.clear();
 
         names.into_iter().zip(groups).collect()
+    }
+}
+
+/// Like [`StreamCollector`] but stores full `RecordBatch` rows so that extra
+/// columns beyond (contig, start, end) can be reconstructed via Arrow `take`.
+///
+/// Groups carry `(start, end, global_row_idx)` tuples.
+pub struct FullBatchCollector {
+    input: SendableRecordBatchStream,
+    columns: Arc<(String, String, String)>,
+    input_schema: SchemaRef,
+    batches: Vec<RecordBatch>,
+    contig_to_idx: AHashMap<String, usize>,
+    groups: Vec<Vec<(i64, i64, usize)>>,
+    contig_names: Vec<String>,
+    row_offset: usize,
+    done: bool,
+    concatenated: Option<RecordBatch>,
+}
+
+impl FullBatchCollector {
+    pub fn new(
+        input: SendableRecordBatchStream,
+        columns: Arc<(String, String, String)>,
+        input_schema: SchemaRef,
+    ) -> Self {
+        Self {
+            input,
+            columns,
+            input_schema,
+            batches: Vec::new(),
+            contig_to_idx: AHashMap::new(),
+            groups: Vec::new(),
+            contig_names: Vec::new(),
+            row_offset: 0,
+            done: false,
+            concatenated: None,
+        }
+    }
+
+    /// Poll the input stream, collecting full batches and building grouped
+    /// interval tuples `(start, end, global_row_idx)`.
+    pub fn poll_collect(&mut self, cx: &mut Context<'_>) -> Poll<Result<bool>> {
+        if self.done {
+            return Poll::Ready(Ok(true));
+        }
+
+        loop {
+            let batch_opt = ready!(Pin::new(&mut self.input).poll_next_unpin(cx));
+
+            match batch_opt {
+                Some(Ok(batch)) => {
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+                    let (contig_arr, start_arr, end_arr) = get_join_col_arrays(
+                        &batch,
+                        (&self.columns.0, &self.columns.1, &self.columns.2),
+                    )?;
+                    let start_resolved = start_arr.resolve_i64()?;
+                    let end_resolved = end_arr.resolve_i64()?;
+                    let starts = &*start_resolved;
+                    let ends = &*end_resolved;
+
+                    let base = self.row_offset;
+                    for i in 0..batch.num_rows() {
+                        let contig = contig_arr.value(i);
+                        let idx = match self.contig_to_idx.get(contig) {
+                            Some(&idx) => idx,
+                            None => {
+                                let idx = self.groups.len();
+                                self.groups.push(Vec::with_capacity(1024));
+                                self.contig_names.push(contig.to_string());
+                                self.contig_to_idx.insert(contig.to_string(), idx);
+                                idx
+                            }
+                        };
+                        self.groups[idx].push((starts[i], ends[i], base + i));
+                    }
+
+                    self.row_offset += batch.num_rows();
+                    self.batches.push(batch);
+                }
+                Some(Err(e)) => {
+                    self.done = true;
+                    return Poll::Ready(Err(e));
+                }
+                None => {
+                    self.done = true;
+                    // Sort each group by (start, end, row_idx)
+                    for intervals in &mut self.groups {
+                        intervals.sort_unstable();
+                    }
+                    // Concatenate all stored batches into one
+                    if !self.batches.is_empty() {
+                        let concatenated = concat_batches(&self.input_schema, &self.batches)?;
+                        self.batches.clear();
+                        self.concatenated = Some(concatenated);
+                    }
+                    return Poll::Ready(Ok(true));
+                }
+            }
+        }
+    }
+
+    /// Take ownership of the collected groups sorted by contig name.
+    pub fn take_groups(&mut self) -> IndexedGroups {
+        let names = std::mem::take(&mut self.contig_names);
+        let groups = std::mem::take(&mut self.groups);
+        self.contig_to_idx.clear();
+
+        let mut pairs: IndexedGroups = names.into_iter().zip(groups).collect();
+        pairs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        pairs
+    }
+
+    /// Take the concatenated `RecordBatch` containing all input rows.
+    pub fn take_concatenated(&mut self) -> Option<RecordBatch> {
+        self.concatenated.take()
     }
 }


### PR DESCRIPTION
## Summary

- **cluster UDTF**: now preserves all input columns and appends `cluster`, `cluster_start`, `cluster_end` (matching bioframe.cluster behavior)
- **subtract UDTF**: now preserves all left-table columns; when an interval is split by multiple right intervals, extra columns are duplicated to each fragment (matching bioframe.subtract behavior)
- Uses a **two-path design** to avoid overhead when input has only 3 range columns:
  - **Fast path** (3-column input): identical to previous implementation using `StreamCollector` + typed builders
  - **Extra-columns path** (>3 columns): new `FullBatchCollector` stores full `RecordBatch` rows, reconstructs output via Arrow `take` kernel from collected row indices

## Files changed

| File | Change |
|------|--------|
| `grouped_stream.rs` | Added `FullBatchCollector` struct + `IndexedGroups` type alias |
| `cluster.rs` | Two-path `ClusterStream`/`ClusterStreamExtra`; accepts `input_schema` |
| `subtract.rs` | Two-path `SubtractStream`/`SubtractStreamExtra`; accepts `left_schema` |
| `table_function.rs` | `block_in_place` schema resolution for cluster and subtract |
| `integration_test.rs` | 3 new tests for extra-column preservation |

## Test plan

- [x] `test_cluster_udtf_preserves_extra_columns` — verifies `gene` + `score` columns appear alongside cluster metadata
- [x] `test_subtract_udtf_preserves_extra_columns` — verifies extra columns duplicated to each fragment
- [x] `test_subtract_udtf_extra_cols_multiple_splits` — 3-way split preserves extra columns on all fragments
- [x] All 20 existing cluster/subtract tests pass unchanged (fast path regression)
- [x] `test_range_udtfs_target_partitions_invariant` passes
- [x] Full test suite: 89 passed, 0 failed
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)