### PR TITLE
fix: frameshift intron regression — fall back to coding_sequence_variant (#132)

### DIFF
--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -1098,6 +1098,12 @@ impl TranscriptConsequenceEngine {
                 terms.remove(&SoTerm::InframeInsertion);
                 terms.remove(&SoTerm::InframeDeletion);
                 terms.remove(&SoTerm::ProteinAlteringVariant);
+                // Note: VEP's start_lost/stop_lost/stop_gained predicates
+                // also guard on defined cds_start/cds_end (L1445 pattern).
+                // Heuristic terms from add_start_stop_heuristic_terms are
+                // not removed here — tiny mid-gene frameshift introns don't
+                // overlap start/stop codons in practice.  If this ever
+                // fires, extend the remove list.
             }
 
             // Deletions that extend beyond CDS into UTR: add UTR term


### PR DESCRIPTION
## Summary

Fixes #132 — PR #122 routed all frameshift intron variants through `add_coding_terms`, which unconditionally adds `FrameshiftVariant` (HIGH). For variants spanning tiny frameshift introns (1-5bp), `classify_coding_change` fails → `FrameshiftVariant` persists instead of VEP's `coding_sequence_variant` (MODIFIER).

**Fix:** When `in_frameshift_intron && coding_class.is_none()`, remove specific coding terms, keeping only `CodingSequenceVariant`.

**Affected:** chr3:44499299 (×2), chr10:87864103, chr12:121626865, chr16:3004601 = 5 Consequence + 5 IMPACT.

## Test plan
- [x] Updated `issue_118_frameshift_intron_insertion_gets_coding_consequences` — mid-intron variant now correctly gets `coding_sequence_variant`
- [x] `issue_118_frameshift_intron_insertion_populates_coding_fields` — exon-boundary variant still gets coding terms (anchor maps)
- [x] All 565 tests pass, clippy clean
- [ ] E2E: chr3, chr10

🤖 Generated with [Claude Code](https://claude.com/claude-code)