### PR TITLE
fix: 3'-shift peptide dups and revert out-of-bounds cDNA dups

### DIFF
--- a/datafusion/bio-function-vep/src/hgvs.rs
+++ b/datafusion/bio-function-vep/src/hgvs.rs
@@ -224,6 +224,9 @@ pub fn format_hgvsc(
         // pushes an insertion through a repeat past the transcript
         // start/end. Intronic dups (between exons) are valid.
         if notation.kind == "dup" {
+            // unwrap_or(0): if tx_exons is empty (shouldn't happen for a
+            // valid transcript), span_end=0 causes every dup to revert —
+            // safe because format_hgvsc is never called without exons.
             let span_start = tx_exons.iter().map(|e| e.start).min().unwrap_or(0);
             let span_end = tx_exons.iter().map(|e| e.end).max().unwrap_or(0);
             if notation.start < span_start || notation.end > span_end {
@@ -1426,9 +1429,15 @@ fn try_peptide_dup_at(
         // this walk internally; vepyr's original code only found the
         // leftmost (5') match.
         // https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L2371-L2410
+        // The single-char rotation check (comparing the char sliding out
+        // of the left with the char sliding in from the right) intentionally
+        // matches VEP's `_shift_3prime()` which performs the same rotation.
+        // For periodic repeats ("PA","PA","PA"...) this correctly walks to
+        // the 3'-most position. For non-periodic sequences the window
+        // content rotates but the walk produces the same result as VEP.
         let ref_chars: Vec<char> = ref_translation.chars().collect();
         while notation.end < ref_chars.len() {
-            let first = ref_chars.get(notation.start.wrapping_sub(1)).copied();
+            let first = ref_chars.get(notation.start.saturating_sub(1)).copied();
             let next = ref_chars.get(notation.end).copied();
             match (first, next) {
                 (Some(f), Some(n)) if f == n => {
@@ -1441,7 +1450,7 @@ fn try_peptide_dup_at(
 
         // Update alt_allele to the amino acids at the shifted positions
         // so that format_hgvsp_notation shows the correct residue names.
-        if let Some(slice) = ref_chars.get(notation.start.wrapping_sub(1)..notation.end) {
+        if let Some(slice) = ref_chars.get(notation.start.saturating_sub(1)..notation.end) {
             notation.alt_allele = slice.iter().collect();
         }
 
@@ -3232,6 +3241,32 @@ mod tests {
     }
 
     #[test]
+    fn peptide_dup_non_periodic_advances_like_vep() {
+        // Non-periodic sequences: the single-char rotation check matches
+        // VEP's _shift_3prime() behavior. For ref "MABAC", alt "AB":
+        // Initial dup at 2-3, walk: ref[1]=A == ref[3]=A → advance to 3-4.
+        // ref[2]=B ≠ ref[4]=C → stop at 3-4.
+        // alt_allele is refreshed from ref[2..4] = "AC".
+        let mut notation = ProteinHgvsNotation {
+            start: 3,
+            end: 3,
+            ref_allele: String::new(),
+            alt_allele: "AB".into(),
+            original_ref: String::new(),
+            preseq: String::new(),
+            kind: "ins".into(),
+        };
+        let result = try_peptide_dup_at(&mut notation, "MABAC", 4);
+        assert!(result);
+        assert_eq!(notation.kind, "dup");
+        // Advances to 3-4 (matches VEP's single-char rotation)
+        assert_eq!(notation.start, 3);
+        assert_eq!(notation.end, 4);
+        // alt_allele refreshed from reference at new positions (3-4 = "BA")
+        assert_eq!(notation.alt_allele, "BA");
+    }
+
+    #[test]
     fn peptide_dup_via_check_for_peptide_duplication() {
         // Test the full check_for_peptide_duplication flow with 3' shift.
         // Ref: MAAAEEEEK — E at 5,6,7,8
@@ -3289,6 +3324,12 @@ mod tests {
     }
 
     // ── HGVSc dup boundary revert tests (issue #88 remaining) ──────────
+    //
+    // NOTE: A full integration test calling `format_hgvsc` with a shifted
+    // dup landing outside the exon span would be ideal but requires
+    // substantial fixture plumbing (HgvsGenomicShift, FASTA context, etc.).
+    // The boundary condition is validated end-to-end by the 42-variant
+    // benchmark in the PR. The unit test below verifies the span arithmetic.
 
     #[test]
     fn dup_range_before_transcript_span_is_detected() {
@@ -3296,9 +3337,11 @@ mod tests {
         let exons = vec![&exon];
         let span_start = exons.iter().map(|e| e.start).min().unwrap();
         let span_end = exons.iter().map(|e| e.end).max().unwrap();
-        // Dup range 85..89 is before exon span start 90
+        // Dup range 85..89 is before exon span start 90 → would trigger revert
         assert!(85 < span_start);
-        // Dup range 95..100 is within exon span
+        // Dup range 95..100 is within exon span → no revert
         assert!(95 >= span_start && 100 <= span_end);
+        // Dup range 141..145 is after exon span end 140 → would trigger revert
+        assert!(141 > span_end);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #89, fixes remaining HGVSc dup-vs-ins mismatches from #88.

Three changes in `hgvs.rs`:

1. **HGVSp dup 3'-shift** (`try_peptide_dup_at`): After detecting a peptide duplication, walk the dup window rightward through identical residues to the 3'-most position per HGVS nomenclature. Previously only the leftmost (5') match was used. Also refresh `alt_allele` from the reference translation so residue names are correct at the shifted positions.

2. **HGVSc dup boundary check** (`format_hgvsc`): After `apply_shifted_insertion_duplication` converts an insertion to dup, verify the dup range falls within the transcript's genomic span. When HGVS 3' shift pushes a dup past the transcript boundary (before first exon or after last exon), revert to insertion notation to match VEP.

### Verification (HG002 full-genome benchmark, 66 variants across 20 chromosomes)

| Issue | Field | Match | Differ | Empty | Rate |
|-------|-------|-------|--------|-------|------|
| #88 (42 variants) | HGVSc | 1264/1264 | 0 | 0 | **100%** |
| #88 (42 variants) | HGVSp | 1257/1264 | 0 | 7* | **99.4%** |
| #89 (24 variants) | HGVSp | 252/259 | 7** | 0 | **97.3%** |
| #89 (24 variants) | HGVSc | 259/259 | 0 | 0 | **100%** |

\* 7 `p.Ter=` / frameshift values — tracked in issue #101 (incomplete_terminal_codon_variant)
\** 7 entries from single variant chr3:63912714 — dup-vs-ins classification edge case where VEP uses `ins` notation

## Test plan

- [x] 7 new unit tests for peptide dup 3' shifting (single/multi-residue, edge cases, issue #89 examples)
- [x] 1 new unit test for HGVSc dup boundary detection
- [x] 2 existing tests updated to expect 3'-shifted positions
- [x] All 475 existing tests pass (including golden roundtrip)
- [x] clippy clean, fmt clean
- [x] Validated against 66 affected variants across 20 chromosomes using `run_annotation_fast.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)