### PR TITLE
feat: improve GCP benchmark infrastructure

### DIFF
--- a/benchmark-infra/ansible/playbook.yml
+++ b/benchmark-infra/ansible/playbook.yml
@@ -87,6 +87,8 @@
         rsync_opts:
           - "--include=HG002_chr1.vcf.gz"
           - "--include=HG002_chr1.vcf.gz.tbi"
+          - "--include=HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+          - "--include=HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi"
           - "--include=output/"
           - "--include=output/everything/"
           - "--include=output/everything/HG002_chr1_0_vep115_golden.vcf"
@@ -113,6 +115,13 @@
         src: "{{ local_ensembl_cache_dir }}/"
         dest: "{{ data_dir }}/homo_sapiens/115_GRCh38/"
 
+    - name: Fix data directory ownership
+      file:
+        path: "{{ data_dir }}"
+        owner: "{{ benchmark_user }}"
+        group: "{{ benchmark_user }}"
+        recurse: yes
+
     # ── Clone and build the project ──────────────────────────────────
     - name: Sync project source
       synchronize:
@@ -136,7 +145,7 @@
       shell: |
         source /home/{{ benchmark_user }}/.cargo/env
         cd {{ repo_dir }}
-        cargo build --release -p datafusion-bio-function-vep
+        cargo build --release -p datafusion-bio-function-vep --examples
       args:
         executable: /bin/bash
       environment:

--- a/benchmark-infra/scripts/run_benchmark.sh
+++ b/benchmark-infra/scripts/run_benchmark.sh
@@ -1,103 +1,187 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Usage: ./run_benchmark.sh [ensembl|parquet|fjall|all] [chr1|chr22|wgs] [buffer_size] [fork]
+#
+# Backend:
+#   ensembl  — Ensembl VEP via Docker only
+#   parquet  — Native VEP with Parquet backend only
+#   fjall    — Native VEP with Fjall backend only
+#   all      — All three (default)
+#
+# Dataset:
+#   chr1     — HG002 chr1 only, 319K variants (default)
+#   chr22    — HG002 chr22 only, ~50K variants (quick test)
+#   wgs      — HG002 full genome (chr1-22), ~4M variants
+#
+# Buffer size:
+#   Ensembl VEP --buffer_size (default: 5000)
+#
+# Fork:
+#   Ensembl VEP --fork (default: nproc, all available cores)
+
 # ── Configuration ─────────────────────────────────────────────────────
 DATA_DIR="/data/vep"
 REPO_DIR="$HOME/datafusion-bio-functions"
 RESULTS_DIR="${DATA_DIR}/results"
-VCF="${DATA_DIR}/vcf/HG002_chr1.vcf.gz"
 FASTA="${DATA_DIR}/Homo_sapiens.GRCh38.dna.primary_assembly.fa"
-CHR1_CACHE="${DATA_DIR}/chr1-vep"
-ENSEMBL_CACHE="${DATA_DIR}/homo_sapiens/115_GRCh38"
-VARIATION_PARQUET="${CHR1_CACHE}/115_GRCh38_variation_1_vep.parquet"
 VEP_IMAGE="ensemblorg/ensembl-vep:release_115.2"
 
