### PR TITLE
fix: correct start_retained/start_lost logic to match Ensembl VEP

### DIFF
--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -2947,6 +2947,9 @@ fn classify_coding_change(
     //   <https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L992-L1026>
     // - start_retained_variant = !_snp_start_altered for SNPs:
     //   <https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L958>
+    // start_idx < 3: variant touches at least one of CDS positions 0, 1, 2
+    // (the start codon). Unlike the insertion path (cds_idx < 2), SNVs and
+    // deletions at position 2 DO overlap the start codon.
     if start_idx < 3 && !tx.cds_start_nf {
         if new_aas.first() == Some(&'M') {
             class.start_retained = true;
@@ -8275,18 +8278,20 @@ mod tests {
     }
 
     #[test]
-    fn insertion_within_start_codon_sets_start_retained() {
+    fn insertion_within_start_codon_emits_start_lost() {
         // Insertion within start codon (cds_idx=0 or 1) should still fire.
         // CDS: ATG GCT GAA TGA. Insert "AAA" after pos 1001 (cds_idx=1).
-        // This disrupts the start codon.
+        // A + AAA + TGGCTGAATGA → AAAATGGCTGAATGA, first codon = AAA = Lys.
+        // Met is lost, new AA is not Met → start_lost only.
         let cds = "ATGGCTGAATGA";
         let c = classify_ins(cds, 1002, "AAA").unwrap();
-        // Insertion at cds_idx=1 is within start codon — should evaluate
-        // start codon consequences. The inserted bases shift the codon,
-        // so start_lost should fire.
         assert!(
-            c.start_lost || c.start_retained,
-            "Insertion at cds_idx=1 (within start codon) should trigger start codon logic"
+            c.start_lost,
+            "Insertion at cds_idx=1 disrupts start codon: should emit start_lost"
+        );
+        assert!(
+            !c.start_retained,
+            "Insertion at cds_idx=1 produces Lys, not Met: should NOT emit start_retained"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #84 — start codon consequence mismatches vs Ensembl VEP, verified against [VariationEffect.pm (release/115)](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm).

### C2a — insertion path (49 mismatches)
Tighten `cds_idx < 3` to `cds_idx < 2` in `classify_insertion` so insertions anchored at the boundary of codon 1 (after the last start codon base) no longer emit spurious `start_retained_variant`. VEP uses [inverted coordinates for insertions](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L965-L985) (`start > end`), so `overlap()` naturally excludes the right-boundary case.

### C2a — deletion/heuristic path (2 mismatches)
Remove boundary deletion heuristic that co-emitted `start_retained` alongside `start_lost`. In VEP these use [independent logic](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L947-L962): `start_retained = !_ins_del_start_altered()`, while `start_lost` requires the start to be altered. For deletions that disrupt the start codon, only `start_lost` fires.

### C2b — non-standard start codons (9 mismatches, IMPACT fix)
Replace `old_aas.first() == 'M'` gate with `!tx.cds_start_nf` to match VEP's [`_overlaps_start_codon`](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L975) which checks the transcript attribute, not amino acid identity.

`start_lost` and `start_retained` can **co-fire** for non-standard start codons (GTG, ATT) because they test different things:
- [`start_retained` = `!_snp_start_altered`](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L958): nucleotide-level — is the mutated codon [still ATG](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L992-L1026)?
- [`start_lost`](https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L872-L882): peptide-level — did the amino acid at position 1 change?

Example: V→M at GTG start codon fires both → `start_lost&start_retained_variant` with **HIGH** impact, matching VEP.

## Test plan

- [x] 7 new unit tests covering all issue examples + edge cases
- [x] Updated existing `boundary_deletion_coemits` test
- [x] Full VEP test suite passes (459 unit + 10 integration = 469 tests, 0 failures)
- [x] Clippy clean (`-D warnings`)
- [ ] Verify against GIAB HG002 full-genome benchmark (cluster C2 mismatches resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)