### PR TITLE
fix: consequence classification mismatches vs VEP (stop codon + regulatory)

### DIFF
--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -1690,6 +1690,12 @@ impl TranscriptConsequenceEngine {
                 // Only suppress stop_gained/stop_lost for inframe indels
                 // where the primary indel consequence already describes the
                 // event.
+                //
+                // Traceability:
+                // - VEP's `stop_lost` predicate fires independently of frameshift:
+                //   <https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L1290-L1340>
+                // - VEP's `frameshift_variant` predicate does NOT suppress stop_lost:
+                //   <https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L1434-L1468>
                 if terms.contains(&SoTerm::InframeDeletion)
                     || terms.contains(&SoTerm::InframeInsertion)
                 {


### PR DESCRIPTION
## Summary

Fixes #90 (partial — 17/24 variants resolved, 60/101 field mismatches fixed)

Four changes in `transcript_consequence.rs`:

1. **Sub-pattern D** (synonymous → stop_retained): SNV in stop codon that preserves the stop (e.g. TGA→TAA) now classified as `stop_retained_variant` instead of `synonymous_variant`. Added per-codon check for `old_aa == '*' && new_aa == '*'`.

2. **Sub-pattern C** (frameshift + stop_lost): VEP evaluates each consequence independently — `stop_lost` CAN co-occur with `frameshift_variant`. Removed blanket suppression; only suppress for inframe indels.

3. **Sub-pattern A** (indel stop_retained): For indels near the stop codon where the stop index shifts by exactly the indel length (in codons), set `stop_retained` — the stop codon is preserved but moved.

4. **Sub-pattern F** (regulatory_region_ablation): When a deletion fully encompasses a regulatory feature, add `regulatory_region_ablation` alongside `regulatory_region_variant`.

### Verification (24 affected variants across 12 chromosomes)

- **17/24 variants fully resolved** (255/296 transcript entries match)
- **7 variants with remaining diffs** (41 entries):
  - chr3:56557250 (20 tx) — insertion stop_retained with frameshift→inframe override (sub-pattern B, needs insertion-path investigation)
  - chr8:9030032 (3 tx) — deletion at CDS/3'UTR boundary (sub-pattern A, may use heuristic path)
  - chr6:73652738 (1 tx) — regulatory ablation coordinate check (sub-pattern F, needs coordinate investigation)
  - chr2:12737375 (1 tx) — miRNA data issue (sub-pattern E, not a code fix)

## Test plan

- [x] 3 new unit tests: stop codon SNV (TGA→TAA, TAA→TAG), deletion stop_retained with shifted index
- [x] All 480 tests pass (including golden roundtrip)
- [x] clippy clean, fmt clean
- [x] Validated against 24 variants across 12 chromosomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)