+MODE="${1:-all}"
+DATASET="${2:-chr1}"
+BUFFER_SIZE="${3:-5000}"
+FORK="${4:-$(nproc)}"
+
+# ── Dataset selection ─────────────────────────────────────────────────
+case "${DATASET}" in
+  chr1)
+    VCF="${DATA_DIR}/vcf/HG002_chr1.vcf.gz"
+    CACHE_DIR="${DATA_DIR}/chr1-vep"
+    FJALL_CACHE="${CACHE_DIR}/fjall_variation_cache"
+    SAMPLE_LIMIT=320000
+    ;;
+  chr22)
+    VCF="${DATA_DIR}/vcf/HG002_chr22.vcf.gz"
+    CACHE_DIR="${DATA_DIR}/chr22-vep"
+    FJALL_CACHE="${CACHE_DIR}/fjall_variation_cache"
+    SAMPLE_LIMIT=0
+    ;;
+  wgs)
+    VCF="${DATA_DIR}/vcf/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+    CACHE_DIR="${DATA_DIR}/wgs-vep"
+    FJALL_CACHE="${CACHE_DIR}/fjall_variation_cache"
+    SAMPLE_LIMIT=0
+    ;;
+  *)
+    echo "Unknown dataset: ${DATASET}. Use chr1, chr22, or wgs."
+    exit 1
+    ;;
+esac
+
+if [ ! -f "${VCF}" ]; then
+  echo "ERROR: VCF not found: ${VCF}"
+  exit 1
+fi
+
+ENSEMBL_OUT="${RESULTS_DIR}/ensembl_${DATASET}.vcf"
+
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-RESULT_FILE="${RESULTS_DIR}/benchmark_${TIMESTAMP}.txt"
+RESULT_FILE="${RESULTS_DIR}/benchmark_${MODE}_${DATASET}_${TIMESTAMP}.txt"
 
 mkdir -p "${RESULTS_DIR}"
 
-echo "=== VEP Benchmark on $(hostname) ===" | tee "${RESULT_FILE}"
+source "$HOME/.cargo/env"
+
+echo "=== VEP Benchmark on $(hostname) [mode=${MODE}, dataset=${DATASET}] ===" | tee "${RESULT_FILE}"
 echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee -a "${RESULT_FILE}"
 echo "Machine: $(uname -a)" | tee -a "${RESULT_FILE}"
 echo "CPUs: $(nproc)" | tee -a "${RESULT_FILE}"
 echo "RAM: $(free -h | awk '/Mem:/{print $2}')" | tee -a "${RESULT_FILE}"
+echo "VCF: ${VCF}" | tee -a "${RESULT_FILE}"
+echo "Cache: ${CACHE_DIR}" | tee -a "${RESULT_FILE}"
+echo "Sample limit: ${SAMPLE_LIMIT} (0=all)" | tee -a "${RESULT_FILE}"
+echo "Ensembl buffer_size: ${BUFFER_SIZE}" | tee -a "${RESULT_FILE}"
+echo "Ensembl fork: ${FORK}" | tee -a "${RESULT_FILE}"
 echo "" | tee -a "${RESULT_FILE}"
 
-# ── 1. Ensembl VEP (Docker) ──────────────────────────────────────────
-echo "=== Running Ensembl VEP (Docker) ===" | tee -a "${RESULT_FILE}"
+# ── Ensembl VEP (Docker) ────────────────────────────────────────────
+if [ "$MODE" = "ensembl" ] || [ "$MODE" = "all" ]; then
+  if [ -f "${ENSEMBL_OUT}" ]; then
+    echo "=== Ensembl VEP: SKIPPED (output exists: ${ENSEMBL_OUT}) ===" | tee -a "${RESULT_FILE}"
+  else
+    echo "=== Running Ensembl VEP (Docker) [${DATASET}] ===" | tee -a "${RESULT_FILE}"
 
-ENSEMBL_OUT="${RESULTS_DIR}/ensembl_chr1_${TIMESTAMP}.vcf"
-ENSEMBL_START=$(date +%s%N)
+    ENSEMBL_START=$(date +%s%N)
 
