### PR TITLE
fix: use mem::forget to avoid fjall Drop deadlock (#86)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,8 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.0.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=9e9d873#9e9d873008f846f4c8346a9a7b0efc294f710119"
+version = "1.1.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c7cad33b50235bd9a460f103a2ae7a41653f9ad3#c7cad33b50235bd9a460f103a2ae7a41653f9ad3"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1128,12 +1128,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.0.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=9e9d873#9e9d873008f846f4c8346a9a7b0efc294f710119"
+version = "1.1.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c7cad33b50235bd9a460f103a2ae7a41653f9ad3#c7cad33b50235bd9a460f103a2ae7a41653f9ad3"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.0.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=9e9d873)",
+ "datafusion-bio-format-core 1.1.0",
  "datafusion-execution",
  "flate2",
  "log",
@@ -1154,7 +1154,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.0.0 (git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7ccaa58)",
+ "datafusion-bio-format-core 1.0.0",
  "datafusion-execution",
  "env_logger",
  "flate2",

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -901,6 +901,12 @@ impl CacheBuilder {
             compact_start.elapsed().as_secs_f64()
         );
 
+        // Skip fjall's Drop which deadlocks when background worker threads are busy
+        // compacting — the bounded(1000) flume channel fills up, send() blocks while
+        // the worker is still in compact(). All data is persisted and compacted above.
+        // See: https://github.com/biodatageeks/datafusion-bio-functions/issues/86
+        std::mem::forget(store);
+
         let elapsed = start_time.elapsed().as_secs_f64();
         info!(
             "variation.fjall rebuilt: {} positions, {} variants, {:.1} MB in {:.1}s",
@@ -1434,14 +1440,12 @@ impl CacheBuilder {
         db.persist(fjall::PersistMode::SyncAll)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-        info!("translation_sift.fjall: closing database...");
-        let close_start = Instant::now();
-        drop(sift_store);
-        drop(db);
-        info!(
-            "translation_sift.fjall: database closed in {:.1}s",
-            close_start.elapsed().as_secs_f64()
-        );
+        // Skip fjall's Drop which deadlocks when background worker threads are busy
+        // compacting — the bounded(1000) flume channel fills up, send() blocks while
+        // the worker is still in compact(). All data is persisted above.
+        // See: https://github.com/biodatageeks/datafusion-bio-functions/issues/86
+        std::mem::forget(sift_store);
+        std::mem::forget(db);
 
         let elapsed = start_time.elapsed().as_secs_f64();
         info!(


### PR DESCRIPTION
## Summary

- Fixes #86 — `build_cache` hangs indefinitely at "closing database..." on full-sized Ensembl VEP caches
- Uses `std::mem::forget` to skip fjall's broken `Drop` impl after all data is persisted and compacted
- Applied to both `build_variation_fjall_from_parquet()` and `build_sift_fjall()`

## Root cause

fjall 3.1.x `DatabaseInner::drop()` sends `Close` messages on a bounded(1000) flume channel in a spin loop. When background workers are still in long-running `compact()` (which doesn't check `stop_signal`), the channel fills up and `send()` blocks permanently → deadlock.

## Why this is safe

Both code paths call `persist()` + `major_compact()` before the forget — all data is on disk and fully compacted. The `Drop` only needs to join worker threads, but it deadlocks trying. `mem::forget` is safe Rust and the standard workaround for broken `Drop` implementations.

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [ ] Full Ensembl VEP 115 cache build completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)