### PR TITLE
fix: incomplete_terminal_codon_variant companion term interactions (#101)

### DIFF
--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -1728,20 +1728,32 @@ impl TranscriptConsequenceEngine {
         // Traceability:
         // - VEP partial_codon (incomplete_terminal_codon_variant predicate):
         //   <https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L1479-L1505>
+        // VEP's cds_length = length(_translateable_seq), which is the
+        // SPLICED CDS (includes leading N padding, excludes introns).
+        // Prefer translation data; fall back to summing coding_segments.
         let cds_len_opt = tx_translation
             .and_then(|t| {
+                // cds_len and cds_sequence.len() both include leading Ns,
+                // matching VEP's _translateable_seq.
                 t.cds_len
                     .or_else(|| t.cds_sequence.as_ref().map(|s| s.len()))
             })
             .or_else(|| {
-                let (Some(s), Some(e)) = (tx.cds_start, tx.cds_end) else {
-                    return None;
-                };
-                Some(usize::try_from(e - s + 1).unwrap_or(0))
+                // No translation data — compute spliced CDS length from
+                // coding segments (sum of exon/CDS overlaps), not the
+                // genomic span which includes introns.
+                coding_segments(tx, tx_exons).map(|segs| {
+                    segs.iter()
+                        .map(|(s, e)| usize::try_from(e - s + 1).unwrap_or(0))
+                        .sum()
+                })
             });
         if let Some(cds_len) = cds_len_opt {
             let variant_pos = variant.start.min(variant.end);
             if let Some(cds_idx) = genomic_to_cds_index(tx, tx_exons, variant_pos) {
+                // leading_n is only available from cds_sequence. When
+                // cds_len comes from t.cds_len, both values include
+                // leading Ns (VEP's _translateable_seq is N-inclusive).
                 let leading_n = tx_translation
                     .and_then(|t| t.cds_sequence.as_deref())
                     .map(|s| s.as_bytes().iter().take_while(|&&b| b == b'N').count())


### PR DESCRIPTION
## Summary

Fixes #101 — three sub-patterns of incorrect interaction between `incomplete_terminal_codon_variant` and other consequence terms.

### Sub-pattern A: `synonymous_variant` → `coding_sequence_variant` at incomplete terminal codons (~16 mismatches)

VEP's `synonymous_variant` has `($ref_pep !~ /X/) && ($alt_pep !~ /X/)` — when peptides contain `X` (from incomplete codon or N-padded first codon on `cds_start_NF` transcripts), synonymous is suppressed, and `coding_sequence_variant` fires as the fallback. Our code now checks if the affected codon position is at or beyond `old_aas.len()` (incomplete region) or contains `X`, and suppresses `synonymous` accordingly.

### Sub-pattern B: Extra `incomplete_terminal_codon_variant` alongside `stop_retained` (~2 mismatches)

VEP's `stop_retained` has `return 0 if partial_codon(@_)` — the two terms cannot co-occur. Added `StopRetainedVariant` to the stripping condition in `strip_parent_terms`.

### Tightened `incomplete_terminal_codon_variant` emission (~5 false positives)

Replaced the broad `cds_is_incomplete && overlaps_stop_codon` check with VEP's exact `partial_codon` logic: only fires when `cds_len % 3 != 0` AND the variant's CDS position (via `genomic_to_cds_index`) falls in the last (incomplete) codon.

**Expected improvement:** ~20+ Consequence mismatches + cascading IMPACT.

## Test plan

- [x] `issue_101_snv_at_incomplete_codon_no_synonymous` — X-containing peptide suppresses synonymous
- [x] `issue_101_snv_at_complete_codon_still_synonymous` — regression guard: regular synonymous unchanged
- [x] `issue_101_stop_retained_strips_incomplete_terminal_codon` — stripping test
- [x] `issue_101_false_incomplete_terminal_codon_not_emitted` — complete CDS doesn't fire partial_codon
- [x] `issue_101_partial_codon_fires_for_incomplete_cds` — incomplete CDS does fire
- [x] All 565 tests pass, clippy clean
- [ ] E2E benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)