-docker run --rm \
-  --user "$(id -u):$(id -g)" \
-  -v "${DATA_DIR}:/opt/vep/.vep" \
-  -v "${DATA_DIR}/vcf:/work:ro" \
-  -v "$(dirname "${FASTA}"):/fasta" \
-  -v "${RESULTS_DIR}:/output" \
-  "${VEP_IMAGE}" \
-  vep \
-    --input_file /work/HG002_chr1.vcf.gz \
-    --output_file /output/ensembl_output.vcf \
-    --vcf \
-    --offline \
-    --cache \
-    --dir /opt/vep/.vep \
-    --assembly GRCh38 \
-    --everything \
-    --fasta /fasta/$(basename "${FASTA}") \
-    --force_overwrite \
-    --no_stats
+    docker run --rm \
+      --user "$(id -u):$(id -g)" \
+      --tmpfs /tmp:exec \
+      -v "${DATA_DIR}/homo_sapiens:/opt/vep/.vep/homo_sapiens:ro" \
+      -v "${DATA_DIR}/vcf:/work:ro" \
+      -v "$(dirname "${FASTA}"):/fasta" \
+      -v "${RESULTS_DIR}:/output" \
+      "${VEP_IMAGE}" \
+      vep \
+        --input_file "/work/$(basename "${VCF}")" \
+        --output_file "/output/ensembl_${DATASET}.vcf" \
+        --vcf \
+        --offline \
+        --cache \
+        --dir /opt/vep/.vep \
+        --assembly GRCh38 \
+        --everything \
+        --fasta "/fasta/$(basename "${FASTA}")" \
+        --fork "${FORK}" \
+        --buffer_size "${BUFFER_SIZE}" \
+        --no_check_variants_order \
+        --force_overwrite \
+        --no_stats
 
-ENSEMBL_END=$(date +%s%N)
-ENSEMBL_MS=$(( (ENSEMBL_END - ENSEMBL_START) / 1000000 ))
+    ENSEMBL_END=$(date +%s%N)
+    ENSEMBL_MS=$(( (ENSEMBL_END - ENSEMBL_START) / 1000000 ))
 
-echo "Ensembl VEP time: ${ENSEMBL_MS}ms ($(echo "scale=1; ${ENSEMBL_MS}/1000" | bc)s)" | tee -a "${RESULT_FILE}"
-echo "" | tee -a "${RESULT_FILE}"
-
-# Move output
-if [ -f "${RESULTS_DIR}/ensembl_output.vcf" ]; then
-  mv "${RESULTS_DIR}/ensembl_output.vcf" "${ENSEMBL_OUT}"
-  echo "Ensembl output: ${ENSEMBL_OUT}" | tee -a "${RESULT_FILE}"
+    echo "Ensembl VEP time: ${ENSEMBL_MS}ms ($(echo "scale=1; ${ENSEMBL_MS}/1000" | bc)s)" | tee -a "${RESULT_FILE}"
+  fi
+  echo "" | tee -a "${RESULT_FILE}"
 fi
 
-# ── 2. Native datafusion-bio VEP ─────────────────────────────────────
-echo "=== Running native datafusion-bio VEP ===" | tee -a "${RESULT_FILE}"
+# ── Native VEP — Parquet backend ────────────────────────────────────
+if [ "$MODE" = "parquet" ] || [ "$MODE" = "all" ]; then
+  if [ -d "${CACHE_DIR}" ]; then
+    echo "=== Running native VEP (Parquet) [${DATASET}] ===" | tee -a "${RESULT_FILE}"
 
-NATIVE_OUT="${RESULTS_DIR}/native_chr1_${TIMESTAMP}.vcf"
+    PARQUET_OUT="${RESULTS_DIR}/native_parquet_${DATASET}_${TIMESTAMP}.vcf"
 
-source "$HOME/.cargo/env"
+    VEP_PROFILE=1 "${REPO_DIR}/target/release/examples/profile_annotation" \
+      "${VCF}" \
+      "${CACHE_DIR}" \
+      "${SAMPLE_LIMIT}" \
+      --everything \
+      --reference-fasta-path="${FASTA}" \
+      --output="${PARQUET_OUT}" \
+      2>&1 | tee -a "${RESULT_FILE}"
 
