### PR TITLE
fix: apply csq_escape to SWISSPROT field

### DIFF
--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -7591,4 +7591,39 @@ mod tests {
             "RefSeq ID-based mapping should work regardless of hgnc_backfill flag"
         );
     }
+
+    // ── csq_escape ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_csq_escape_comma_becomes_ampersand() {
+        // Multi-accession SWISSPROT values must not split CSQ entries (issue #93)
+        assert_eq!(
+            csq_escape("A0A0J9YXY3.52,P0DPF7.28"),
+            "A0A0J9YXY3.52&P0DPF7.28"
+        );
+    }
+
+    #[test]
+    fn test_csq_escape_pipe_becomes_ampersand() {
+        assert_eq!(csq_escape("a|b"), "a&b");
+    }
+
+    #[test]
+    fn test_csq_escape_semicolon_percent_encoded() {
+        assert_eq!(csq_escape("a;b"), "a%3Bb");
+    }
+
+    #[test]
+    fn test_csq_escape_dash_becomes_empty() {
+        assert_eq!(csq_escape("-"), "");
+    }
+
+    #[test]
+    fn test_csq_escape_no_change() {
+        let val = "Q9Y6K1.3";
+        let escaped = csq_escape(val);
+        assert_eq!(escaped, val);
+        // Should be a borrowed Cow (no allocation)
+        assert!(matches!(escaped, std::borrow::Cow::Borrowed(_)));
+    }
 }


### PR DESCRIPTION
## Summary
- Apply `csq_escape()` to the SWISSPROT field in CSQ output, preventing commas in multi-accession values (e.g. `A0A0J9YXY3.52,P0DPF7.28`) from splitting a single transcript annotation into two broken CSQ entries
- Add unit tests for `csq_escape` covering comma, pipe, semicolon, dash, and no-change cases

## Test plan
- [x] `cargo test` — all existing tests pass
- [x] 5 new `csq_escape` unit tests pass
- [ ] e2e: re-run `run_annotation_fast.py chr7` to confirm the 15 SWISSPROT field mismatches from the GIAB benchmark are resolved

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)