### PR TITLE
fix: align release workflow Rust toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '1.88.0'
+          toolchain: '1.91.0'
           components: 'clippy, rustfmt'
 
       - name: Install cargo-edit for version bumping

--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ cargo doc --no-deps --all-features --open
 
 ## Requirements
 
-- Rust 1.88.0 or later (specified in `rust-toolchain.toml`)
+- Rust 1.91.0 or later (specified in `rust-toolchain.toml`)
 - Git (for building crates with git dependencies)
 
 ## Related Projects

--- a/datafusion/bio-function-vep/benchmark.md
+++ b/datafusion/bio-function-vep/benchmark.md
@@ -3,7 +3,7 @@
 ## Environment
 
 - Machine: macOS Darwin 24.6.0 (Apple Silicon)
-- Rust: edition 2024, toolchain 1.88.0
+- Rust: edition 2024, toolchain 1.91.0
 - DataFusion: 52.1.0
 - fjall: 3.1.1
 


### PR DESCRIPTION
## Summary
- update the release workflow to use Rust 1.91.0
- align the release job with CI and rust-toolchain.toml
- avoid the release failure caused by fjall 3.1.1 requiring rustc 1.90+

## Verification
- cargo +1.88.0 check --all fails with the same MSRV error seen in the failed release run
- cargo +1.91.0 check --all passes locally

## Context
The failed GitHub Actions run was https://github.com/biodatageeks/datafusion-bio-functions/actions/runs/23456990110/job/68248681397 .