-VEP_PROFILE=1 cargo run \
-  -p datafusion-bio-function-vep \
-  --release \
-  --manifest-path="${REPO_DIR}/Cargo.toml" \
-  --example profile_annotation -- \
-  "${VCF}" \
-  "${CHR1_CACHE}" \
-  320000 \
-  --everything \
-  --reference-fasta-path="${FASTA}" \
-  --output="${NATIVE_OUT}" \
-  2>&1 | tee -a "${RESULT_FILE}"
+    echo "" | tee -a "${RESULT_FILE}"
+  else
+    echo "=== Parquet backend: SKIPPED (no cache at ${CACHE_DIR}) ===" | tee -a "${RESULT_FILE}"
+    echo "" | tee -a "${RESULT_FILE}"
+  fi
+fi
 
-echo "" | tee -a "${RESULT_FILE}"
+# ── Native VEP — Fjall backend ──────────────────────────────────────
+if [ "$MODE" = "fjall" ] || [ "$MODE" = "all" ]; then
+  if [ -d "${FJALL_CACHE}/keyspaces" ]; then
+    echo "=== Running native VEP (Fjall) [${DATASET}] ===" | tee -a "${RESULT_FILE}"
 
-# ── 3. Summary ───────────────────────────────────────────────────────
+    FJALL_OUT="${RESULTS_DIR}/native_fjall_${DATASET}_${TIMESTAMP}.vcf"
+
+    VEP_PROFILE=1 "${REPO_DIR}/target/release/examples/profile_annotation" \
+      "${VCF}" \
+      "${FJALL_CACHE}" \
+      "${SAMPLE_LIMIT}" \
+      --everything \
+      --reference-fasta-path="${FASTA}" \
+      --output="${FJALL_OUT}" \
+      2>&1 | tee -a "${RESULT_FILE}"
+
+    echo "" | tee -a "${RESULT_FILE}"
+  else
+    echo "=== Fjall backend: SKIPPED (no cache at ${FJALL_CACHE}) ===" | tee -a "${RESULT_FILE}"
+    echo "Build it with:" | tee -a "${RESULT_FILE}"
+    echo "  ${REPO_DIR}/target/release/examples/load_cache_full <variation_parquet> ${FJALL_CACHE} 4" | tee -a "${RESULT_FILE}"
+    echo "" | tee -a "${RESULT_FILE}"
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
 echo "=== Summary ===" | tee -a "${RESULT_FILE}"
-echo "Ensembl VEP (Docker): ${ENSEMBL_MS}ms" | tee -a "${RESULT_FILE}"
-echo "Results saved to: ${RESULT_FILE}" | tee -a "${RESULT_FILE}"
 
-# Count output lines
-if [ -f "${ENSEMBL_OUT}" ]; then
-  ENSEMBL_LINES=$(grep -cv '^#' "${ENSEMBL_OUT}" || true)
-  echo "Ensembl output variants: ${ENSEMBL_LINES}" | tee -a "${RESULT_FILE}"
-fi
-if [ -f "${NATIVE_OUT}" ]; then
-  NATIVE_LINES=$(grep -cv '^#' "${NATIVE_OUT}" || true)
-  echo "Native output variants: ${NATIVE_LINES}" | tee -a "${RESULT_FILE}"
-fi
+for f in "${ENSEMBL_OUT}" "${PARQUET_OUT:-}" "${FJALL_OUT:-}"; do
+  if [ -n "$f" ] && [ -f "$f" ]; then
+    LINES=$(grep -cv '^#' "$f" || true)
+    echo "$(basename "$f"): ${LINES} variants" | tee -a "${RESULT_FILE}"
+  fi
+done
 
 echo ""
 echo "Done! Results in ${RESULT_FILE}"


### PR DESCRIPTION
## Summary
- Add benchmark VCF/index files to Ansible S3 sync and fix data directory ownership
- Build examples in release mode for the benchmark binary
- Rewrite `run_benchmark.sh` to support multiple backends (ensembl/parquet/fjall/all), dataset selection (chr1/chr22/wgs), and configurable buffer size / fork params

## Test plan
- [ ] Deploy to GCP instance with Ansible and verify data sync includes new files
- [ ] Run `./run_benchmark.sh all chr1` and confirm all three backends complete
- [ ] Verify `cargo build --release --examples` produces the benchmark binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)