### PR TITLE
feat: include Format: field list in VCF CSQ INFO header

### DIFF
--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -296,9 +296,8 @@ pub async fn annotate_to_vcf(
                     crate::golden_benchmark::CSQ_FIELD_NAMES
                 };
                 let format_list = field_names.join("|");
-                let description = format!(
-                    "Consequence annotations from annotate_vep. Format: {format_list}"
-                );
+                let description =
+                    format!("Consequence annotations from annotate_vep. Format: {format_list}");
                 let mut meta = std::collections::HashMap::new();
                 meta.insert("bio.vcf.field.field_type".to_string(), "INFO".to_string());
                 meta.insert("bio.vcf.field.description".to_string(), description);

--- a/datafusion/bio-function-vep/tests/vcf_roundtrip_golden.rs
+++ b/datafusion/bio-function-vep/tests/vcf_roundtrip_golden.rs
@@ -94,10 +94,7 @@ async fn test_roundtrip_golden_all_column_values() {
             fields.len(),
             expected.len()
         );
-        assert_eq!(
-            fields, expected,
-            "CSQ Format field names/order mismatch"
-        );
+        assert_eq!(fields, expected, "CSQ Format field names/order mismatch");
     }
 
     // ── Step 2: Read input, output, and golden with VcfTableProvider ──


### PR DESCRIPTION
## Summary
- Adds `Format:` pipe-delimited field list to the CSQ INFO header, matching Ensembl VEP convention
- Field list is dynamically generated from active annotation columns (74-field default vs 80-field `--everything`)
- Adds roundtrip test assertion verifying the header contains correct field names and order

Closes #63

## Test plan
- [ ] Roundtrip golden test (`vcf_roundtrip_golden`) verifies CSQ header contains `Format:` with correct 80-field list
- [ ] Verify `bcftools +split-vep` can parse the output VCF by field name

🤖 Generated with [Claude Code](https://claude.com/claude-code)