### PR TITLE
fix: coding_sequence_variant IMPACT MODIFIER not LOW (#134)

### DIFF
--- a/datafusion/bio-function-vep/src/so_terms.rs
+++ b/datafusion/bio-function-vep/src/so_terms.rs
@@ -266,8 +266,9 @@ impl SoTerm {
             | Self::IncompleteTerminalCodonVariant
             | Self::StartRetainedVariant
             | Self::StopRetainedVariant
-            | Self::SynonymousVariant
-            | Self::CodingSequenceVariant => SoImpact::Low,
+            | Self::SynonymousVariant => SoImpact::Low,
+
+            Self::CodingSequenceVariant => SoImpact::Modifier,
 
             Self::MatureMirnaVariant
             | Self::FivePrimeUtrVariant


### PR DESCRIPTION
## Summary

- Fixes the IMPACT mapping for `coding_sequence_variant` from `LOW` to `MODIFIER` to match VEP's `%OVERLAP_CONSEQUENCES` definition
- Resolves the cds_start_NF IMPACT mismatches (Pattern B, 4 variants) from #134 where the only consequence term is `coding_sequence_variant` but IMPACT was LOW instead of MODIFIER
- Partially addresses frameshift intron IMPACT mismatches (Pattern A) where `coding_sequence_variant` is the most severe term after specific coding terms are stripped

## Root cause

`so_terms.rs` mapped `CodingSequenceVariant` to `SoImpact::Low`, but Ensembl VEP 115 defines `coding_sequence_variant` as **MODIFIER** impact in `Bio::EnsEMBL::Variation::Utils::Constants`.

## Test plan

- [x] All 775 unit/integration tests pass
- [x] `cargo clippy -- -D warnings` clean
- [ ] Verify IMPACT mismatch count drops on golden roundtrip tests

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)