### PR TITLE
fix: add stop_gained via local codon window for insertions (#116)

### DIFF
--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -11883,4 +11883,29 @@ mod tests {
             terms
         );
     }
+
+    #[test]
+    fn issue_116_inframe_insertion_near_stop_earlier_check_catches() {
+        // Edge case from review: 3bp inframe insertion 1 codon before
+        // the stop. The earlier stop_retained check (full CDS translation,
+        // old_stop_idx == new_stop_idx) fires because the stop position
+        // is preserved. This blocks stop_gained.
+        //
+        // CDS: ATG GAT GAA TGA (M D E *) — 12 bases
+        // Insert "CCT" at pos 1007 (within codon 2, after 1st base)
+        // Mutated: "ATGGATGCCTAATGA" → M D A * *
+        // old_stop = 3, new_stop = 3 → stop_retained from earlier check.
+        let cds = "ATGGATGAATGA";
+        let c = classify_ins(cds, 1007, "CCT").unwrap();
+        assert!(
+            c.stop_retained,
+            "Earlier check (old_stop==new_stop near insertion) should fire. Got: {:?}",
+            c
+        );
+        assert!(
+            !c.stop_gained,
+            "stop_gained must be blocked by stop_retained. Got: {:?}",
+            c
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #116 — vepyr misses `stop_gained` for frameshift insertions where VEP's local codon window contains a premature stop codon.

**Root cause:** `classify_insertion` had **no stop_gained check at all**. VEP's `stop_gained` uses the same `_get_peptide_alleles` (local codon window) as `stop_retained` — no frameshift guard. For a 4bp insertion, the window is 7 bytes → 2 AAs. If one AA is `*` and ref isn't `*`, `stop_gained` fires.

**Fix:** Restructured the local codon window computation (from #117's stop_retained fix) to be shared, then added:
```rust
if !stop_retained && !stop_gained && ref_aa != '*' && local_aas.contains(&'*') {
    stop_gained = true;
}
```

Matching VEP's guard at L1217: `return 0 if stop_retained(@_)` before the `stop_gained` check.

**Remaining variants:**
- chr11:5727045 T>TGAGC (1 transcript) — frameshift_variant → stop_gained&frameshift_variant
- chr20:37179387 G>G...ACT (4 transcripts) — frameshift_variant → splice_donor&stop_gained&frameshift_variant

**Expected improvement:** 5 Consequence mismatches + cascading IMPACT.

## Test plan

- [x] `issue_116_frameshift_insertion_stop_gained_local_window` — 4bp insertion, stop in 2-AA window, stop_gained fires
- [x] `issue_116_large_frameshift_insertion_stop_gained` — 28bp insertion, stop in 10-AA window
- [x] `issue_116_frameshift_insertion_no_false_stop_gained` — 1bp far from stop, no false positive
- [x] `issue_116_stop_gained_suppressed_when_stop_retained` — stop_retained blocks stop_gained
- [x] `issue_116_full_pipeline_frameshift_with_stop_gained` — full pipeline, both terms present
- [x] All 558 tests pass, clippy clean
- [ ] E2E benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)