### PR TITLE
Add VEP flag_pick_allele_gene and pick_order support

### DIFF
--- a/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
+++ b/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
@@ -76,6 +76,18 @@ struct Args {
     reference_fasta_path: Option<PathBuf>,
     /// Use VEP --everything flag (enables all features, 80-field CSQ schema).
     everything: bool,
+    /// Select one consequence per variant using VEP --pick.
+    pick: bool,
+    /// Select one consequence per allele using VEP --pick_allele.
+    pick_allele: bool,
+    /// Select one consequence per gene using VEP --per_gene.
+    per_gene: bool,
+    /// Select one consequence per allele and gene using VEP --pick_allele_gene.
+    pick_allele_gene: bool,
+    /// Add standalone PICK field using VEP --flag_pick.
+    flag_pick: bool,
+    /// Add standalone PICK field using VEP --flag_pick_allele.
+    flag_pick_allele: bool,
     /// Add standalone PICK field using VEP --flag_pick_allele_gene.
     /// VEP also marks retained non-transcript regulatory/motif/intergenic rows.
     flag_pick_allele_gene: bool,
@@ -173,6 +185,20 @@ impl Args {
                     PathBuf::from(value)
                 },
             );
+        let pick = args.iter().any(|a| a == "--pick");
+        let pick_allele = args
+            .iter()
+            .any(|a| a == "--pick-allele" || a == "--pick_allele");
+        let per_gene = args.iter().any(|a| a == "--per-gene" || a == "--per_gene");
+        let pick_allele_gene = args
+            .iter()
+            .any(|a| a == "--pick-allele-gene" || a == "--pick_allele_gene");
+        let flag_pick = args
+            .iter()
+            .any(|a| a == "--flag-pick" || a == "--flag_pick");
+        let flag_pick_allele = args
+            .iter()
+            .any(|a| a == "--flag-pick-allele" || a == "--flag_pick_allele");
         let flag_pick_allele_gene = args
             .iter()
             .any(|a| a == "--flag-pick-allele-gene" || a == "--flag_pick_allele_gene");
@@ -259,6 +285,12 @@ impl Args {
             shift_hgvs,
             reference_fasta_path,
             everything: args.iter().any(|a| a == "--everything"),
+            pick,
+            pick_allele,
+            per_gene,
+            pick_allele_gene,
+            flag_pick,
+            flag_pick_allele,
             flag_pick_allele_gene,
             pick_order,
             use_fjall: args.iter().any(|a| a == "--use-fjall"),
@@ -271,6 +303,22 @@ impl Args {
 
     fn run_datafusion(&self) -> bool {
         self.steps.iter().any(|s| s == "datafusion")
+    }
+
+    fn pick_options(&self) -> [(&'static str, bool); 7] {
+        [
+            ("pick", self.pick),
+            ("pick_allele", self.pick_allele),
+            ("per_gene", self.per_gene),
+            ("pick_allele_gene", self.pick_allele_gene),
+            ("flag_pick", self.flag_pick),
+            ("flag_pick_allele", self.flag_pick_allele),
+            ("flag_pick_allele_gene", self.flag_pick_allele_gene),
+        ]
+    }
+
+    fn include_pick_output(&self) -> bool {
+        self.flag_pick || self.flag_pick_allele || self.flag_pick_allele_gene
     }
 }
 
@@ -320,7 +368,9 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|| "(none)".to_string())
     );
     println!("  everything: {}", args.everything);
-    println!("  flag_pick_allele_gene: {}", args.flag_pick_allele_gene);
+    for (name, enabled) in args.pick_options() {
+        println!("  {name}: {enabled}");
+    }
     println!(
         "  pick_order: {}",
         args.pick_order.as_deref().unwrap_or("(default)")
@@ -427,7 +477,7 @@ async fn main() -> Result<()> {
                 args.shift_hgvs,
                 args.reference_fasta_path.as_deref(),
                 args.everything,
-                args.flag_pick_allele_gene,
+                args.pick_options(),
                 args.pick_order.as_deref(),
             )?;
             let elapsed = docker_start.elapsed().as_secs_f64();
@@ -485,7 +535,7 @@ async fn main() -> Result<()> {
             args.everything,
             args.refseq,
             args.merged,
-            args.flag_pick_allele_gene,
+            args.include_pick_output(),
         );
         let csq_field_report = compare_csq_fields_with_names(golden, ours, &csq_field_names);
         let discrepancies = collect_discrepancies(golden, ours);
@@ -602,8 +652,10 @@ fn build_options_json(args: &Args) -> Result<Option<String>> {
         if args.use_fjall {
             entries.push("\"use_fjall\":true".to_string());
         }
-        if args.flag_pick_allele_gene {
-            entries.push("\"flag_pick_allele_gene\":true".to_string());
+        for (name, enabled) in args.pick_options() {
+            if enabled {
+                entries.push(format!("\"{name}\":true"));
+            }
         }
         if let Some(pick_order) = &args.pick_order {
             entries.push(format!("\"pick_order\":\"{}\"", sql_literal(pick_order)));
@@ -806,8 +858,10 @@ fn build_options_json(args: &Args) -> Result<Option<String>> {
         entries.push("\"exclude_predicted\":true".to_string());
     }
 
-    if args.flag_pick_allele_gene {
-        entries.push("\"flag_pick_allele_gene\":true".to_string());
+    for (name, enabled) in args.pick_options() {
+        if enabled {
+            entries.push(format!("\"{name}\":true"));
+        }
     }
 
     if let Some(pick_order) = &args.pick_order {
@@ -909,7 +963,7 @@ fn run_vep_docker(
     shift_hgvs: Option<bool>,
     reference_fasta_path: Option<&Path>,
     everything: bool,
-    flag_pick_allele_gene: bool,
+    pick_options: [(&'static str, bool); 7],
     pick_order: Option<&str>,
 ) -> Result<()> {
     let sampled_name = sampled_vcf
@@ -1020,9 +1074,11 @@ fn run_vep_docker(
         cmd.arg("--max_af");
         cmd.arg("--pubmed");
 
-        let fields =
-            csq_field_names_for_mode_with_pick(false, refseq, merged, flag_pick_allele_gene)
-                .join(",");
+        let include_pick_output = pick_options
+            .iter()
+            .any(|(name, enabled)| *enabled && name.starts_with("flag_"));
+        let fields = csq_field_names_for_mode_with_pick(false, refseq, merged, include_pick_output)
+            .join(",");
         cmd.arg("--fields").arg(fields);
     }
 
@@ -1048,8 +1104,10 @@ fn run_vep_docker(
     if exclude_predicted {
         cmd.arg("--exclude_predicted");
     }
-    if flag_pick_allele_gene {
-        cmd.arg("--flag_pick_allele_gene");
+    for (name, enabled) in pick_options {
+        if enabled {
+            cmd.arg(format!("--{name}"));
+        }
     }
     if let Some(pick_order) = pick_order {
         cmd.arg("--pick_order").arg(pick_order);

--- a/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
+++ b/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
@@ -23,8 +23,8 @@ use datafusion_bio_function_vep::golden_benchmark::{
     DEFAULT_LOCAL_HG002_CHR22_VCF_GZ, DEFAULT_LOCAL_VEP_CACHE_DIR, TermComparisonReport,
     VariantAnnotation, VariantDiscrepancy, VariantKey, collect_discrepancies,
     compare_annotation_terms, compare_annotations, compare_csq_fields_with_names,
-    csq_field_names_for_mode, diagnose_csq_multiplicity, diagnose_unmatched_csq, ensure_local_copy,
-    normalize_chrom, parse_vep_vcf_annotations, sample_gz_vcf_first_n,
+    csq_field_names_for_mode_with_pick, diagnose_csq_multiplicity, diagnose_unmatched_csq,
+    ensure_local_copy, normalize_chrom, parse_vep_vcf_annotations, sample_gz_vcf_first_n,
 };
 use datafusion_bio_function_vep::register_vep_functions;
 
@@ -77,6 +77,7 @@ struct Args {
     /// Use VEP --everything flag (enables all features, 80-field CSQ schema).
     everything: bool,
     /// Add standalone PICK field using VEP --flag_pick_allele_gene.
+    /// VEP also marks retained non-transcript regulatory/motif/intergenic rows.
     flag_pick_allele_gene: bool,
     /// Override VEP's pick ranking order.
     pick_order: Option<String>,
@@ -480,7 +481,7 @@ async fn main() -> Result<()> {
     if let (Some(golden), Some(ours)) = (&golden_annotations, &ours_annotations) {
         let report = compare_annotations(golden, ours);
         let term_report = compare_annotation_terms(golden, ours);
-        let csq_field_names = csq_field_names_for_mode(
+        let csq_field_names = csq_field_names_for_mode_with_pick(
             args.everything,
             args.refseq,
             args.merged,
@@ -1020,7 +1021,8 @@ fn run_vep_docker(
         cmd.arg("--pubmed");
 
         let fields =
-            csq_field_names_for_mode(false, refseq, merged, flag_pick_allele_gene).join(",");
+            csq_field_names_for_mode_with_pick(false, refseq, merged, flag_pick_allele_gene)
+                .join(",");
         cmd.arg("--fields").arg(fields);
     }
 

--- a/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
+++ b/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
@@ -76,6 +76,10 @@ struct Args {
     reference_fasta_path: Option<PathBuf>,
     /// Use VEP --everything flag (enables all features, 80-field CSQ schema).
     everything: bool,
+    /// Add standalone PICK field using VEP --flag_pick_allele_gene.
+    flag_pick_allele_gene: bool,
+    /// Override VEP's pick ranking order.
+    pick_order: Option<String>,
     /// Use fjall KV store for variation lookup + SIFT (--use-fjall).
     /// Cache directory must contain a `variation.fjall/` subdirectory.
     use_fjall: bool,
@@ -106,9 +110,27 @@ fn positional_or_env_string(
         .or_else(|| default.map(str::to_string))
 }
 
+fn option_value(args: &[String], names: &[&str]) -> Option<(String, usize)> {
+    for (idx, arg) in args.iter().enumerate() {
+        for name in names {
+            let prefix = format!("{name}=");
+            if let Some(value) = arg.strip_prefix(&prefix) {
+                return Some((value.to_string(), idx));
+            }
+            if arg == name {
+                if let Some(value) = args.get(idx + 1).filter(|value| !value.starts_with("--")) {
+                    return Some((value.to_string(), idx + 1));
+                }
+            }
+        }
+    }
+    None
+}
+
 impl Args {
     fn parse() -> Result<Self> {
         let args: Vec<String> = std::env::args().collect();
+        let mut option_value_indices = Vec::new();
 
         let refseq = args.iter().any(|a| a == "--refseq");
         // Check for --merged flag anywhere in args.
@@ -126,13 +148,13 @@ impl Args {
             })
             .unwrap_or_else(|| vec!["ensembl".to_string(), "datafusion".to_string()]);
         let hgvs = args.iter().any(|a| a == "--hgvs");
-        let shift_hgvs = args
-            .iter()
-            .find_map(|a| {
-                a.strip_prefix("--shift-hgvs=")
-                    .or_else(|| a.strip_prefix("--shift_hgvs="))
-            })
-            .and_then(parse_cli_bool)
+        let shift_hgvs =
+            if let Some((raw, idx)) = option_value(&args, &["--shift-hgvs", "--shift_hgvs"]) {
+                option_value_indices.push(idx);
+                parse_cli_bool(&raw)
+            } else {
+                None
+            }
             .or_else(|| {
                 args.iter()
                     .any(|a| a == "--shift-hgvs" || a == "--shift_hgvs")
@@ -143,12 +165,28 @@ impl Args {
                     .any(|a| a == "--no-shift-hgvs" || a == "--no-shift_hgvs")
                     .then_some(false)
             });
-        let reference_fasta_path = args
+        let reference_fasta_path =
+            option_value(&args, &["--reference-fasta-path", "--reference_fasta_path"]).map(
+                |(value, idx)| {
+                    option_value_indices.push(idx);
+                    PathBuf::from(value)
+                },
+            );
+        let flag_pick_allele_gene = args
             .iter()
-            .find_map(|a| a.strip_prefix("--reference-fasta-path="))
-            .map(PathBuf::from);
+            .any(|a| a == "--flag-pick-allele-gene" || a == "--flag_pick_allele_gene");
+        let pick_order =
+            option_value(&args, &["--pick-order", "--pick_order"]).map(|(value, idx)| {
+                option_value_indices.push(idx);
+                value
+            });
         // Filter out flags for positional parsing.
-        let positional: Vec<&String> = args.iter().filter(|a| !a.starts_with("--")).collect();
+        let positional: Vec<&String> = args
+            .iter()
+            .enumerate()
+            .filter(|(idx, a)| !a.starts_with("--") && !option_value_indices.contains(idx))
+            .map(|(_, a)| a)
+            .collect();
         let cache_source = positional_or_env_string(&positional, 2, ENV_CACHE_SOURCE, None)
             .ok_or_else(|| {
                 DataFusionError::Execution(format!(
@@ -220,6 +258,8 @@ impl Args {
             shift_hgvs,
             reference_fasta_path,
             everything: args.iter().any(|a| a == "--everything"),
+            flag_pick_allele_gene,
+            pick_order,
             use_fjall: args.iter().any(|a| a == "--use-fjall"),
         })
     }
@@ -279,6 +319,11 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|| "(none)".to_string())
     );
     println!("  everything: {}", args.everything);
+    println!("  flag_pick_allele_gene: {}", args.flag_pick_allele_gene);
+    println!(
+        "  pick_order: {}",
+        args.pick_order.as_deref().unwrap_or("(default)")
+    );
     println!("  use_fjall: {}", args.use_fjall);
 
     fs::create_dir_all(&args.work_dir).map_err(io_err)?;
@@ -381,6 +426,8 @@ async fn main() -> Result<()> {
                 args.shift_hgvs,
                 args.reference_fasta_path.as_deref(),
                 args.everything,
+                args.flag_pick_allele_gene,
+                args.pick_order.as_deref(),
             )?;
             let elapsed = docker_start.elapsed().as_secs_f64();
             println!(
@@ -433,7 +480,12 @@ async fn main() -> Result<()> {
     if let (Some(golden), Some(ours)) = (&golden_annotations, &ours_annotations) {
         let report = compare_annotations(golden, ours);
         let term_report = compare_annotation_terms(golden, ours);
-        let csq_field_names = csq_field_names_for_mode(args.everything, args.refseq, args.merged);
+        let csq_field_names = csq_field_names_for_mode(
+            args.everything,
+            args.refseq,
+            args.merged,
+            args.flag_pick_allele_gene,
+        );
         let csq_field_report = compare_csq_fields_with_names(golden, ours, &csq_field_names);
         let discrepancies = collect_discrepancies(golden, ours);
         let unmatched_report = diagnose_unmatched_csq(golden, ours);
@@ -548,6 +600,12 @@ fn build_options_json(args: &Args) -> Result<Option<String>> {
         }
         if args.use_fjall {
             entries.push("\"use_fjall\":true".to_string());
+        }
+        if args.flag_pick_allele_gene {
+            entries.push("\"flag_pick_allele_gene\":true".to_string());
+        }
+        if let Some(pick_order) = &args.pick_order {
+            entries.push(format!("\"pick_order\":\"{}\"", sql_literal(pick_order)));
         }
         return Ok(Some(format!("{{{}}}", entries.join(","))));
     }
@@ -747,6 +805,14 @@ fn build_options_json(args: &Args) -> Result<Option<String>> {
         entries.push("\"exclude_predicted\":true".to_string());
     }
 
+    if args.flag_pick_allele_gene {
+        entries.push("\"flag_pick_allele_gene\":true".to_string());
+    }
+
+    if let Some(pick_order) = &args.pick_order {
+        entries.push(format!("\"pick_order\":\"{}\"", sql_literal(pick_order)));
+    }
+
     if entries.is_empty() {
         return Ok(None);
     }
@@ -842,6 +908,8 @@ fn run_vep_docker(
     shift_hgvs: Option<bool>,
     reference_fasta_path: Option<&Path>,
     everything: bool,
+    flag_pick_allele_gene: bool,
+    pick_order: Option<&str>,
 ) -> Result<()> {
     let sampled_name = sampled_vcf
         .file_name()
@@ -951,7 +1019,8 @@ fn run_vep_docker(
         cmd.arg("--max_af");
         cmd.arg("--pubmed");
 
-        let fields = csq_field_names_for_mode(false, refseq, merged).join(",");
+        let fields =
+            csq_field_names_for_mode(false, refseq, merged, flag_pick_allele_gene).join(",");
         cmd.arg("--fields").arg(fields);
     }
 
@@ -976,6 +1045,12 @@ fn run_vep_docker(
     }
     if exclude_predicted {
         cmd.arg("--exclude_predicted");
+    }
+    if flag_pick_allele_gene {
+        cmd.arg("--flag_pick_allele_gene");
+    }
+    if let Some(pick_order) = pick_order {
+        cmd.arg("--pick_order").arg(pick_order);
     }
 
     let output = cmd.output().map_err(io_err)?;

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -2166,18 +2166,7 @@ fn build_pick_candidate_info(
             //   initializes transcript criteria from transcript attributes,
             //   translation/CDS length, and `_source_cache`
             //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L702-L767>
-            let length =
-                if let Some(translation) = ctx.translation_by_tx.get(tx.transcript_id.as_str()) {
-                    let cds_len = translation
-                        .cds_sequence
-                        .as_ref()
-                        .map(|sequence| sequence.len())
-                        .or(translation.cds_len)
-                        .unwrap_or(0);
-                    -i64::try_from(cds_len).unwrap_or(i64::MAX)
-                } else {
-                    -tx.end.saturating_sub(tx.start).saturating_add(1)
-                };
+            let length = -i64::try_from(pick_transcript_length(tx, ctx)).unwrap_or(i64::MAX);
             (
                 if tx
                     .mane_select
@@ -2230,6 +2219,35 @@ fn build_pick_candidate_info(
         refseq: pick_assignment_source_rank(tx, "refseq"),
         rank: pick_assignment_rank(tc),
     }
+}
+
+fn pick_transcript_length(tx: &TranscriptFeature, ctx: &PreparedContext<'_>) -> usize {
+    if let Some(translation) = ctx.translation_by_tx.get(tx.transcript_id.as_str()) {
+        return translation
+            .cds_sequence
+            .as_ref()
+            .map(|sequence| sequence.len())
+            .or_else(|| tx.translateable_seq.as_ref().map(|sequence| sequence.len()))
+            .or(translation.cds_len)
+            .unwrap_or(0);
+    }
+
+    tx.spliced_seq
+        .as_ref()
+        .map(|sequence| sequence.len())
+        .or_else(|| tx.cdna_seq.as_ref().map(|sequence| sequence.len()))
+        .or_else(|| {
+            ctx.exons_by_tx.get(tx.transcript_id.as_str()).map(|exons| {
+                exons
+                    .iter()
+                    .map(|exon| exon.end.saturating_sub(exon.start).saturating_add(1))
+                    .filter_map(|len| usize::try_from(len).ok())
+                    .sum()
+            })
+        })
+        .unwrap_or_else(|| {
+            usize::try_from(tx.end.saturating_sub(tx.start).saturating_add(1)).unwrap_or(0)
+        })
 }
 
 fn pick_assignment_gene_key(
@@ -9215,6 +9233,64 @@ mod tests {
             },
         ];
         let ctx = PreparedContext::new(&transcripts, &[], &translations, &[], &[], &[], &[]);
+        let mut assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+        ];
+
+        mark_flag_pick_allele_gene(
+            &mut assignments,
+            &ctx,
+            &PickFlags {
+                flag_pick_allele_gene: true,
+                pick_order: vec![PickCriterion::Length],
+            },
+        );
+
+        assert!(!assignments[0].picked);
+        assert!(assignments[1].picked);
+    }
+
+    #[test]
+    fn test_mark_flag_pick_allele_gene_uses_spliced_length_for_noncoding_transcripts() {
+        let mut tx_shorter_spliced =
+            make_tx("ENST00000041", Some("GENE1"), Some("HGNC"), None, None);
+        tx_shorter_spliced.gene_stable_id = Some("ENSG00000041".to_string());
+        tx_shorter_spliced.biotype = "lncRNA".to_string();
+        tx_shorter_spliced.start = 1;
+        tx_shorter_spliced.end = 1000;
+
+        let mut tx_longer_spliced =
+            make_tx("ENST00000042", Some("GENE1"), Some("HGNC"), None, None);
+        tx_longer_spliced.gene_stable_id = Some("ENSG00000041".to_string());
+        tx_longer_spliced.biotype = "lncRNA".to_string();
+        tx_longer_spliced.start = 1;
+        tx_longer_spliced.end = 500;
+
+        let transcripts = vec![tx_shorter_spliced, tx_longer_spliced];
+        let exons = vec![
+            ExonFeature {
+                transcript_id: "ENST00000041".to_string(),
+                exon_number: 1,
+                start: 1,
+                end: 100,
+            },
+            ExonFeature {
+                transcript_id: "ENST00000042".to_string(),
+                exon_number: 1,
+                start: 1,
+                end: 200,
+            },
+        ];
+        let ctx = PreparedContext::new(&transcripts, &exons, &[], &[], &[], &[], &[]);
         let mut assignments = vec![
             TranscriptConsequence {
                 transcript_idx: Some(0),

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -91,11 +91,11 @@ use crate::miss_worklist::{MissWorklist, collect_miss_worklist};
 use crate::partitioned_cache::PartitionedParquetCache;
 use crate::so_terms::{SoImpact, SoTerm, most_severe_term};
 use crate::transcript_consequence::{
-    CachedPredictions, CompactPrediction, ExonFeature, MirnaFeature, MotifFeature, PreparedContext,
-    ProteinDomainFeature, RefSeqEdit, RegulatoryFeature, SiftPolyphenCache, StructuralFeature,
-    SvEventKind, SvFeatureKind, TranscriptCdnaMapperSegment, TranscriptConsequence,
-    TranscriptConsequenceEngine, TranscriptFeature, TranslationFeature, VariantInput,
-    infer_refseq_deletion_edits_from_sequences, refseq_edit_offset_delta,
+    CachedPredictions, CompactPrediction, ExonFeature, FeatureType, MirnaFeature, MotifFeature,
+    PreparedContext, ProteinDomainFeature, RefSeqEdit, RegulatoryFeature, SiftPolyphenCache,
+    StructuralFeature, SvEventKind, SvFeatureKind, TranscriptCdnaMapperSegment,
+    TranscriptConsequence, TranscriptConsequenceEngine, TranscriptFeature, TranslationFeature,
+    VariantInput, infer_refseq_deletion_edits_from_sequences, refseq_edit_offset_delta,
 };
 use crate::variant_lookup_exec::{
     ColocatedCacheEntry, ColocatedKey, ColocatedSink, ColocatedSinkValue,
@@ -2245,6 +2245,19 @@ fn pick_assignment_gene_key(
     tx.gene_stable_id.clone()
 }
 
+fn pick_assignment_feature_id<'a>(
+    assignment_idx: usize,
+    assignments: &'a [TranscriptConsequence],
+    ctx: &'a PreparedContext<'_>,
+) -> &'a str {
+    assignments
+        .get(assignment_idx)
+        .and_then(|tc| tc.transcript_idx)
+        .and_then(|idx| ctx.transcripts.get(idx))
+        .map(|tx| tx.transcript_id.as_str())
+        .unwrap_or("")
+}
+
 fn pick_assignment_source_rank(tx: Option<&TranscriptFeature>, wanted: &str) -> u8 {
     let Some(tx) = tx else {
         return 1;
@@ -2375,14 +2388,27 @@ fn mark_flag_pick_allele_gene(
     }
 
     let mut grouped: HashMap<String, Vec<usize>> = HashMap::new();
-    for (idx, tc) in assignments.iter().enumerate() {
-        let Some(gene_key) = pick_assignment_gene_key(tc, ctx) else {
+    for idx in 0..assignments.len() {
+        if assignments[idx].feature_type != FeatureType::Transcript {
+            // VEP's per-gene picker returns non-transcript overlap alleles
+            // unchanged, and the flagging path marks every returned item.
+            assignments[idx].picked = true;
+            continue;
+        }
+        let Some(gene_key) = pick_assignment_gene_key(&assignments[idx], ctx) else {
             continue;
         };
         grouped.entry(gene_key).or_default().push(idx);
     }
 
-    for candidate_indices in grouped.values() {
+    for candidate_indices in grouped.values_mut() {
+        candidate_indices.sort_by(|&a, &b| {
+            pick_assignment_feature_id(a, assignments, ctx).cmp(pick_assignment_feature_id(
+                b,
+                assignments,
+                ctx,
+            ))
+        });
         let Some(winner) =
             pick_worst_assignment(candidate_indices, assignments, ctx, &pick_flags.pick_order)
         else {
@@ -9039,6 +9065,79 @@ mod tests {
     }
 
     #[test]
+    fn test_mark_flag_pick_allele_gene_marks_non_transcript_assignments() {
+        let ctx = PreparedContext::new(&[], &[], &[], &[], &[], &[], &[]);
+        let mut assignments = vec![
+            TranscriptConsequence {
+                feature_type: FeatureType::RegulatoryFeature,
+                terms: vec![SoTerm::RegulatoryRegionVariant],
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                feature_type: FeatureType::MotifFeature,
+                terms: vec![SoTerm::TfBindingSiteVariant],
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                feature_type: FeatureType::None,
+                terms: vec![SoTerm::IntergenicVariant],
+                ..Default::default()
+            },
+        ];
+
+        mark_flag_pick_allele_gene(
+            &mut assignments,
+            &ctx,
+            &PickFlags {
+                flag_pick_allele_gene: true,
+                pick_order: vec![PickCriterion::Rank],
+            },
+        );
+
+        assert!(assignments.iter().all(|assignment| assignment.picked));
+    }
+
+    #[test]
+    fn test_mark_flag_pick_allele_gene_tie_breaks_by_feature_id_order() {
+        let mut tx_a = make_tx("ENST00000031", Some("GENE1"), Some("HGNC"), None, None);
+        tx_a.gene_stable_id = Some("ENSG00000031".to_string());
+        tx_a.biotype = "protein_coding".to_string();
+
+        let mut tx_b = make_tx("ENST00000032", Some("GENE1"), Some("HGNC"), None, None);
+        tx_b.gene_stable_id = Some("ENSG00000031".to_string());
+        tx_b.biotype = "protein_coding".to_string();
+
+        let transcripts = vec![tx_b, tx_a];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let mut assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                terms: vec![SoTerm::IntronVariant],
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                terms: vec![SoTerm::IntronVariant],
+                ..Default::default()
+            },
+        ];
+
+        mark_flag_pick_allele_gene(
+            &mut assignments,
+            &ctx,
+            &PickFlags {
+                flag_pick_allele_gene: true,
+                pick_order: vec![PickCriterion::Rank],
+            },
+        );
+
+        assert!(!assignments[0].picked);
+        assert!(assignments[1].picked);
+    }
+
+    #[test]
     fn test_mark_flag_pick_allele_gene_requires_exact_source_match() {
         let mut tx_havana = make_tx("ENST00000001", Some("GENE1"), Some("HGNC"), None, None);
         tx_havana.gene_stable_id = Some("ENSG00000001".to_string());
@@ -9144,11 +9243,11 @@ mod tests {
 
     #[test]
     fn test_mark_flag_pick_allele_gene_skips_candidates_without_gene_stable_id() {
-        let mut tx_a = make_tx("ENST00000021", Some("GENE1"), Some("HGNC"), None, None);
+        let mut tx_a = make_tx("ENST00000021", None, Some("GENE1"), Some("HGNC"), None);
         tx_a.biotype = "protein_coding".to_string();
         tx_a.is_canonical = false;
 
-        let mut tx_b = make_tx("ENST00000022", Some("GENE1"), Some("HGNC"), None, None);
+        let mut tx_b = make_tx("ENST00000022", None, Some("GENE1"), Some("HGNC"), None);
         tx_b.biotype = "protein_coding".to_string();
         tx_b.is_canonical = true;
 

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -1208,6 +1208,9 @@ impl Default for PickFlags {
     fn default() -> Self {
         Self {
             flag_pick_allele_gene: false,
+            // Traceability:
+            // - Ensembl VEP release 115 default `pick_order`
+            //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/Config.pm#L300-L307>
             pick_order: vec![
                 PickCriterion::ManeSelect,
                 PickCriterion::ManePlusClinical,
@@ -2071,178 +2074,277 @@ fn format_appris(raw: &str) -> String {
     raw.replace("principal", "P").replace("alternative", "A")
 }
 
-fn parse_appris_pick_rank(raw: Option<&str>) -> (u8, u8) {
+fn parse_appris_pick_rank(raw: Option<&str>) -> u8 {
     let Some(raw) = raw else {
-        return (3, u8::MAX);
+        return 100;
     };
-    if let Some(suffix) = raw.strip_prefix("principal") {
-        return (0, suffix.parse::<u8>().unwrap_or(u8::MAX));
-    }
-    if let Some(suffix) = raw.strip_prefix("alternative") {
-        return (1, suffix.parse::<u8>().unwrap_or(u8::MAX));
-    }
-    (2, u8::MAX)
-}
 
-fn compare_pick_bool(a: bool, b: bool) -> Ordering {
-    match (a, b) {
-        (true, false) => Ordering::Less,
-        (false, true) => Ordering::Greater,
-        _ => Ordering::Equal,
-    }
-}
-
-fn compare_pick_option_i32(a: Option<i32>, b: Option<i32>) -> Ordering {
-    match (a, b) {
-        (Some(av), Some(bv)) => av.cmp(&bv),
-        (Some(_), None) => Ordering::Less,
-        (None, Some(_)) => Ordering::Greater,
-        (None, None) => Ordering::Equal,
-    }
-}
-
-fn compare_pick_usize_desc(a: usize, b: usize) -> Ordering {
-    b.cmp(&a)
-}
-
-fn compare_pick_biotype(a: Option<&str>, b: Option<&str>) -> Ordering {
-    let rank = |value: Option<&str>| match value {
-        Some("protein_coding") => 0_u8,
-        Some(other) if !other.is_empty() => 1_u8,
-        _ => 2_u8,
+    // Traceability:
+    // - Ensembl VEP release 115 `pick_worst_VariationFeatureOverlapAllele()`
+    //   parses APPRIS as `([A-Za-z]).+(\\d+)`, then adds 10 for
+    //   `alternative*` values
+    //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L756-L767>
+    let Some(first) = raw
+        .chars()
+        .next()
+        .filter(|ch| ch.is_ascii_alphabetic())
+        .map(|ch| ch.to_ascii_lowercase())
+    else {
+        return 100;
     };
-    rank(a)
-        .cmp(&rank(b))
-        .then_with(|| a.unwrap_or("").cmp(b.unwrap_or("")))
+    let trailing_digits_len = raw
+        .chars()
+        .rev()
+        .take_while(|ch| ch.is_ascii_digit())
+        .count();
+    if trailing_digits_len == 0 {
+        return 100;
+    }
+    let digits = &raw[raw.len() - trailing_digits_len..];
+    let Some(mut grade) = digits.parse::<u8>().ok() else {
+        return 100;
+    };
+    if grade == 0 {
+        return 100;
+    }
+    if first == 'a' {
+        grade = grade.saturating_add(10);
+    }
+    grade
+}
+
+#[derive(Debug, Clone)]
+struct PickCandidateInfo {
+    assignment_idx: usize,
+    mane_select: u8,
+    mane_plus_clinical: u8,
+    canonical: u8,
+    ccds: u8,
+    length: i64,
+    biotype: u8,
+    tsl: i32,
+    appris: u8,
+    ensembl: u8,
+    refseq: u8,
+    rank: u32,
+}
+
+fn build_pick_candidate_info(
+    assignment_idx: usize,
+    assignments: &[TranscriptConsequence],
+    ctx: &PreparedContext<'_>,
+) -> PickCandidateInfo {
+    let tc = &assignments[assignment_idx];
+    let tx = tc.transcript_idx.map(|idx| ctx.transcripts[idx]);
+
+    let (mane_select, mane_plus_clinical, canonical, ccds, length, biotype, tsl, appris) =
+        if let Some(tx) = tx {
+            // Traceability:
+            // - Ensembl VEP release 115 `pick_worst_VariationFeatureOverlapAllele()`
+            //   initializes transcript criteria from transcript attributes,
+            //   translation/CDS length, and `_source_cache`
+            //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L702-L767>
+            let length =
+                if let Some(translation) = ctx.translation_by_tx.get(tx.transcript_id.as_str()) {
+                    let cds_len = translation
+                        .cds_sequence
+                        .as_ref()
+                        .map(|sequence| sequence.len())
+                        .or(translation.cds_len)
+                        .unwrap_or(0);
+                    -i64::try_from(cds_len).unwrap_or(i64::MAX)
+                } else {
+                    -tx.end.saturating_sub(tx.start).saturating_add(1)
+                };
+            (
+                if tx
+                    .mane_select
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty())
+                {
+                    0
+                } else {
+                    1
+                },
+                if tx
+                    .mane_plus_clinical
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty())
+                {
+                    0
+                } else {
+                    1
+                },
+                if tx.is_canonical { 0 } else { 1 },
+                if tx
+                    .ccds
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty() && value != "-")
+                {
+                    0
+                } else {
+                    1
+                },
+                length,
+                if tx.biotype == "protein_coding" { 0 } else { 1 },
+                tx.tsl.unwrap_or(100),
+                parse_appris_pick_rank(tx.appris.as_deref()),
+            )
+        } else {
+            (1, 1, 1, 1, 0, 1, 100, 100)
+        };
+
+    PickCandidateInfo {
+        assignment_idx,
+        mane_select,
+        mane_plus_clinical,
+        canonical,
+        ccds,
+        length,
+        biotype,
+        tsl,
+        appris,
+        ensembl: pick_assignment_source_rank(tx, "ensembl"),
+        refseq: pick_assignment_source_rank(tx, "refseq"),
+        rank: pick_assignment_rank(tc),
+    }
 }
 
 fn pick_assignment_gene_key(
     tc: &TranscriptConsequence,
     ctx: &PreparedContext<'_>,
 ) -> Option<String> {
+    // Traceability:
+    // - Ensembl VEP release 115 groups transcript consequences by
+    //   `transcript->{_gene_stable_id}`, only falling back to a gene-adaptor
+    //   lookup when that cache slot is absent
+    //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L845-L855>
+    //
+    // We intentionally require the cache-provided `gene_stable_id` here and do
+    // not substitute `gene_symbol` or `transcript_id`, because those are local
+    // heuristics rather than VEP pick-group semantics.
     let tx = ctx.transcripts.get(tc.transcript_idx?)?;
-    tx.gene_stable_id
-        .clone()
-        .or_else(|| tx.gene_symbol.clone())
-        .or_else(|| Some(tx.transcript_id.clone()))
+    tx.gene_stable_id.clone()
 }
 
-fn pick_assignment_source_rank(tx: Option<&TranscriptFeature>, wanted: &str) -> bool {
+fn pick_assignment_source_rank(tx: Option<&TranscriptFeature>, wanted: &str) -> u8 {
     let Some(tx) = tx else {
-        return false;
+        return 1;
     };
-    let source = tx
+
+    // Traceability:
+    // - Ensembl VEP release 115 sets `$info->{lc($tr->{_source_cache})} = 0`
+    //   and only exact `ensembl` / `refseq` keys influence those categories
+    //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L734-L741>
+    if tx
         .source
         .as_deref()
-        .and_then(normalize_source_label)
-        .unwrap_or_else(|| {
-            if tx.transcript_id.starts_with("ENS") {
-                "Ensembl".to_string()
-            } else if tx.transcript_id.starts_with("NM_")
-                || tx.transcript_id.starts_with("NR_")
-                || tx.transcript_id.starts_with("XM_")
-                || tx.transcript_id.starts_with("XR_")
-            {
-                "RefSeq".to_string()
-            } else {
-                String::new()
-            }
-        });
-    source == wanted
+        .is_some_and(|source| source.eq_ignore_ascii_case(wanted))
+    {
+        0
+    } else {
+        1
+    }
 }
 
 fn pick_assignment_rank(tc: &TranscriptConsequence) -> u32 {
     most_severe_term(tc.terms.iter())
         .map(|term| term.rank() as u32)
-        .unwrap_or(u32::MAX)
+        .unwrap_or(1000)
 }
 
-fn pick_assignment_length(tc: &TranscriptConsequence, ctx: &PreparedContext<'_>) -> usize {
-    let Some(tx_idx) = tc.transcript_idx else {
-        return 0;
-    };
-    let tx = ctx.transcripts[tx_idx];
-    if let Some(length) = ctx
-        .translation_by_tx
-        .get(tx.transcript_id.as_str())
-        .and_then(|translation| translation.protein_len.or(translation.cds_len))
-    {
-        return length;
+fn retain_best_pick_candidates<T, F>(
+    candidates: &mut Vec<PickCandidateInfo>,
+    mut key: F,
+) -> Option<usize>
+where
+    T: Ord + Copy,
+    F: FnMut(&PickCandidateInfo) -> T,
+{
+    candidates.sort_by_key(|candidate| key(candidate));
+    let best = key(&candidates[0]);
+    let keep = candidates
+        .iter()
+        .take_while(|candidate| key(candidate) == best)
+        .count();
+    if keep == 1 {
+        return Some(candidates[0].assignment_idx);
     }
-    tx.end
-        .saturating_sub(tx.start)
-        .saturating_add(1)
-        .try_into()
-        .unwrap_or(0)
+    candidates.truncate(keep);
+    None
 }
 
-fn compare_pick_assignments(
-    a_idx: usize,
-    b_idx: usize,
+fn pick_worst_assignment(
+    candidate_indices: &[usize],
     assignments: &[TranscriptConsequence],
     ctx: &PreparedContext<'_>,
     pick_order: &[PickCriterion],
-) -> Ordering {
-    let a = &assignments[a_idx];
-    let b = &assignments[b_idx];
-    let a_tx = a.transcript_idx.map(|idx| ctx.transcripts[idx]);
-    let b_tx = b.transcript_idx.map(|idx| ctx.transcripts[idx]);
+) -> Option<usize> {
+    // Traceability:
+    // - Ensembl VEP release 115
+    //   `OutputFactory::pick_worst_VariationFeatureOverlapAllele()`
+    //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L679-L809>
+    //
+    // VEP computes category values for all candidates, stably sorts on one
+    // `pick_order` criterion at a time, keeps only the tied best candidates,
+    // and then repeats with the next criterion.
+    let mut candidates: Vec<PickCandidateInfo> = candidate_indices
+        .iter()
+        .copied()
+        .map(|assignment_idx| build_pick_candidate_info(assignment_idx, assignments, ctx))
+        .collect();
+
+    if candidates.is_empty() {
+        return None;
+    }
+    if candidates.len() == 1 {
+        return Some(candidates[0].assignment_idx);
+    }
 
     for criterion in pick_order {
-        let ordering = match criterion {
-            PickCriterion::ManeSelect => compare_pick_bool(
-                a_tx.and_then(|tx| tx.mane_select.as_deref()).is_some(),
-                b_tx.and_then(|tx| tx.mane_select.as_deref()).is_some(),
-            ),
-            PickCriterion::ManePlusClinical => compare_pick_bool(
-                a_tx.and_then(|tx| tx.mane_plus_clinical.as_deref())
-                    .is_some(),
-                b_tx.and_then(|tx| tx.mane_plus_clinical.as_deref())
-                    .is_some(),
-            ),
-            PickCriterion::Canonical => compare_pick_bool(
-                a_tx.map(|tx| tx.is_canonical).unwrap_or(false),
-                b_tx.map(|tx| tx.is_canonical).unwrap_or(false),
-            ),
+        let winner = match criterion {
+            PickCriterion::ManeSelect => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.mane_select)
+            }
+            PickCriterion::ManePlusClinical => {
+                retain_best_pick_candidates(&mut candidates, |candidate| {
+                    candidate.mane_plus_clinical
+                })
+            }
+            PickCriterion::Canonical => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.canonical)
+            }
             PickCriterion::Appris => {
-                parse_appris_pick_rank(a_tx.and_then(|tx| tx.appris.as_deref())).cmp(
-                    &parse_appris_pick_rank(b_tx.and_then(|tx| tx.appris.as_deref())),
-                )
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.appris)
             }
             PickCriterion::Tsl => {
-                compare_pick_option_i32(a_tx.and_then(|tx| tx.tsl), b_tx.and_then(|tx| tx.tsl))
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.tsl)
             }
-            PickCriterion::Biotype => compare_pick_biotype(
-                a_tx.map(|tx| tx.biotype.as_str()),
-                b_tx.map(|tx| tx.biotype.as_str()),
-            ),
-            PickCriterion::Ccds => compare_pick_bool(
-                a_tx.and_then(|tx| tx.ccds.as_deref()).is_some(),
-                b_tx.and_then(|tx| tx.ccds.as_deref()).is_some(),
-            ),
-            PickCriterion::Rank => pick_assignment_rank(a).cmp(&pick_assignment_rank(b)),
-            PickCriterion::Length => compare_pick_usize_desc(
-                pick_assignment_length(a, ctx),
-                pick_assignment_length(b, ctx),
-            ),
-            PickCriterion::Ensembl => compare_pick_bool(
-                pick_assignment_source_rank(a_tx, "Ensembl"),
-                pick_assignment_source_rank(b_tx, "Ensembl"),
-            ),
-            PickCriterion::Refseq => compare_pick_bool(
-                pick_assignment_source_rank(a_tx, "RefSeq"),
-                pick_assignment_source_rank(b_tx, "RefSeq"),
-            ),
+            PickCriterion::Biotype => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.biotype)
+            }
+            PickCriterion::Ccds => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.ccds)
+            }
+            PickCriterion::Rank => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.rank)
+            }
+            PickCriterion::Length => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.length)
+            }
+            PickCriterion::Ensembl => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.ensembl)
+            }
+            PickCriterion::Refseq => {
+                retain_best_pick_candidates(&mut candidates, |candidate| candidate.refseq)
+            }
         };
-        if ordering != Ordering::Equal {
-            return ordering;
+        if winner.is_some() {
+            return winner;
         }
     }
 
-    a.transcript_idx
-        .cmp(&b.transcript_idx)
-        .then_with(|| a.transcript_id.cmp(&b.transcript_id))
-        .then_with(|| a_idx.cmp(&b_idx))
+    candidates.first().map(|candidate| candidate.assignment_idx)
 }
 
 fn append_pick_flag(flags: &mut Option<String>) {
@@ -2276,17 +2378,11 @@ fn mark_flag_pick_allele_gene(
     }
 
     for candidate_indices in grouped.values() {
-        if candidate_indices.is_empty() {
+        let Some(winner) =
+            pick_worst_assignment(candidate_indices, assignments, ctx, &pick_flags.pick_order)
+        else {
             continue;
-        }
-        let mut winner = candidate_indices[0];
-        for &candidate in candidate_indices.iter().skip(1) {
-            if compare_pick_assignments(candidate, winner, assignments, ctx, &pick_flags.pick_order)
-                == Ordering::Less
-            {
-                winner = candidate;
-            }
-        }
+        };
         append_pick_flag(&mut assignments[winner].flags);
     }
 }
@@ -8828,7 +8924,7 @@ impl TableProvider for AnnotateProvider {
 mod tests {
     use super::*;
     use crate::transcript_consequence::{
-        CachedPredictions, ProteinDomainFeature, SiftPolyphenCache, TranslationFeature,
+        CachedPredictions, FeatureType, ProteinDomainFeature, SiftPolyphenCache, TranslationFeature,
     };
 
     // ── format_appris ──────────────────────────────────────────────────
@@ -8897,6 +8993,152 @@ mod tests {
         let mut empty = None;
         append_pick_flag(&mut empty);
         assert_eq!(empty, Some("PICK".to_string()));
+    }
+
+    #[test]
+    fn test_parse_appris_pick_rank_matches_release_115() {
+        assert_eq!(parse_appris_pick_rank(Some("principal5")), 5);
+        assert_eq!(parse_appris_pick_rank(Some("alternative2")), 12);
+        assert_eq!(parse_appris_pick_rank(Some("other")), 100);
+        assert_eq!(parse_appris_pick_rank(None), 100);
+    }
+
+    #[test]
+    fn test_mark_flag_pick_allele_gene_requires_exact_source_match() {
+        let mut tx_havana = make_tx("ENST00000001", Some("GENE1"), Some("HGNC"), None);
+        tx_havana.gene_stable_id = Some("ENSG00000001".to_string());
+        tx_havana.biotype = "protein_coding".to_string();
+        tx_havana.source = Some("ensembl_havana".to_string());
+
+        let mut tx_ensembl = make_tx("ENST00000002", Some("GENE1"), Some("HGNC"), None);
+        tx_ensembl.gene_stable_id = Some("ENSG00000001".to_string());
+        tx_ensembl.biotype = "protein_coding".to_string();
+        tx_ensembl.source = Some("Ensembl".to_string());
+
+        let transcripts = vec![tx_havana, tx_ensembl];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let mut assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+        ];
+
+        mark_flag_pick_allele_gene(
+            &mut assignments,
+            &ctx,
+            &PickFlags {
+                flag_pick_allele_gene: true,
+                pick_order: vec![PickCriterion::Ensembl],
+            },
+        );
+
+        assert_eq!(assignments[0].flags, None);
+        assert_eq!(assignments[1].flags, Some("PICK".to_string()));
+    }
+
+    #[test]
+    fn test_mark_flag_pick_allele_gene_prefers_cds_length_over_protein_length() {
+        let mut tx_shorter_cds = make_tx("ENST00000011", Some("GENE1"), Some("HGNC"), None);
+        tx_shorter_cds.gene_stable_id = Some("ENSG00000011".to_string());
+        tx_shorter_cds.biotype = "protein_coding".to_string();
+
+        let mut tx_longer_cds = make_tx("ENST00000012", Some("GENE1"), Some("HGNC"), None);
+        tx_longer_cds.gene_stable_id = Some("ENSG00000011".to_string());
+        tx_longer_cds.biotype = "protein_coding".to_string();
+
+        let transcripts = vec![tx_shorter_cds, tx_longer_cds];
+        let translations = vec![
+            TranslationFeature {
+                transcript_id: "ENST00000011".to_string(),
+                cds_len: Some(90),
+                protein_len: Some(100),
+                translation_seq: None,
+                cds_sequence: Some("A".repeat(90)),
+                stable_id: None,
+                version: None,
+                protein_features: Vec::new(),
+            },
+            TranslationFeature {
+                transcript_id: "ENST00000012".to_string(),
+                cds_len: Some(99),
+                protein_len: Some(20),
+                translation_seq: None,
+                cds_sequence: Some("A".repeat(99)),
+                stable_id: None,
+                version: None,
+                protein_features: Vec::new(),
+            },
+        ];
+        let ctx = PreparedContext::new(&transcripts, &[], &translations, &[], &[], &[], &[]);
+        let mut assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+        ];
+
+        mark_flag_pick_allele_gene(
+            &mut assignments,
+            &ctx,
+            &PickFlags {
+                flag_pick_allele_gene: true,
+                pick_order: vec![PickCriterion::Length],
+            },
+        );
+
+        assert_eq!(assignments[0].flags, None);
+        assert_eq!(assignments[1].flags, Some("PICK".to_string()));
+    }
+
+    #[test]
+    fn test_mark_flag_pick_allele_gene_requires_gene_stable_id() {
+        let mut tx_a = make_tx("ENST00000021", Some("GENE1"), Some("HGNC"), None);
+        tx_a.biotype = "protein_coding".to_string();
+        tx_a.is_canonical = false;
+
+        let mut tx_b = make_tx("ENST00000022", Some("GENE1"), Some("HGNC"), None);
+        tx_b.biotype = "protein_coding".to_string();
+        tx_b.is_canonical = true;
+
+        let transcripts = vec![tx_a, tx_b];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let mut assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+        ];
+
+        mark_flag_pick_allele_gene(
+            &mut assignments,
+            &ctx,
+            &PickFlags {
+                flag_pick_allele_gene: true,
+                pick_order: vec![PickCriterion::Canonical],
+            },
+        );
+
+        assert_eq!(assignments[0].flags, None);
+        assert_eq!(assignments[1].flags, None);
     }
 
     // ── format_prediction ──────────────────────────────────────────────

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -4953,14 +4953,14 @@ impl AnnotateProvider {
                             };
                             let source_block = if include_source_field {
                                 format!(
-                                    "||||{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                    "|||||{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
                                 )
                             } else if include_refseq_fields {
                                 format!(
-                                    "||||{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                    "|||||{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
                                 )
                             } else {
-                                format!("||||{source_val}")
+                                format!("|||||{source_val}")
                             };
                             let _ = write!(
                                 csq_buf,

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -1215,16 +1215,41 @@ impl PickCriterion {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PickMode {
+    None,
+    Pick,
+    PickAllele,
+    PerGene,
+    PickAlleleGene,
+    FlagPick,
+    FlagPickAllele,
+    FlagPickAlleleGene,
+}
+
+impl PickMode {
+    fn is_enabled(self) -> bool {
+        self != Self::None
+    }
+
+    fn is_flag(self) -> bool {
+        matches!(
+            self,
+            Self::FlagPick | Self::FlagPickAllele | Self::FlagPickAlleleGene
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 struct PickFlags {
-    flag_pick_allele_gene: bool,
+    mode: PickMode,
     pick_order: Vec<PickCriterion>,
 }
 
 impl Default for PickFlags {
     fn default() -> Self {
         Self {
-            flag_pick_allele_gene: false,
+            mode: PickMode::None,
             // Traceability:
             // - Ensembl VEP release 115 default `pick_order`
             //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/Config.pm#L300-L307>
@@ -1253,8 +1278,26 @@ impl PickFlags {
                 .unwrap_or(false)
         };
 
+        let mode = if parse("pick") {
+            PickMode::Pick
+        } else if parse("pick_allele") {
+            PickMode::PickAllele
+        } else if parse("per_gene") {
+            PickMode::PerGene
+        } else if parse("pick_allele_gene") {
+            PickMode::PickAlleleGene
+        } else if parse("flag_pick") {
+            PickMode::FlagPick
+        } else if parse("flag_pick_allele") {
+            PickMode::FlagPickAllele
+        } else if parse("flag_pick_allele_gene") {
+            PickMode::FlagPickAlleleGene
+        } else {
+            PickMode::None
+        };
+
         let mut out = Self {
-            flag_pick_allele_gene: parse("flag_pick_allele_gene"),
+            mode,
             ..Self::default()
         };
 
@@ -1263,6 +1306,7 @@ impl PickFlags {
         {
             let parsed: Vec<PickCriterion> = raw_order
                 .split(',')
+                .filter(|part| !part.trim().is_empty())
                 .map(PickCriterion::from_str)
                 .collect::<Result<Vec<_>>>()?;
             if parsed.is_empty() {
@@ -1277,7 +1321,11 @@ impl PickFlags {
     }
 
     fn requires_transcript_annotations(&self, skip_csq: bool, skip_typed_cols: bool) -> bool {
-        self.flag_pick_allele_gene && (!skip_csq || !skip_typed_cols)
+        self.mode.is_enabled() && (!skip_csq || !skip_typed_cols)
+    }
+
+    fn include_pick_output(&self) -> bool {
+        self.mode.is_flag()
     }
 }
 
@@ -2397,44 +2445,159 @@ fn pick_worst_assignment(
     candidates.first().map(|candidate| candidate.assignment_idx)
 }
 
-fn mark_flag_pick_allele_gene(
-    assignments: &mut [TranscriptConsequence],
+fn pick_assignment_allele_key<'a>(_tc: &'a TranscriptConsequence, row_allele: &'a str) -> &'a str {
+    row_allele
+}
+
+fn sort_pick_candidates_by_feature_id(
+    candidate_indices: &mut [usize],
+    assignments: &[TranscriptConsequence],
+    ctx: &PreparedContext<'_>,
+) {
+    candidate_indices.sort_by(|&a, &b| {
+        pick_assignment_feature_id(a, assignments, ctx).cmp(pick_assignment_feature_id(
+            b,
+            assignments,
+            ctx,
+        ))
+    });
+}
+
+fn insert_pick_winner(
+    selected: &mut HashSet<usize>,
+    candidate_indices: &mut [usize],
+    assignments: &[TranscriptConsequence],
     ctx: &PreparedContext<'_>,
     pick_flags: &PickFlags,
 ) {
-    if !pick_flags.flag_pick_allele_gene {
+    let Some(winner) =
+        pick_worst_assignment(candidate_indices, assignments, ctx, &pick_flags.pick_order)
+    else {
         return;
-    }
+    };
+    selected.insert(winner);
+}
 
-    let mut grouped: HashMap<String, Vec<usize>> = HashMap::new();
-    for idx in 0..assignments.len() {
-        if assignments[idx].feature_type != FeatureType::Transcript {
-            // VEP's per-gene picker returns non-transcript overlap alleles
-            // unchanged, and the flagging path marks every returned item.
-            assignments[idx].picked = true;
-            continue;
+fn select_pick_indices(
+    assignments: &[TranscriptConsequence],
+    ctx: &PreparedContext<'_>,
+    pick_flags: &PickFlags,
+    row_allele: &str,
+) -> HashSet<usize> {
+    let mut selected = HashSet::new();
+
+    match pick_flags.mode {
+        PickMode::None => {}
+        PickMode::Pick | PickMode::FlagPick => {
+            let mut candidates: Vec<usize> = (0..assignments.len()).collect();
+            insert_pick_winner(&mut selected, &mut candidates, assignments, ctx, pick_flags);
         }
-        let Some(gene_key) = pick_assignment_gene_key(&assignments[idx], ctx) else {
-            continue;
-        };
-        grouped.entry(gene_key).or_default().push(idx);
+        PickMode::PickAllele | PickMode::FlagPickAllele => {
+            let mut grouped: HashMap<String, Vec<usize>> = HashMap::new();
+            for (idx, assignment) in assignments.iter().enumerate() {
+                let allele = pick_assignment_allele_key(assignment, row_allele).to_string();
+                grouped.entry(allele).or_default().push(idx);
+            }
+            for candidate_indices in grouped.values_mut() {
+                insert_pick_winner(
+                    &mut selected,
+                    candidate_indices,
+                    assignments,
+                    ctx,
+                    pick_flags,
+                );
+            }
+        }
+        PickMode::PerGene => {
+            let mut grouped: HashMap<String, Vec<usize>> = HashMap::new();
+            for (idx, assignment) in assignments.iter().enumerate() {
+                if assignment.feature_type != FeatureType::Transcript {
+                    continue;
+                }
+                let Some(gene_key) = pick_assignment_gene_key(assignment, ctx) else {
+                    continue;
+                };
+                grouped.entry(gene_key).or_default().push(idx);
+            }
+            for candidate_indices in grouped.values_mut() {
+                sort_pick_candidates_by_feature_id(candidate_indices, assignments, ctx);
+                insert_pick_winner(
+                    &mut selected,
+                    candidate_indices,
+                    assignments,
+                    ctx,
+                    pick_flags,
+                );
+            }
+        }
+        PickMode::PickAlleleGene | PickMode::FlagPickAlleleGene => {
+            let mut grouped: HashMap<(String, String), Vec<usize>> = HashMap::new();
+            for (idx, assignment) in assignments.iter().enumerate() {
+                if assignment.feature_type != FeatureType::Transcript {
+                    continue;
+                }
+                let Some(gene_key) = pick_assignment_gene_key(assignment, ctx) else {
+                    continue;
+                };
+                let allele = pick_assignment_allele_key(assignment, row_allele).to_string();
+                grouped.entry((allele, gene_key)).or_default().push(idx);
+            }
+            for candidate_indices in grouped.values_mut() {
+                sort_pick_candidates_by_feature_id(candidate_indices, assignments, ctx);
+                insert_pick_winner(
+                    &mut selected,
+                    candidate_indices,
+                    assignments,
+                    ctx,
+                    pick_flags,
+                );
+            }
+        }
     }
 
-    for candidate_indices in grouped.values_mut() {
-        candidate_indices.sort_by(|&a, &b| {
-            pick_assignment_feature_id(a, assignments, ctx).cmp(pick_assignment_feature_id(
-                b,
-                assignments,
-                ctx,
-            ))
-        });
-        let Some(winner) =
-            pick_worst_assignment(candidate_indices, assignments, ctx, &pick_flags.pick_order)
-        else {
-            continue;
-        };
-        assignments[winner].picked = true;
+    selected
+}
+
+fn apply_pick_mode(
+    mut assignments: Vec<TranscriptConsequence>,
+    ctx: &PreparedContext<'_>,
+    pick_flags: &PickFlags,
+    row_allele: &str,
+) -> Vec<TranscriptConsequence> {
+    if !pick_flags.mode.is_enabled() {
+        return assignments;
     }
+
+    let selected = select_pick_indices(&assignments, ctx, pick_flags, row_allele);
+    if pick_flags.mode.is_flag() {
+        for (idx, assignment) in assignments.iter_mut().enumerate() {
+            if selected.contains(&idx)
+                || (pick_flags.mode == PickMode::FlagPickAlleleGene
+                    && assignment.feature_type != FeatureType::Transcript)
+            {
+                assignment.picked = true;
+            }
+        }
+        return assignments;
+    }
+
+    let retain_non_transcript = matches!(
+        pick_flags.mode,
+        PickMode::PerGene | PickMode::PickAlleleGene
+    );
+    assignments
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, assignment)| {
+            if selected.contains(&idx)
+                || (retain_non_transcript && assignment.feature_type != FeatureType::Transcript)
+            {
+                Some(assignment)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Compute miRNA CSQ field from ncRNA secondary structure and variant cDNA position.
@@ -2734,7 +2897,7 @@ impl AnnotateProvider {
         let transcript_selection =
             TranscriptSelectionFlags::from_options_json(options_json.as_deref())?;
         let pick_flags = PickFlags::from_options_json(options_json.as_deref())?;
-        let include_pick_output = pick_flags.flag_pick_allele_gene;
+        let include_pick_output = pick_flags.include_pick_output();
         let annotation_column_defs =
             annotation_column_defs_for_selection(transcript_selection, include_pick_output);
         // Output schema starts with all VCF columns and appends annotation fields.
@@ -4640,7 +4803,11 @@ impl AnnotateProvider {
                 }
                 let assignments = engine.evaluate_variant_prepared(&variant, ctx);
 
-                // Derive most_severe from all assignments.
+                // Derive the local scalar `most_severe_consequence` from all
+                // computed assignments, even when pick filtering later reduces
+                // emitted CSQ/typed entries. Ensembl VEP VCF output has no
+                // equivalent scalar field, so this preserves the existing
+                // annotate_vep API contract.
                 let mut all_terms =
                     TranscriptConsequenceEngine::collapse_variant_terms(&assignments);
                 if all_terms.is_empty() {
@@ -4648,9 +4815,8 @@ impl AnnotateProvider {
                 }
                 let most = most_severe_term(all_terms.iter()).unwrap_or(SoTerm::SequenceVariant);
                 most_str = most.as_str().to_string();
-                row_assignments = assignments;
+                row_assignments = apply_pick_mode(assignments, ctx, pick_flags, &vep_allele);
                 row_variant = Some(variant);
-                mark_flag_pick_allele_gene(&mut row_assignments, ctx, pick_flags);
 
                 // Build VEP-compatible sorted permutation index.
                 // Used by both CSQ serialization and typed annotation columns
@@ -9036,7 +9202,7 @@ mod tests {
         ))
         .expect("pick flags should parse");
 
-        assert!(flags.flag_pick_allele_gene);
+        assert_eq!(flags.mode, PickMode::FlagPickAlleleGene);
         assert_eq!(
             flags.pick_order,
             vec![
@@ -9061,6 +9227,42 @@ mod tests {
         .to_string();
 
         assert!(err.contains("unsupported pick_order criterion 'bogus'"));
+    }
+
+    #[test]
+    fn test_pick_flags_default_mode_is_none() {
+        let flags = PickFlags::from_options_json(Some("{}")).expect("pick flags should parse");
+        assert_eq!(flags.mode, PickMode::None);
+        assert!(!flags.include_pick_output());
+    }
+
+    #[test]
+    fn test_pick_flags_use_vep_precedence() {
+        let flags = PickFlags::from_options_json(Some(
+            "{\"flag_pick_allele_gene\":true,\"flag_pick\":true,\"pick_allele\":true,\"pick\":true}",
+        ))
+        .expect("pick flags should parse");
+
+        assert_eq!(flags.mode, PickMode::Pick);
+        assert!(!flags.include_pick_output());
+
+        let flags = PickFlags::from_options_json(Some(
+            "{\"flag_pick_allele_gene\":true,\"flag_pick\":true}",
+        ))
+        .expect("pick flags should parse");
+        assert_eq!(flags.mode, PickMode::FlagPick);
+        assert!(flags.include_pick_output());
+    }
+
+    #[test]
+    fn test_pick_flags_reject_empty_pick_order() {
+        let err = PickFlags::from_options_json(Some(
+            "{\"flag_pick_allele_gene\":true,\"pick_order\":\" , \"}",
+        ))
+        .expect_err("empty pick_order should fail")
+        .to_string();
+
+        assert!(err.contains("pick_order must contain at least one criterion"));
     }
 
     #[test]
@@ -9091,7 +9293,7 @@ mod tests {
     #[test]
     fn test_mark_flag_pick_allele_gene_marks_non_transcript_assignments() {
         let ctx = PreparedContext::new(&[], &[], &[], &[], &[], &[], &[]);
-        let mut assignments = vec![
+        let assignments = vec![
             TranscriptConsequence {
                 feature_type: FeatureType::RegulatoryFeature,
                 terms: vec![SoTerm::RegulatoryRegionVariant],
@@ -9109,16 +9311,154 @@ mod tests {
             },
         ];
 
-        mark_flag_pick_allele_gene(
-            &mut assignments,
+        let assignments = apply_pick_mode(
+            assignments,
             &ctx,
             &PickFlags {
-                flag_pick_allele_gene: true,
+                mode: PickMode::FlagPickAlleleGene,
                 pick_order: vec![PickCriterion::Rank],
             },
+            "A",
         );
 
         assert!(assignments.iter().all(|assignment| assignment.picked));
+    }
+
+    #[test]
+    fn test_apply_pick_mode_filters_variant_and_allele_modes() {
+        let mut tx_a = make_tx("ENST00000051", None, Some("GENE1"), Some("HGNC"), None);
+        tx_a.biotype = "protein_coding".to_string();
+        tx_a.is_canonical = false;
+
+        let mut tx_b = make_tx("ENST00000052", None, Some("GENE1"), Some("HGNC"), None);
+        tx_b.biotype = "protein_coding".to_string();
+        tx_b.is_canonical = true;
+
+        let transcripts = vec![tx_a, tx_b];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+        ];
+
+        for mode in [PickMode::Pick, PickMode::PickAllele] {
+            let picked = apply_pick_mode(
+                assignments.clone(),
+                &ctx,
+                &PickFlags {
+                    mode,
+                    pick_order: vec![PickCriterion::Canonical],
+                },
+                "A",
+            );
+            assert_eq!(picked.len(), 1);
+            assert_eq!(picked[0].transcript_idx, Some(1));
+            assert!(!picked[0].picked);
+        }
+    }
+
+    #[test]
+    fn test_apply_pick_mode_filters_per_gene_modes_and_retains_non_transcripts() {
+        let mut tx_a = make_tx("ENST00000061", Some("GENE1"), Some("HGNC"), None, None);
+        tx_a.biotype = "protein_coding".to_string();
+        tx_a.is_canonical = false;
+
+        let mut tx_b = make_tx("ENST00000062", Some("GENE1"), Some("HGNC"), None, None);
+        tx_b.biotype = "protein_coding".to_string();
+        tx_b.is_canonical = true;
+
+        let mut tx_c = make_tx("ENST00000063", Some("GENE2"), Some("HGNC"), None, None);
+        tx_c.biotype = "protein_coding".to_string();
+
+        let transcripts = vec![tx_a, tx_b, tx_c];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(2),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                feature_type: FeatureType::RegulatoryFeature,
+                terms: vec![SoTerm::RegulatoryRegionVariant],
+                ..Default::default()
+            },
+        ];
+
+        for mode in [PickMode::PerGene, PickMode::PickAlleleGene] {
+            let picked = apply_pick_mode(
+                assignments.clone(),
+                &ctx,
+                &PickFlags {
+                    mode,
+                    pick_order: vec![PickCriterion::Canonical],
+                },
+                "A",
+            );
+            assert_eq!(picked.len(), 3);
+            assert_eq!(picked[0].transcript_idx, Some(1));
+            assert_eq!(picked[1].transcript_idx, Some(2));
+            assert_eq!(picked[2].feature_type, FeatureType::RegulatoryFeature);
+        }
+    }
+
+    #[test]
+    fn test_apply_pick_mode_marks_flag_modes_without_filtering() {
+        let mut tx_a = make_tx("ENST00000071", Some("GENE1"), Some("HGNC"), None, None);
+        tx_a.biotype = "protein_coding".to_string();
+        tx_a.is_canonical = false;
+
+        let mut tx_b = make_tx("ENST00000072", Some("GENE1"), Some("HGNC"), None, None);
+        tx_b.biotype = "protein_coding".to_string();
+        tx_b.is_canonical = true;
+
+        let transcripts = vec![tx_a, tx_b];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                ..Default::default()
+            },
+        ];
+
+        for mode in [PickMode::FlagPick, PickMode::FlagPickAllele] {
+            let picked = apply_pick_mode(
+                assignments.clone(),
+                &ctx,
+                &PickFlags {
+                    mode,
+                    pick_order: vec![PickCriterion::Canonical],
+                },
+                "A",
+            );
+            assert_eq!(picked.len(), 2);
+            assert!(!picked[0].picked);
+            assert!(picked[1].picked);
+        }
     }
 
     #[test]
@@ -9133,7 +9473,7 @@ mod tests {
 
         let transcripts = vec![tx_b, tx_a];
         let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
-        let mut assignments = vec![
+        let assignments = vec![
             TranscriptConsequence {
                 transcript_idx: Some(1),
                 feature_type: FeatureType::Transcript,
@@ -9148,13 +9488,14 @@ mod tests {
             },
         ];
 
-        mark_flag_pick_allele_gene(
-            &mut assignments,
+        let assignments = apply_pick_mode(
+            assignments,
             &ctx,
             &PickFlags {
-                flag_pick_allele_gene: true,
+                mode: PickMode::FlagPickAlleleGene,
                 pick_order: vec![PickCriterion::Rank],
             },
+            "A",
         );
 
         assert!(!assignments[0].picked);
@@ -9177,7 +9518,7 @@ mod tests {
 
         let transcripts = vec![tx_havana, tx_ensembl];
         let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
-        let mut assignments = vec![
+        let assignments = vec![
             TranscriptConsequence {
                 transcript_idx: Some(0),
                 feature_type: FeatureType::Transcript,
@@ -9190,13 +9531,14 @@ mod tests {
             },
         ];
 
-        mark_flag_pick_allele_gene(
-            &mut assignments,
+        let assignments = apply_pick_mode(
+            assignments,
             &ctx,
             &PickFlags {
-                flag_pick_allele_gene: true,
+                mode: PickMode::FlagPickAlleleGene,
                 pick_order: vec![PickCriterion::Ensembl],
             },
+            "A",
         );
 
         assert!(!assignments[0].picked);
@@ -9241,7 +9583,7 @@ mod tests {
             },
         ];
         let ctx = PreparedContext::new(&transcripts, &[], &translations, &[], &[], &[], &[]);
-        let mut assignments = vec![
+        let assignments = vec![
             TranscriptConsequence {
                 transcript_idx: Some(0),
                 feature_type: FeatureType::Transcript,
@@ -9254,13 +9596,14 @@ mod tests {
             },
         ];
 
-        mark_flag_pick_allele_gene(
-            &mut assignments,
+        let assignments = apply_pick_mode(
+            assignments,
             &ctx,
             &PickFlags {
-                flag_pick_allele_gene: true,
+                mode: PickMode::FlagPickAlleleGene,
                 pick_order: vec![PickCriterion::Length],
             },
+            "A",
         );
 
         assert!(!assignments[0].picked);
@@ -9300,7 +9643,7 @@ mod tests {
             },
         ];
         let ctx = PreparedContext::new(&transcripts, &exons, &[], &[], &[], &[], &[]);
-        let mut assignments = vec![
+        let assignments = vec![
             TranscriptConsequence {
                 transcript_idx: Some(0),
                 feature_type: FeatureType::Transcript,
@@ -9313,13 +9656,14 @@ mod tests {
             },
         ];
 
-        mark_flag_pick_allele_gene(
-            &mut assignments,
+        let assignments = apply_pick_mode(
+            assignments,
             &ctx,
             &PickFlags {
-                flag_pick_allele_gene: true,
+                mode: PickMode::FlagPickAlleleGene,
                 pick_order: vec![PickCriterion::Length],
             },
+            "A",
         );
 
         assert!(!assignments[0].picked);
@@ -9338,7 +9682,7 @@ mod tests {
 
         let transcripts = vec![tx_a, tx_b];
         let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
-        let mut assignments = vec![
+        let assignments = vec![
             TranscriptConsequence {
                 transcript_idx: Some(0),
                 feature_type: FeatureType::Transcript,
@@ -9351,13 +9695,14 @@ mod tests {
             },
         ];
 
-        mark_flag_pick_allele_gene(
-            &mut assignments,
+        let assignments = apply_pick_mode(
+            assignments,
             &ctx,
             &PickFlags {
-                flag_pick_allele_gene: true,
+                mode: PickMode::FlagPickAlleleGene,
                 pick_order: vec![PickCriterion::Canonical],
             },
+            "A",
         );
 
         assert!(!assignments[0].picked);

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -140,13 +140,15 @@ fn list_i64_data_type() -> DataType {
     DataType::List(Arc::new(Field::new("item", DataType::Int64, true)))
 }
 
-/// Full default annotation output column definitions (87 columns, excluding csq and most_severe_consequence).
+/// Full annotation output column definitions (87 columns without `PICK`, 88 with `PICK`,
+/// excluding `CSQ` and `most_severe_consequence`).
 ///
-/// Order matches the README schema: transcript-level (42), frequency (29), variant-level (9), cache-only (7).
-fn annotation_column_defs() -> Vec<AnnotationColumnDef> {
+/// Order matches the VEP/README schema: transcript-level (42 or 43 with `PICK`),
+/// frequency (29), variant-level (9), cache-only (7).
+fn annotation_column_defs(include_pick_output: bool) -> Vec<AnnotationColumnDef> {
     use AnnotationCategory::*;
-    vec![
-        // ── Transcript-level (42) ──
+    let mut defs = vec![
+        // ── Transcript-level (42, or 43 with PICK) ──
         AnnotationColumnDef {
             name: "Allele",
             data_type: DataType::Utf8,
@@ -273,6 +275,16 @@ fn annotation_column_defs() -> Vec<AnnotationColumnDef> {
             category: Transcript,
             cache_col: None,
         },
+    ];
+    if include_pick_output {
+        defs.push(AnnotationColumnDef {
+            name: "PICK",
+            data_type: list_utf8_data_type(),
+            category: Transcript,
+            cache_col: None,
+        });
+    }
+    defs.extend([
         AnnotationColumnDef {
             name: "VARIANT_CLASS",
             data_type: DataType::Utf8,
@@ -672,13 +684,17 @@ fn annotation_column_defs() -> Vec<AnnotationColumnDef> {
             category: CacheOnly,
             cache_col: Some("dbsnp_ids"),
         },
-    ]
+    ]);
+    defs
 }
 
-fn refseq_annotation_column_defs(include_source: bool) -> Vec<AnnotationColumnDef> {
+fn refseq_annotation_column_defs(
+    include_source: bool,
+    include_pick_output: bool,
+) -> Vec<AnnotationColumnDef> {
     use AnnotationCategory::Transcript;
 
-    let mut defs = annotation_column_defs();
+    let mut defs = annotation_column_defs(include_pick_output);
     let insert_at = defs
         .iter()
         .position(|def| def.name == "GENE_PHENO")
@@ -729,11 +745,12 @@ fn refseq_annotation_column_defs(include_source: bool) -> Vec<AnnotationColumnDe
 
 fn annotation_column_defs_for_selection(
     transcript_selection: TranscriptSelectionFlags,
+    include_pick_output: bool,
 ) -> Vec<AnnotationColumnDef> {
     if transcript_selection.refseq_fields() {
-        refseq_annotation_column_defs(transcript_selection.source_field())
+        refseq_annotation_column_defs(transcript_selection.source_field(), include_pick_output)
     } else {
-        annotation_column_defs()
+        annotation_column_defs(include_pick_output)
     }
 }
 
@@ -1505,11 +1522,16 @@ struct CsqPlaceholderLayout {
 }
 
 impl CsqPlaceholderLayout {
-    fn for_mode(everything: bool, transcript_selection: TranscriptSelectionFlags) -> Self {
+    fn for_mode(
+        everything: bool,
+        transcript_selection: TranscriptSelectionFlags,
+        include_pick: bool,
+    ) -> Self {
         let fields = crate::golden_benchmark::csq_field_names_for_mode(
             everything,
             transcript_selection.source_mode == TranscriptSourceMode::RefSeq,
             transcript_selection.source_mode == TranscriptSourceMode::Merged,
+            include_pick,
         )
         .into_iter()
         .map(CsqPlaceholderField::from_name)
@@ -2219,10 +2241,6 @@ fn pick_assignment_gene_key(
     //   `transcript->{_gene_stable_id}`, only falling back to a gene-adaptor
     //   lookup when that cache slot is absent
     //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L845-L855>
-    //
-    // We intentionally require the cache-provided `gene_stable_id` here and do
-    // not substitute `gene_symbol` or `transcript_id`, because those are local
-    // heuristics rather than VEP pick-group semantics.
     let tx = ctx.transcripts.get(tc.transcript_idx?)?;
     tx.gene_stable_id.clone()
 }
@@ -2347,19 +2365,6 @@ fn pick_worst_assignment(
     candidates.first().map(|candidate| candidate.assignment_idx)
 }
 
-fn append_pick_flag(flags: &mut Option<String>) {
-    if flags
-        .as_deref()
-        .is_some_and(|value| value.split('&').any(|part| part == "PICK"))
-    {
-        return;
-    }
-    match flags {
-        Some(existing) if !existing.is_empty() => existing.push_str("&PICK"),
-        _ => *flags = Some("PICK".to_string()),
-    }
-}
-
 fn mark_flag_pick_allele_gene(
     assignments: &mut [TranscriptConsequence],
     ctx: &PreparedContext<'_>,
@@ -2383,7 +2388,7 @@ fn mark_flag_pick_allele_gene(
         else {
             continue;
         };
-        append_pick_flag(&mut assignments[winner].flags);
+        assignments[winner].picked = true;
     }
 }
 
@@ -2666,6 +2671,7 @@ pub struct AnnotateProvider {
     backend: AnnotationBackend,
     options_json: Option<String>,
     transcript_selection: TranscriptSelectionFlags,
+    include_pick_output: bool,
     annotation_column_defs: Vec<AnnotationColumnDef>,
     schema: SchemaRef,
 }
@@ -2681,8 +2687,12 @@ impl AnnotateProvider {
     ) -> Result<Self> {
         let transcript_selection =
             TranscriptSelectionFlags::from_options_json(options_json.as_deref())?;
-        let annotation_column_defs = annotation_column_defs_for_selection(transcript_selection);
-
+        let include_pick_output = options_json
+            .as_deref()
+            .and_then(|opts| Self::parse_json_bool_option(opts, "flag_pick_allele_gene"))
+            .unwrap_or(false);
+        let annotation_column_defs =
+            annotation_column_defs_for_selection(transcript_selection, include_pick_output);
         // Output schema starts with all VCF columns and appends annotation fields.
         let mut fields: Vec<Arc<Field>> = vcf_schema
             .fields()
@@ -2717,6 +2727,7 @@ impl AnnotateProvider {
             backend,
             options_json,
             transcript_selection,
+            include_pick_output,
             annotation_column_defs,
             schema: Arc::new(Schema::new(fields)),
         })
@@ -3162,8 +3173,11 @@ impl AnnotateProvider {
                     .or(raw_flags_str)
                     .or_else(|| flags_str_from_bools(cds_start_nf, cds_end_nf));
 
-                let gene_stable_id =
-                    gene_stable_id_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
+                let raw_object_json =
+                    raw_object_json_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
+                let gene_stable_id = gene_stable_id_idx
+                    .and_then(|idx| string_at(batch.column(idx).as_ref(), row))
+                    .or_else(|| gene_stable_id_from_raw_object_json(raw_object_json.as_deref()));
                 let gene_symbol =
                     gene_symbol_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
                 let gene_symbol_source = gene_symbol_source_idx
@@ -4082,7 +4096,6 @@ impl AnnotateProvider {
         );
 
         let cache_columns: Vec<String> = requested_columns.iter().map(|s| s.to_string()).collect();
-
         let projected_schema = if let Some(indices) = projection {
             Arc::new(self.schema.project(indices)?)
         } else {
@@ -4158,6 +4171,7 @@ impl AnnotateProvider {
         hgvs_reference_reader: &mut Option<FastaReader>,
     ) -> Result<RecordBatch> {
         let schema = batch.schema();
+        let include_pick_output = pick_flags.flag_pick_allele_gene;
         let chrom_idx = schema.index_of("chrom").map_err(|_| {
             DataFusionError::Execution(
                 "annotate_vep(): input VCF row is missing required chrom column".to_string(),
@@ -4195,8 +4209,8 @@ impl AnnotateProvider {
         let mut most_builder =
             StringBuilder::with_capacity(batch.num_rows(), batch.num_rows() * 16);
 
-        // --- Annotation column builders (87 columns) ---
-        // Transcript-level (42)
+        // --- Annotation column builders (87 columns, or 88 with PICK) ---
+        // Transcript-level (42, or 43 with PICK)
         let mut b_allele = StringBuilder::with_capacity(batch.num_rows(), batch.num_rows() * 4);
         let mut b_consequence = ListBuilder::new(StringBuilder::new());
         let mut b_impact = ListBuilder::new(StringBuilder::new());
@@ -4218,6 +4232,7 @@ impl AnnotateProvider {
         let mut b_distance = ListBuilder::new(Int64Builder::new());
         let mut b_strand = ListBuilder::new(Int8Builder::new());
         let mut b_flags = ListBuilder::new(StringBuilder::new());
+        let mut b_pick = ListBuilder::new(StringBuilder::new());
         let mut b_variant_class =
             StringBuilder::with_capacity(batch.num_rows(), batch.num_rows() * 8);
         let mut b_symbol_source = ListBuilder::new(StringBuilder::new());
@@ -4301,6 +4316,7 @@ impl AnnotateProvider {
                 b_distance.append(false);
                 b_strand.append(false);
                 b_flags.append(false);
+                b_pick.append(false);
                 b_variant_class.append_null();
                 b_symbol_source.append(false);
                 b_hgnc_id.append(false);
@@ -4366,8 +4382,11 @@ impl AnnotateProvider {
         // Reusable permutation index for VEP-compatible CSQ ordering.
         // Allocated once, reused across all rows in the batch.
         let mut sorted_indices: Vec<usize> = Vec::new();
-        let placeholder_layout =
-            CsqPlaceholderLayout::for_mode(flags.everything, transcript_selection);
+        let placeholder_layout = CsqPlaceholderLayout::for_mode(
+            flags.everything,
+            transcript_selection,
+            include_pick_output,
+        );
 
         for row in 0..batch.num_rows() {
             let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
@@ -4664,6 +4683,7 @@ impl AnnotateProvider {
                         }
                         let distance = tc.distance.map(|d| d.to_string()).unwrap_or_default();
                         let tc_flags = tc.flags.as_deref().unwrap_or("");
+                        let pick_str = if tc.picked { "1" } else { "" };
                         let hgvsc = if hgvs_flags.hgvsc {
                             tc.hgvsc.as_deref().unwrap_or("")
                         } else {
@@ -4847,92 +4867,68 @@ impl AnnotateProvider {
                                     String::new()
                                 }
                             };
-                            // 80-field CSQ: 22 base + 20 Batch 1 + 33 Batch 3 + 5 motif.
+                            // 80-field CSQ base layout, with optional PICK and RefSeq fields.
                             // Traceability:
                             // - VEP Constants.pm CSQ field order for --everything
                             //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/Constants.pm#L66-L138
-                            if include_source_field {
-                                let _ = write!(
-                                    csq_buf,
-                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
-                                 {exon}|{intron}|{hgvsc}|{hgvsp}|\
-                                 {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
-                                 {existing_var}|{distance}|{strand_str}|{tc_flags}|\
-                                 {variant_class}|{symbol_source}|{hgnc_id}|\
-                                 {canonical}|{mane}|{mane_select}|{mane_plus}|{tsl_str}|{appris_str}|{ccds}|{ensp}|\
-                                 {swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}|{gene_pheno}|\
-                                 {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
-                                 {hgvs_offset}|\
-                                 {batch3_suffix}|||||"
-                                );
-                            } else if include_refseq_fields {
-                                let _ = write!(
-                                    csq_buf,
-                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
-                                 {exon}|{intron}|{hgvsc}|{hgvsp}|\
-                                 {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
-                                 {existing_var}|{distance}|{strand_str}|{tc_flags}|\
-                                 {variant_class}|{symbol_source}|{hgnc_id}|\
-                                 {canonical}|{mane}|{mane_select}|{mane_plus}|{tsl_str}|{appris_str}|{ccds}|{ensp}|\
-                                 {swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}|{gene_pheno}|\
-                                 {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
-                                 {hgvs_offset}|\
-                                 {batch3_suffix}|||||"
-                                );
+                            let pick_field = if include_pick_output {
+                                format!("|{pick_str}")
                             } else {
-                                let _ = write!(
-                                    csq_buf,
-                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
-                                 {exon}|{intron}|{hgvsc}|{hgvsp}|\
-                                 {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
-                                 {existing_var}|{distance}|{strand_str}|{tc_flags}|\
-                                 {variant_class}|{symbol_source}|{hgnc_id}|\
-                                 {canonical}|{mane}|{mane_select}|{mane_plus}|{tsl_str}|{appris_str}|{ccds}|{ensp}|\
-                                 {swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|{gene_pheno}|\
-                                 {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
-                                 {hgvs_offset}|\
-                                 {batch3_suffix}|||||"
-                                );
-                            }
+                                String::new()
+                            };
+                            let refseq_block = if include_source_field {
+                                format!(
+                                    "|{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                )
+                            } else if include_refseq_fields {
+                                format!(
+                                    "|{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                )
+                            } else {
+                                String::new()
+                            };
+                            let _ = write!(
+                                csq_buf,
+                                "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
+                             {exon}|{intron}|{hgvsc}|{hgvsp}|\
+                             {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
+                             {existing_var}|{distance}|{strand_str}|{tc_flags}{pick_field}|\
+                             {variant_class}|{symbol_source}|{hgnc_id}|\
+                             {canonical}|{mane}|{mane_select}|{mane_plus}|{tsl_str}|{appris_str}|{ccds}|{ensp}|\
+                             {swissprot}|{trembl}|{uniparc}|{uniprot_isoform}{refseq_block}|{gene_pheno}|\
+                             {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
+                             {hgvs_offset}|\
+                             {batch3_suffix}|||||"
+                            );
                         } else {
-                            // 74-field CSQ: 29 base + 12 Batch 1 + 33 Batch 3.
-                            if include_source_field {
-                                let _ = write!(
-                                    csq_buf,
-                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
-                                 {exon}|{intron}|{hgvsc}|{hgvsp}|\
-                                 {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
-                                 {existing_var}|{distance}|{strand_str}|{tc_flags}|{symbol_source}|{hgnc_id}|\
-                                 |||||{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}|\
-                                 {variant_class}|{canonical}|{tsl_str}|{mane_select}|{mane_plus}|\
-                                 {ensp}|{gene_pheno}|{ccds}|{swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|\
-                                 {batch3_suffix}"
-                                );
-                            } else if include_refseq_fields {
-                                let _ = write!(
-                                    csq_buf,
-                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
-                                 {exon}|{intron}|{hgvsc}|{hgvsp}|\
-                                 {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
-                                 {existing_var}|{distance}|{strand_str}|{tc_flags}|{symbol_source}|{hgnc_id}|\
-                                 |||||{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}|\
-                                 {variant_class}|{canonical}|{tsl_str}|{mane_select}|{mane_plus}|\
-                                 {ensp}|{gene_pheno}|{ccds}|{swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|\
-                                 {batch3_suffix}"
-                                );
+                            // 74-field CSQ base layout, with optional PICK and RefSeq fields.
+                            let pick_field = if include_pick_output {
+                                format!("|{pick_str}")
                             } else {
-                                let _ = write!(
-                                    csq_buf,
-                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
-                                 {exon}|{intron}|{hgvsc}|{hgvsp}|\
-                                 {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
-                                 {existing_var}|{distance}|{strand_str}|{tc_flags}|{symbol_source}|{hgnc_id}|\
-                                 |||||{source_val}|\
-                                 {variant_class}|{canonical}|{tsl_str}|{mane_select}|{mane_plus}|\
-                                 {ensp}|{gene_pheno}|{ccds}|{swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|\
-                                 {batch3_suffix}"
-                                );
-                            }
+                                String::new()
+                            };
+                            let source_block = if include_source_field {
+                                format!(
+                                    "||||{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                )
+                            } else if include_refseq_fields {
+                                format!(
+                                    "||||{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                )
+                            } else {
+                                format!("||||{source_val}")
+                            };
+                            let _ = write!(
+                                csq_buf,
+                                "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
+                             {exon}|{intron}|{hgvsc}|{hgvsp}|\
+                             {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
+                             {existing_var}|{distance}|{strand_str}|{tc_flags}{pick_field}|{symbol_source}|{hgnc_id}|\
+                             {source_block}|\
+                             {variant_class}|{canonical}|{tsl_str}|{mane_select}|{mane_plus}|\
+                             {ensp}|{gene_pheno}|{ccds}|{swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|\
+                             {batch3_suffix}"
+                            );
                         }
                     }
                     if csq_buf.is_empty() {
@@ -4958,12 +4954,12 @@ impl AnnotateProvider {
             }
             most_builder.append_value(&most_str);
 
-            // --- Populate 87 annotation column builders for this row ---
+            // --- Populate structured annotation column builders for this row ---
             // Skip all typed column work when they're not in the projection.
             if skip_typed_cols {
                 append_null_annotation_row!();
             } else {
-                // -- Transcript-level columns (42) --
+                // -- Transcript-level columns (42, or 43 with PICK) --
                 // Allele (scalar, same for all transcripts)
                 b_allele.append_value(&vep_allele);
                 // VARIANT_CLASS (scalar)
@@ -5117,6 +5113,13 @@ impl AnnotateProvider {
 
                         // FLAGS
                         append_opt_str(b_flags.values(), tc.flags.as_deref());
+                        if include_pick_output {
+                            if tc.picked {
+                                b_pick.values().append_value("1");
+                            } else {
+                                b_pick.values().append_null();
+                            }
+                        }
 
                         // SYMBOL_SOURCE, HGNC_ID
                         append_opt_str(
@@ -5359,6 +5362,7 @@ impl AnnotateProvider {
                     b_distance.append(true);
                     b_strand.append(true);
                     b_flags.append(true);
+                    b_pick.append(include_pick_output);
                     b_symbol_source.append(true);
                     b_hgnc_id.append(true);
                     b_canonical.append(true);
@@ -5410,6 +5414,7 @@ impl AnnotateProvider {
                     b_distance.append(false);
                     b_strand.append(false);
                     b_flags.append(false);
+                    b_pick.append(false);
                     b_symbol_source.append(false);
                     b_hgnc_id.append(false);
                     b_canonical.append(false);
@@ -5642,7 +5647,7 @@ impl AnnotateProvider {
                 out_cols.push(new_null_array(&col_def.data_type, batch.num_rows()));
             }
         } else {
-            // Transcript-level columns (42)
+            // Transcript-level columns (42, or 43 with PICK)
             out_cols.push(Arc::new(b_allele.finish()));
             out_cols.push(Arc::new(b_consequence.finish()));
             out_cols.push(Arc::new(b_impact.finish()));
@@ -5664,6 +5669,9 @@ impl AnnotateProvider {
             out_cols.push(Arc::new(b_distance.finish()));
             out_cols.push(Arc::new(b_strand.finish()));
             out_cols.push(Arc::new(b_flags.finish()));
+            if self.include_pick_output {
+                out_cols.push(Arc::new(b_pick.finish()));
+            }
             out_cols.push(Arc::new(b_variant_class.finish()));
             out_cols.push(Arc::new(b_symbol_source.finish()));
             out_cols.push(Arc::new(b_hgnc_id.finish()));
@@ -5788,6 +5796,28 @@ fn flags_str_from_bools(cds_start_nf: bool, cds_end_nf: bool) -> Option<String> 
         (false, true) => Some("cds_end_NF".to_string()),
         (false, false) => None,
     }
+}
+
+fn gene_stable_id_from_raw_object_json(raw_object_json: Option<&str>) -> Option<String> {
+    let raw_object_json = raw_object_json?;
+    let parsed: Value = serde_json::from_str(raw_object_json).ok()?;
+    let transcript = parsed.get("__value")?;
+
+    // Traceability:
+    // - Ensembl VEP release 115 groups by `transcript->{_gene_stable_id}` and
+    //   otherwise fetches the gene stable ID from the transcript's gene object
+    //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L849-L851>
+    transcript
+        .get("_gene_stable_id")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            transcript
+                .get("_gene")
+                .and_then(|gene| gene.get("stable_id"))
+                .and_then(Value::as_str)
+        })
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 fn normalize_source_label(source: &str) -> Option<String> {
@@ -8984,15 +9014,20 @@ mod tests {
     }
 
     #[test]
-    fn test_append_pick_flag_preserves_existing_flags_and_avoids_duplicates() {
-        let mut flags = Some("cds_end_NF".to_string());
-        append_pick_flag(&mut flags);
-        append_pick_flag(&mut flags);
-        assert_eq!(flags, Some("cds_end_NF&PICK".to_string()));
+    fn test_gene_stable_id_from_raw_object_json_prefers_transcript_slot_then_gene_slot() {
+        let from_transcript = r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene_stable_id":"ENSG00000001","_gene":{"stable_id":"ENSGSHOULDNOTWIN"}}}"#;
+        assert_eq!(
+            gene_stable_id_from_raw_object_json(Some(from_transcript)).as_deref(),
+            Some("ENSG00000001")
+        );
 
-        let mut empty = None;
-        append_pick_flag(&mut empty);
-        assert_eq!(empty, Some("PICK".to_string()));
+        let from_gene = r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene":{"stable_id":"ENSG00000002"}}}"#;
+        assert_eq!(
+            gene_stable_id_from_raw_object_json(Some(from_gene)).as_deref(),
+            Some("ENSG00000002")
+        );
+
+        assert_eq!(gene_stable_id_from_raw_object_json(None), None);
     }
 
     #[test]
@@ -9039,8 +9074,8 @@ mod tests {
             },
         );
 
-        assert_eq!(assignments[0].flags, None);
-        assert_eq!(assignments[1].flags, Some("PICK".to_string()));
+        assert!(!assignments[0].picked);
+        assert!(assignments[1].picked);
     }
 
     #[test]
@@ -9099,12 +9134,12 @@ mod tests {
             },
         );
 
-        assert_eq!(assignments[0].flags, None);
-        assert_eq!(assignments[1].flags, Some("PICK".to_string()));
+        assert!(!assignments[0].picked);
+        assert!(assignments[1].picked);
     }
 
     #[test]
-    fn test_mark_flag_pick_allele_gene_requires_gene_stable_id() {
+    fn test_mark_flag_pick_allele_gene_skips_candidates_without_gene_stable_id() {
         let mut tx_a = make_tx("ENST00000021", Some("GENE1"), Some("HGNC"), None);
         tx_a.biotype = "protein_coding".to_string();
         tx_a.is_canonical = false;
@@ -9137,8 +9172,8 @@ mod tests {
             },
         );
 
-        assert_eq!(assignments[0].flags, None);
-        assert_eq!(assignments[1].flags, None);
+        assert!(!assignments[0].picked);
+        assert!(!assignments[1].picked);
     }
 
     // ── format_prediction ──────────────────────────────────────────────
@@ -9590,7 +9625,7 @@ mod tests {
                 86,
             ),
         ] {
-            let layout = CsqPlaceholderLayout::for_mode(everything, selection);
+            let layout = CsqPlaceholderLayout::for_mode(everything, selection, false);
             assert_eq!(layout.fields.len(), expected_len);
         }
     }
@@ -9626,11 +9661,12 @@ mod tests {
             source_mode: TranscriptSourceMode::RefSeq,
             ..Default::default()
         };
-        let refseq_layout = CsqPlaceholderLayout::for_mode(false, refseq_selection);
+        let refseq_layout = CsqPlaceholderLayout::for_mode(false, refseq_selection, false);
         let mut refseq_row = String::new();
         refseq_layout.append_entry(&mut refseq_row, &entry);
         let refseq_values: Vec<&str> = refseq_row.split('|').collect();
-        let refseq_fields = crate::golden_benchmark::csq_field_names_for_mode(false, true, false);
+        let refseq_fields =
+            crate::golden_benchmark::csq_field_names_for_mode(false, true, false, false);
         assert_eq!(refseq_values.len(), refseq_fields.len());
         let refseq_index = |name: &str| {
             refseq_fields
@@ -9650,11 +9686,12 @@ mod tests {
             source_mode: TranscriptSourceMode::Merged,
             ..Default::default()
         };
-        let merged_layout = CsqPlaceholderLayout::for_mode(true, merged_selection);
+        let merged_layout = CsqPlaceholderLayout::for_mode(true, merged_selection, false);
         let mut merged_row = String::new();
         merged_layout.append_entry(&mut merged_row, &entry);
         let merged_values: Vec<&str> = merged_row.split('|').collect();
-        let merged_fields = crate::golden_benchmark::csq_field_names_for_mode(true, false, true);
+        let merged_fields =
+            crate::golden_benchmark::csq_field_names_for_mode(true, false, true, false);
         assert_eq!(merged_values.len(), merged_fields.len());
         let merged_index = |name: &str| {
             merged_fields

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -7,6 +7,7 @@
 //! - otherwise falls back to phase-1.5 known-variant CSQ placeholders.
 
 use std::any::Any;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;
@@ -1161,6 +1162,105 @@ impl VepFlags {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PickCriterion {
+    ManeSelect,
+    ManePlusClinical,
+    Canonical,
+    Appris,
+    Tsl,
+    Biotype,
+    Ccds,
+    Rank,
+    Length,
+    Ensembl,
+    Refseq,
+}
+
+impl PickCriterion {
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw.trim() {
+            "mane_select" => Ok(Self::ManeSelect),
+            "mane_plus_clinical" => Ok(Self::ManePlusClinical),
+            "canonical" => Ok(Self::Canonical),
+            "appris" => Ok(Self::Appris),
+            "tsl" => Ok(Self::Tsl),
+            "biotype" => Ok(Self::Biotype),
+            "ccds" => Ok(Self::Ccds),
+            "rank" => Ok(Self::Rank),
+            "length" => Ok(Self::Length),
+            "ensembl" => Ok(Self::Ensembl),
+            "refseq" => Ok(Self::Refseq),
+            other => Err(DataFusionError::Execution(format!(
+                "annotate_vep(): unsupported pick_order criterion '{other}'. Supported criteria: mane_select, mane_plus_clinical, canonical, appris, tsl, biotype, ccds, rank, length, ensembl, refseq"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PickFlags {
+    flag_pick_allele_gene: bool,
+    pick_order: Vec<PickCriterion>,
+}
+
+impl Default for PickFlags {
+    fn default() -> Self {
+        Self {
+            flag_pick_allele_gene: false,
+            pick_order: vec![
+                PickCriterion::ManeSelect,
+                PickCriterion::ManePlusClinical,
+                PickCriterion::Canonical,
+                PickCriterion::Appris,
+                PickCriterion::Tsl,
+                PickCriterion::Biotype,
+                PickCriterion::Ccds,
+                PickCriterion::Rank,
+                PickCriterion::Length,
+                PickCriterion::Ensembl,
+                PickCriterion::Refseq,
+            ],
+        }
+    }
+}
+
+impl PickFlags {
+    fn from_options_json(options_json: Option<&str>) -> Result<Self> {
+        let parse = |key| {
+            options_json
+                .and_then(|opts| AnnotateProvider::parse_json_bool_option(opts, key))
+                .unwrap_or(false)
+        };
+
+        let mut out = Self {
+            flag_pick_allele_gene: parse("flag_pick_allele_gene"),
+            ..Self::default()
+        };
+
+        if let Some(raw_order) = options_json
+            .and_then(|opts| AnnotateProvider::parse_json_string_option(opts, "pick_order"))
+        {
+            let parsed: Vec<PickCriterion> = raw_order
+                .split(',')
+                .map(PickCriterion::from_str)
+                .collect::<Result<Vec<_>>>()?;
+            if parsed.is_empty() {
+                return Err(DataFusionError::Execution(
+                    "annotate_vep(): pick_order must contain at least one criterion".to_string(),
+                ));
+            }
+            out.pick_order = parsed;
+        }
+
+        Ok(out)
+    }
+
+    fn requires_transcript_annotations(&self, skip_csq: bool, skip_typed_cols: bool) -> bool {
+        self.flag_pick_allele_gene && (!skip_csq || !skip_typed_cols)
+    }
+}
+
 /// Parsed HGVS-related flags controlling HGVSc/HGVSp emission.
 ///
 /// Traceability:
@@ -1969,6 +2069,226 @@ fn csq_escape(val: &str) -> std::borrow::Cow<'_, str> {
 /// VEP abbreviates: `principal1` → `P1`, `alternative2` → `A2`.
 fn format_appris(raw: &str) -> String {
     raw.replace("principal", "P").replace("alternative", "A")
+}
+
+fn parse_appris_pick_rank(raw: Option<&str>) -> (u8, u8) {
+    let Some(raw) = raw else {
+        return (3, u8::MAX);
+    };
+    if let Some(suffix) = raw.strip_prefix("principal") {
+        return (0, suffix.parse::<u8>().unwrap_or(u8::MAX));
+    }
+    if let Some(suffix) = raw.strip_prefix("alternative") {
+        return (1, suffix.parse::<u8>().unwrap_or(u8::MAX));
+    }
+    (2, u8::MAX)
+}
+
+fn compare_pick_bool(a: bool, b: bool) -> Ordering {
+    match (a, b) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        _ => Ordering::Equal,
+    }
+}
+
+fn compare_pick_option_i32(a: Option<i32>, b: Option<i32>) -> Ordering {
+    match (a, b) {
+        (Some(av), Some(bv)) => av.cmp(&bv),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn compare_pick_usize_desc(a: usize, b: usize) -> Ordering {
+    b.cmp(&a)
+}
+
+fn compare_pick_biotype(a: Option<&str>, b: Option<&str>) -> Ordering {
+    let rank = |value: Option<&str>| match value {
+        Some("protein_coding") => 0_u8,
+        Some(other) if !other.is_empty() => 1_u8,
+        _ => 2_u8,
+    };
+    rank(a)
+        .cmp(&rank(b))
+        .then_with(|| a.unwrap_or("").cmp(b.unwrap_or("")))
+}
+
+fn pick_assignment_gene_key(
+    tc: &TranscriptConsequence,
+    ctx: &PreparedContext<'_>,
+) -> Option<String> {
+    let tx = ctx.transcripts.get(tc.transcript_idx?)?;
+    tx.gene_stable_id
+        .clone()
+        .or_else(|| tx.gene_symbol.clone())
+        .or_else(|| Some(tx.transcript_id.clone()))
+}
+
+fn pick_assignment_source_rank(tx: Option<&TranscriptFeature>, wanted: &str) -> bool {
+    let Some(tx) = tx else {
+        return false;
+    };
+    let source = tx
+        .source
+        .as_deref()
+        .and_then(normalize_source_label)
+        .unwrap_or_else(|| {
+            if tx.transcript_id.starts_with("ENS") {
+                "Ensembl".to_string()
+            } else if tx.transcript_id.starts_with("NM_")
+                || tx.transcript_id.starts_with("NR_")
+                || tx.transcript_id.starts_with("XM_")
+                || tx.transcript_id.starts_with("XR_")
+            {
+                "RefSeq".to_string()
+            } else {
+                String::new()
+            }
+        });
+    source == wanted
+}
+
+fn pick_assignment_rank(tc: &TranscriptConsequence) -> u32 {
+    most_severe_term(tc.terms.iter())
+        .map(|term| term.rank() as u32)
+        .unwrap_or(u32::MAX)
+}
+
+fn pick_assignment_length(tc: &TranscriptConsequence, ctx: &PreparedContext<'_>) -> usize {
+    let Some(tx_idx) = tc.transcript_idx else {
+        return 0;
+    };
+    let tx = ctx.transcripts[tx_idx];
+    if let Some(length) = ctx
+        .translation_by_tx
+        .get(tx.transcript_id.as_str())
+        .and_then(|translation| translation.protein_len.or(translation.cds_len))
+    {
+        return length;
+    }
+    tx.end
+        .saturating_sub(tx.start)
+        .saturating_add(1)
+        .try_into()
+        .unwrap_or(0)
+}
+
+fn compare_pick_assignments(
+    a_idx: usize,
+    b_idx: usize,
+    assignments: &[TranscriptConsequence],
+    ctx: &PreparedContext<'_>,
+    pick_order: &[PickCriterion],
+) -> Ordering {
+    let a = &assignments[a_idx];
+    let b = &assignments[b_idx];
+    let a_tx = a.transcript_idx.map(|idx| ctx.transcripts[idx]);
+    let b_tx = b.transcript_idx.map(|idx| ctx.transcripts[idx]);
+
+    for criterion in pick_order {
+        let ordering = match criterion {
+            PickCriterion::ManeSelect => compare_pick_bool(
+                a_tx.and_then(|tx| tx.mane_select.as_deref()).is_some(),
+                b_tx.and_then(|tx| tx.mane_select.as_deref()).is_some(),
+            ),
+            PickCriterion::ManePlusClinical => compare_pick_bool(
+                a_tx.and_then(|tx| tx.mane_plus_clinical.as_deref())
+                    .is_some(),
+                b_tx.and_then(|tx| tx.mane_plus_clinical.as_deref())
+                    .is_some(),
+            ),
+            PickCriterion::Canonical => compare_pick_bool(
+                a_tx.map(|tx| tx.is_canonical).unwrap_or(false),
+                b_tx.map(|tx| tx.is_canonical).unwrap_or(false),
+            ),
+            PickCriterion::Appris => {
+                parse_appris_pick_rank(a_tx.and_then(|tx| tx.appris.as_deref())).cmp(
+                    &parse_appris_pick_rank(b_tx.and_then(|tx| tx.appris.as_deref())),
+                )
+            }
+            PickCriterion::Tsl => {
+                compare_pick_option_i32(a_tx.and_then(|tx| tx.tsl), b_tx.and_then(|tx| tx.tsl))
+            }
+            PickCriterion::Biotype => compare_pick_biotype(
+                a_tx.map(|tx| tx.biotype.as_str()),
+                b_tx.map(|tx| tx.biotype.as_str()),
+            ),
+            PickCriterion::Ccds => compare_pick_bool(
+                a_tx.and_then(|tx| tx.ccds.as_deref()).is_some(),
+                b_tx.and_then(|tx| tx.ccds.as_deref()).is_some(),
+            ),
+            PickCriterion::Rank => pick_assignment_rank(a).cmp(&pick_assignment_rank(b)),
+            PickCriterion::Length => compare_pick_usize_desc(
+                pick_assignment_length(a, ctx),
+                pick_assignment_length(b, ctx),
+            ),
+            PickCriterion::Ensembl => compare_pick_bool(
+                pick_assignment_source_rank(a_tx, "Ensembl"),
+                pick_assignment_source_rank(b_tx, "Ensembl"),
+            ),
+            PickCriterion::Refseq => compare_pick_bool(
+                pick_assignment_source_rank(a_tx, "RefSeq"),
+                pick_assignment_source_rank(b_tx, "RefSeq"),
+            ),
+        };
+        if ordering != Ordering::Equal {
+            return ordering;
+        }
+    }
+
+    a.transcript_idx
+        .cmp(&b.transcript_idx)
+        .then_with(|| a.transcript_id.cmp(&b.transcript_id))
+        .then_with(|| a_idx.cmp(&b_idx))
+}
+
+fn append_pick_flag(flags: &mut Option<String>) {
+    if flags
+        .as_deref()
+        .is_some_and(|value| value.split('&').any(|part| part == "PICK"))
+    {
+        return;
+    }
+    match flags {
+        Some(existing) if !existing.is_empty() => existing.push_str("&PICK"),
+        _ => *flags = Some("PICK".to_string()),
+    }
+}
+
+fn mark_flag_pick_allele_gene(
+    assignments: &mut [TranscriptConsequence],
+    ctx: &PreparedContext<'_>,
+    pick_flags: &PickFlags,
+) {
+    if !pick_flags.flag_pick_allele_gene {
+        return;
+    }
+
+    let mut grouped: HashMap<String, Vec<usize>> = HashMap::new();
+    for (idx, tc) in assignments.iter().enumerate() {
+        let Some(gene_key) = pick_assignment_gene_key(tc, ctx) else {
+            continue;
+        };
+        grouped.entry(gene_key).or_default().push(idx);
+    }
+
+    for candidate_indices in grouped.values() {
+        if candidate_indices.is_empty() {
+            continue;
+        }
+        let mut winner = candidate_indices[0];
+        for &candidate in candidate_indices.iter().skip(1) {
+            if compare_pick_assignments(candidate, winner, assignments, ctx, &pick_flags.pick_order)
+                == Ordering::Less
+            {
+                winner = candidate;
+            }
+        }
+        append_pick_flag(&mut assignments[winner].flags);
+    }
 }
 
 /// Compute miRNA CSQ field from ncRNA secondary structure and variant cDNA position.
@@ -3615,6 +3935,7 @@ impl AnnotateProvider {
         let flags = VepFlags::from_options_json(self.options_json.as_deref());
         let hgvs_flags = HgvsFlags::from_options_json(self.options_json.as_deref());
         let transcript_selection = self.transcript_selection;
+        let pick_flags = PickFlags::from_options_json(self.options_json.as_deref())?;
         let allowed_failed = self
             .options_json
             .as_deref()
@@ -3681,6 +4002,7 @@ impl AnnotateProvider {
             flags,
             hgvs_flags,
             transcript_selection,
+            pick_flags,
             allowed_failed,
             reference_fasta_path,
             upstream_distance,
@@ -3736,6 +4058,7 @@ impl AnnotateProvider {
         flags: &VepFlags,
         hgvs_flags: &HgvsFlags,
         transcript_selection: TranscriptSelectionFlags,
+        pick_flags: &PickFlags,
         hgvs_reference_reader: &mut Option<FastaReader>,
     ) -> Result<RecordBatch> {
         let schema = batch.schema();
@@ -4062,11 +4385,15 @@ impl AnnotateProvider {
             let mut row_assignments: Vec<TranscriptConsequence> = Vec::new();
             // Store the VariantInput for HGVS_OFFSET extraction in annotation columns.
             let mut row_variant: Option<VariantInput> = None;
+            let require_transcript_annotations =
+                pick_flags.requires_transcript_annotations(skip_csq, skip_typed_cols);
             if !skip_csq {
                 csq_buf.clear();
             }
-            if let Some(most_val) = &cached_most {
-                // Cache hit — produce single CSQ entry with empty transcript fields.
+            let use_cached_fast_path = cached_most.is_some() && !require_transcript_annotations;
+            if use_cached_fast_path {
+                use std::fmt::Write;
+                let most_val = cached_most.as_deref().unwrap_or_default();
                 if !skip_csq {
                     let csq_val = cached_csq.unwrap_or_default();
                     let impact = SoTerm::from_str(most_val)
@@ -4083,7 +4410,7 @@ impl AnnotateProvider {
                     };
                     placeholder_layout.append_entry(&mut csq_buf, &entry);
                 }
-                most_str = most_val.clone();
+                most_str = most_val.to_string();
             } else {
                 use std::fmt::Write;
                 // Cache miss — compute via transcript engine and produce per-transcript CSQ.
@@ -4161,6 +4488,7 @@ impl AnnotateProvider {
                 most_str = most.as_str().to_string();
                 row_assignments = assignments;
                 row_variant = Some(variant);
+                mark_flag_pick_allele_gene(&mut row_assignments, ctx, pick_flags);
 
                 // Build VEP-compatible sorted permutation index.
                 // Used by both CSQ serialization and typed annotation columns
@@ -6769,6 +7097,7 @@ struct ContigAnnotationConfig {
     annotation_column_count: usize,
     /// Maximum number of output rows (LIMIT pushdown).
     fetch_limit: Option<usize>,
+    pick_flags: PickFlags,
     /// When true, use fjall KV store for variation lookup + SIFT instead of parquet.
     #[cfg(feature = "kv-cache")]
     use_fjall: bool,
@@ -7564,6 +7893,10 @@ fn annotate_window(
             .iter()
             .any(|&i| i >= typed_cols_start && i < typed_cols_end)
     });
+    let pick_requires_full_annotations = ann
+        .config
+        .pick_flags
+        .requires_transcript_annotations(skip_csq, skip_typed_cols);
     let sift_enabled = ann.config.flags.everything;
     let mut out = VecDeque::with_capacity(window_batches.len());
 
@@ -7611,12 +7944,16 @@ fn annotate_window(
         for batch in &buffer_batches {
             // Lazy SIFT window loading (same pattern as before).
             if sift_enabled && ann.sift_direct.is_some() {
-                let batch_has_miss = batch
-                    .schema()
-                    .index_of("cache_most_severe_consequence")
-                    .ok()
-                    .map_or(true, |idx| batch.column(idx).null_count() > 0);
-                if batch_has_miss {
+                let batch_needs_engine = if pick_requires_full_annotations {
+                    true
+                } else {
+                    batch
+                        .schema()
+                        .index_of("cache_most_severe_consequence")
+                        .ok()
+                        .map_or(true, |idx| batch.column(idx).null_count() > 0)
+                };
+                if batch_needs_engine {
                     let schema = batch.schema();
                     if let (Ok(ci), Ok(si), Ok(ei)) = (
                         schema.index_of("chrom"),
@@ -7685,6 +8022,7 @@ fn annotate_window(
                 &ann.config.flags,
                 &ann.config.hgvs_flags,
                 ann.config.transcript_selection,
+                &ann.config.pick_flags,
                 &mut ann.hgvs_reader,
             )?;
 
@@ -8513,6 +8851,52 @@ mod tests {
     #[test]
     fn test_format_appris_passthrough() {
         assert_eq!(format_appris("other"), "other");
+    }
+
+    #[test]
+    fn test_pick_flags_parse_custom_order() {
+        let flags = PickFlags::from_options_json(Some(
+            "{\"flag_pick_allele_gene\":true,\"pick_order\":\"biotype,rank,mane_select,tsl,canonical,appris,ccds,length\"}",
+        ))
+        .expect("pick flags should parse");
+
+        assert!(flags.flag_pick_allele_gene);
+        assert_eq!(
+            flags.pick_order,
+            vec![
+                PickCriterion::Biotype,
+                PickCriterion::Rank,
+                PickCriterion::ManeSelect,
+                PickCriterion::Tsl,
+                PickCriterion::Canonical,
+                PickCriterion::Appris,
+                PickCriterion::Ccds,
+                PickCriterion::Length,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_pick_flags_reject_invalid_pick_order_criterion() {
+        let err = PickFlags::from_options_json(Some(
+            "{\"flag_pick_allele_gene\":true,\"pick_order\":\"mane_select,bogus\"}",
+        ))
+        .expect_err("invalid pick_order should fail")
+        .to_string();
+
+        assert!(err.contains("unsupported pick_order criterion 'bogus'"));
+    }
+
+    #[test]
+    fn test_append_pick_flag_preserves_existing_flags_and_avoids_duplicates() {
+        let mut flags = Some("cds_end_NF".to_string());
+        append_pick_flag(&mut flags);
+        append_pick_flag(&mut flags);
+        assert_eq!(flags, Some("cds_end_NF&PICK".to_string()));
+
+        let mut empty = None;
+        append_pick_flag(&mut empty);
+        assert_eq!(empty, Some("PICK".to_string()));
     }
 
     // ── format_prediction ──────────────────────────────────────────────

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -1527,7 +1527,7 @@ impl CsqPlaceholderLayout {
         transcript_selection: TranscriptSelectionFlags,
         include_pick: bool,
     ) -> Self {
-        let fields = crate::golden_benchmark::csq_field_names_for_mode(
+        let fields = crate::golden_benchmark::csq_field_names_for_mode_with_pick(
             everything,
             transcript_selection.source_mode == TranscriptSourceMode::RefSeq,
             transcript_selection.source_mode == TranscriptSourceMode::Merged,
@@ -1564,6 +1564,7 @@ struct CsqPlaceholderEntry<'a> {
 struct TranscriptRawMetadata {
     display_xref_id: Option<String>,
     source: Option<String>,
+    source_cache: Option<String>,
     gene_hgnc_id_native: Option<String>,
     refseq_match: Option<String>,
     refseq_edits: Vec<RefSeqEdit>,
@@ -2285,11 +2286,8 @@ fn pick_assignment_source_rank(tx: Option<&TranscriptFeature>, wanted: &str) -> 
     // - Ensembl VEP release 115 sets `$info->{lc($tr->{_source_cache})} = 0`
     //   and only exact `ensembl` / `refseq` keys influence those categories
     //   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L734-L741>
-    if tx
-        .source
-        .as_deref()
-        .is_some_and(|source| source.eq_ignore_ascii_case(wanted))
-    {
+    let source = tx.source_cache.as_deref().or(tx.source.as_deref());
+    if source.is_some_and(|source| source.eq_ignore_ascii_case(wanted)) {
         0
     } else {
         1
@@ -2310,6 +2308,9 @@ where
     T: Ord + Copy,
     F: FnMut(&PickCandidateInfo) -> T,
 {
+    if candidates.is_empty() {
+        return None;
+    }
     candidates.sort_by_key(|candidate| key(candidate));
     let best = key(&candidates[0]);
     let keep = candidates
@@ -2715,6 +2716,7 @@ pub struct AnnotateProvider {
     backend: AnnotationBackend,
     options_json: Option<String>,
     transcript_selection: TranscriptSelectionFlags,
+    pick_flags: PickFlags,
     include_pick_output: bool,
     annotation_column_defs: Vec<AnnotationColumnDef>,
     schema: SchemaRef,
@@ -2731,10 +2733,8 @@ impl AnnotateProvider {
     ) -> Result<Self> {
         let transcript_selection =
             TranscriptSelectionFlags::from_options_json(options_json.as_deref())?;
-        let include_pick_output = options_json
-            .as_deref()
-            .and_then(|opts| Self::parse_json_bool_option(opts, "flag_pick_allele_gene"))
-            .unwrap_or(false);
+        let pick_flags = PickFlags::from_options_json(options_json.as_deref())?;
+        let include_pick_output = pick_flags.flag_pick_allele_gene;
         let annotation_column_defs =
             annotation_column_defs_for_selection(transcript_selection, include_pick_output);
         // Output schema starts with all VCF columns and appends annotation fields.
@@ -2771,6 +2771,7 @@ impl AnnotateProvider {
             backend,
             options_json,
             transcript_selection,
+            pick_flags,
             include_pick_output,
             annotation_column_defs,
             schema: Arc::new(Schema::new(fields)),
@@ -3178,6 +3179,7 @@ impl AnnotateProvider {
                 let TranscriptRawMetadata {
                     display_xref_id,
                     source: raw_source,
+                    source_cache: raw_source_cache,
                     gene_hgnc_id_native: raw_gene_hgnc_id_native,
                     refseq_match,
                     refseq_edits,
@@ -3232,11 +3234,11 @@ impl AnnotateProvider {
                 let promoted_gene_hgnc_id =
                     gene_hgnc_id_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
                 let gene_hgnc_id = gene_hgnc_id_native.clone().or(promoted_gene_hgnc_id);
-                let source = raw_source.or_else(|| {
-                    source_idx
-                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row))
-                        .and_then(|value| normalize_source_label(&value))
+                let source_cache = raw_source_cache.or_else(|| {
+                    source_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row))
                 });
+                let source =
+                    raw_source.or_else(|| source_cache.as_deref().and_then(normalize_source_label));
                 let bam_edit_status =
                     bam_edit_status_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
                 let has_non_polya_rna_edit = has_non_polya_rna_edit_idx
@@ -3309,6 +3311,7 @@ impl AnnotateProvider {
                     gene_hgnc_id,
                     display_xref_id,
                     source,
+                    source_cache,
                     refseq_match,
                     refseq_edits,
                     is_gencode_basic,
@@ -4089,7 +4092,7 @@ impl AnnotateProvider {
         let flags = VepFlags::from_options_json(self.options_json.as_deref());
         let hgvs_flags = HgvsFlags::from_options_json(self.options_json.as_deref());
         let transcript_selection = self.transcript_selection;
-        let pick_flags = PickFlags::from_options_json(self.options_json.as_deref())?;
+        let pick_flags = self.pick_flags.clone();
         let allowed_failed = self
             .options_json
             .as_deref()
@@ -4215,7 +4218,7 @@ impl AnnotateProvider {
         hgvs_reference_reader: &mut Option<FastaReader>,
     ) -> Result<RecordBatch> {
         let schema = batch.schema();
-        let include_pick_output = pick_flags.flag_pick_allele_gene;
+        let include_pick_output = self.include_pick_output;
         let chrom_idx = schema.index_of("chrom").map_err(|_| {
             DataFusionError::Execution(
                 "annotate_vep(): input VCF row is missing required chrom column".to_string(),
@@ -6055,10 +6058,12 @@ fn parse_transcript_raw_metadata(raw_object_json: &str) -> TranscriptRawMetadata
         .and_then(|xref| xref.get("display_id"))
         .and_then(Value::as_str)
         .map(str::to_string);
-    let source = tx
+    let source_cache = tx
         .get("_source_cache")
         .and_then(Value::as_str)
-        .and_then(normalize_source_label);
+        .filter(|value| !value.is_empty() && *value != "-")
+        .map(str::to_string);
+    let source = source_cache.as_deref().and_then(normalize_source_label);
     let cdna_mapper_segments = parse_raw_cdna_mapper_segments(vef_cache);
     let gene_hgnc_id_native = tx
         .get("_gene_hgnc_id")
@@ -6123,6 +6128,7 @@ fn parse_transcript_raw_metadata(raw_object_json: &str) -> TranscriptRawMetadata
     TranscriptRawMetadata {
         display_xref_id,
         source,
+        source_cache,
         gene_hgnc_id_native,
         refseq_match: (!refseq_match_codes.is_empty()).then(|| refseq_match_codes.join("&")),
         refseq_edits,
@@ -9160,12 +9166,14 @@ mod tests {
         let mut tx_havana = make_tx("ENST00000001", Some("GENE1"), Some("HGNC"), None, None);
         tx_havana.gene_stable_id = Some("ENSG00000001".to_string());
         tx_havana.biotype = "protein_coding".to_string();
-        tx_havana.source = Some("ensembl_havana".to_string());
+        tx_havana.source = Some("Ensembl".to_string());
+        tx_havana.source_cache = Some("ensembl_havana".to_string());
 
         let mut tx_ensembl = make_tx("ENST00000002", Some("GENE1"), Some("HGNC"), None, None);
         tx_ensembl.gene_stable_id = Some("ENSG00000001".to_string());
         tx_ensembl.biotype = "protein_coding".to_string();
         tx_ensembl.source = Some("Ensembl".to_string());
+        tx_ensembl.source_cache = Some("Ensembl".to_string());
 
         let transcripts = vec![tx_havana, tx_ensembl];
         let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
@@ -9265,6 +9273,7 @@ mod tests {
             make_tx("ENST00000041", Some("GENE1"), Some("HGNC"), None, None);
         tx_shorter_spliced.gene_stable_id = Some("ENSG00000041".to_string());
         tx_shorter_spliced.biotype = "lncRNA".to_string();
+        // Genomic span is intentionally larger; exon length drives the pick.
         tx_shorter_spliced.start = 1;
         tx_shorter_spliced.end = 1000;
 
@@ -9653,6 +9662,7 @@ mod tests {
             gene_hgnc_id: native_hgnc_id.map(|s| s.to_string()),
             display_xref_id: None,
             source: None,
+            source_cache: None,
             refseq_match: None,
             refseq_edits: Vec::new(),
             is_gencode_basic: false,
@@ -9689,6 +9699,7 @@ mod tests {
         tx.chrom = "1".to_string();
         tx.biotype = "protein_coding".to_string();
         tx.source = source.map(str::to_string);
+        tx.source_cache = source.map(str::to_string);
         tx
     }
 
@@ -9845,7 +9856,7 @@ mod tests {
         refseq_layout.append_entry(&mut refseq_row, &entry);
         let refseq_values: Vec<&str> = refseq_row.split('|').collect();
         let refseq_fields =
-            crate::golden_benchmark::csq_field_names_for_mode(false, true, false, false);
+            crate::golden_benchmark::csq_field_names_for_mode_with_pick(false, true, false, false);
         assert_eq!(refseq_values.len(), refseq_fields.len());
         let refseq_index = |name: &str| {
             refseq_fields
@@ -9870,7 +9881,7 @@ mod tests {
         merged_layout.append_entry(&mut merged_row, &entry);
         let merged_values: Vec<&str> = merged_row.split('|').collect();
         let merged_fields =
-            crate::golden_benchmark::csq_field_names_for_mode(true, false, true, false);
+            crate::golden_benchmark::csq_field_names_for_mode_with_pick(true, false, true, false);
         assert_eq!(merged_values.len(), merged_fields.len());
         let merged_index = |name: &str| {
             merged_fields
@@ -9911,6 +9922,7 @@ mod tests {
 
         let metadata = parse_transcript_raw_metadata(raw);
         assert_eq!(metadata.source.as_deref(), Some("RefSeq"));
+        assert_eq!(metadata.source_cache.as_deref(), Some("RefSeq"));
         assert_eq!(metadata.display_xref_id.as_deref(), Some("NM_000001"));
         assert_eq!(metadata.gene_hgnc_id_native.as_deref(), Some("HGNC:5"));
         assert_eq!(metadata.refseq_match.as_deref(), Some("rseq_ens_match_cds"));
@@ -10005,6 +10017,7 @@ mod tests {
         let metadata = parse_transcript_raw_metadata(raw);
 
         assert_eq!(metadata.source.as_deref(), Some("RefSeq"));
+        assert_eq!(metadata.source_cache.as_deref(), Some("BestRefSeq"));
         assert_eq!(
             metadata.refseq_edits,
             vec![

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9040,12 +9040,12 @@ mod tests {
 
     #[test]
     fn test_mark_flag_pick_allele_gene_requires_exact_source_match() {
-        let mut tx_havana = make_tx("ENST00000001", Some("GENE1"), Some("HGNC"), None);
+        let mut tx_havana = make_tx("ENST00000001", Some("GENE1"), Some("HGNC"), None, None);
         tx_havana.gene_stable_id = Some("ENSG00000001".to_string());
         tx_havana.biotype = "protein_coding".to_string();
         tx_havana.source = Some("ensembl_havana".to_string());
 
-        let mut tx_ensembl = make_tx("ENST00000002", Some("GENE1"), Some("HGNC"), None);
+        let mut tx_ensembl = make_tx("ENST00000002", Some("GENE1"), Some("HGNC"), None, None);
         tx_ensembl.gene_stable_id = Some("ENSG00000001".to_string());
         tx_ensembl.biotype = "protein_coding".to_string();
         tx_ensembl.source = Some("Ensembl".to_string());
@@ -9080,11 +9080,11 @@ mod tests {
 
     #[test]
     fn test_mark_flag_pick_allele_gene_prefers_cds_length_over_protein_length() {
-        let mut tx_shorter_cds = make_tx("ENST00000011", Some("GENE1"), Some("HGNC"), None);
+        let mut tx_shorter_cds = make_tx("ENST00000011", Some("GENE1"), Some("HGNC"), None, None);
         tx_shorter_cds.gene_stable_id = Some("ENSG00000011".to_string());
         tx_shorter_cds.biotype = "protein_coding".to_string();
 
-        let mut tx_longer_cds = make_tx("ENST00000012", Some("GENE1"), Some("HGNC"), None);
+        let mut tx_longer_cds = make_tx("ENST00000012", Some("GENE1"), Some("HGNC"), None, None);
         tx_longer_cds.gene_stable_id = Some("ENSG00000011".to_string());
         tx_longer_cds.biotype = "protein_coding".to_string();
 
@@ -9096,6 +9096,8 @@ mod tests {
                 protein_len: Some(100),
                 translation_seq: None,
                 cds_sequence: Some("A".repeat(90)),
+                translation_seq_canonical: None,
+                cds_sequence_canonical: None,
                 stable_id: None,
                 version: None,
                 protein_features: Vec::new(),
@@ -9106,6 +9108,8 @@ mod tests {
                 protein_len: Some(20),
                 translation_seq: None,
                 cds_sequence: Some("A".repeat(99)),
+                translation_seq_canonical: None,
+                cds_sequence_canonical: None,
                 stable_id: None,
                 version: None,
                 protein_features: Vec::new(),
@@ -9140,11 +9144,11 @@ mod tests {
 
     #[test]
     fn test_mark_flag_pick_allele_gene_skips_candidates_without_gene_stable_id() {
-        let mut tx_a = make_tx("ENST00000021", Some("GENE1"), Some("HGNC"), None);
+        let mut tx_a = make_tx("ENST00000021", Some("GENE1"), Some("HGNC"), None, None);
         tx_a.biotype = "protein_coding".to_string();
         tx_a.is_canonical = false;
 
-        let mut tx_b = make_tx("ENST00000022", Some("GENE1"), Some("HGNC"), None);
+        let mut tx_b = make_tx("ENST00000022", Some("GENE1"), Some("HGNC"), None, None);
         tx_b.biotype = "protein_coding".to_string();
         tx_b.is_canonical = true;
 

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -2319,9 +2319,17 @@ fn pick_assignment_feature_id<'a>(
 ) -> &'a str {
     assignments
         .get(assignment_idx)
-        .and_then(|tc| tc.transcript_idx)
-        .and_then(|idx| ctx.transcripts.get(idx))
-        .map(|tx| tx.transcript_id.as_str())
+        .map(|tc| {
+            if tc.feature_type == FeatureType::Transcript {
+                tc.transcript_idx
+                    .and_then(|idx| ctx.transcripts.get(idx))
+                    .map(|tx| tx.transcript_id.as_str())
+                    .or(tc.transcript_id.as_deref())
+                    .unwrap_or("")
+            } else {
+                tc.transcript_id.as_deref().unwrap_or("")
+            }
+        })
         .unwrap_or("")
 }
 
@@ -2449,17 +2457,30 @@ fn pick_assignment_allele_key<'a>(_tc: &'a TranscriptConsequence, row_allele: &'
     row_allele
 }
 
-fn sort_pick_candidates_by_feature_id(
+fn sort_pick_candidates_by_vep_order(
     candidate_indices: &mut [usize],
     assignments: &[TranscriptConsequence],
     ctx: &PreparedContext<'_>,
 ) {
+    // VEP's pick logic applies the configured biological/clinical criteria
+    // first, then returns the first candidate still tied after all criteria.
+    // That last fallback is only a deterministic representative choice; it
+    // carries no additional biological or interpretation meaning. Use the same
+    // feature concat order we use for CSQ output so COITree/query callback order
+    // cannot change which tied transcript/regulatory/motif feature wins.
     candidate_indices.sort_by(|&a, &b| {
-        pick_assignment_feature_id(a, assignments, ctx).cmp(pick_assignment_feature_id(
-            b,
-            assignments,
-            ctx,
-        ))
+        assignments[a]
+            .feature_type
+            .rank()
+            .cmp(&assignments[b].feature_type.rank())
+            .then_with(|| {
+                pick_assignment_feature_id(a, assignments, ctx).cmp(pick_assignment_feature_id(
+                    b,
+                    assignments,
+                    ctx,
+                ))
+            })
+            .then_with(|| a.cmp(&b))
     });
 }
 
@@ -2490,6 +2511,7 @@ fn select_pick_indices(
         PickMode::None => {}
         PickMode::Pick | PickMode::FlagPick => {
             let mut candidates: Vec<usize> = (0..assignments.len()).collect();
+            sort_pick_candidates_by_vep_order(&mut candidates, assignments, ctx);
             insert_pick_winner(&mut selected, &mut candidates, assignments, ctx, pick_flags);
         }
         PickMode::PickAllele | PickMode::FlagPickAllele => {
@@ -2499,6 +2521,7 @@ fn select_pick_indices(
                 grouped.entry(allele).or_default().push(idx);
             }
             for candidate_indices in grouped.values_mut() {
+                sort_pick_candidates_by_vep_order(candidate_indices, assignments, ctx);
                 insert_pick_winner(
                     &mut selected,
                     candidate_indices,
@@ -2520,7 +2543,7 @@ fn select_pick_indices(
                 grouped.entry(gene_key).or_default().push(idx);
             }
             for candidate_indices in grouped.values_mut() {
-                sort_pick_candidates_by_feature_id(candidate_indices, assignments, ctx);
+                sort_pick_candidates_by_vep_order(candidate_indices, assignments, ctx);
                 insert_pick_winner(
                     &mut selected,
                     candidate_indices,
@@ -2543,7 +2566,7 @@ fn select_pick_indices(
                 grouped.entry((allele, gene_key)).or_default().push(idx);
             }
             for candidate_indices in grouped.values_mut() {
-                sort_pick_candidates_by_feature_id(candidate_indices, assignments, ctx);
+                sort_pick_candidates_by_vep_order(candidate_indices, assignments, ctx);
                 insert_pick_winner(
                     &mut selected,
                     candidate_indices,
@@ -9418,6 +9441,45 @@ mod tests {
             assert_eq!(picked[0].transcript_idx, Some(1));
             assert!(!picked[0].picked);
         }
+    }
+
+    #[test]
+    fn test_apply_pick_allele_tie_breaks_by_vep_feature_order() {
+        let mut tx_a = make_tx("ENST00000051", None, Some("GENE1"), Some("HGNC"), None);
+        tx_a.biotype = "protein_coding".to_string();
+
+        let mut tx_b = make_tx("ENST00000052", None, Some("GENE1"), Some("HGNC"), None);
+        tx_b.biotype = "protein_coding".to_string();
+
+        let transcripts = vec![tx_a, tx_b];
+        let ctx = PreparedContext::new(&transcripts, &[], &[], &[], &[], &[], &[]);
+        let assignments = vec![
+            TranscriptConsequence {
+                transcript_idx: Some(1),
+                feature_type: FeatureType::Transcript,
+                terms: vec![SoTerm::FivePrimeUtrVariant],
+                ..Default::default()
+            },
+            TranscriptConsequence {
+                transcript_idx: Some(0),
+                feature_type: FeatureType::Transcript,
+                terms: vec![SoTerm::FivePrimeUtrVariant],
+                ..Default::default()
+            },
+        ];
+
+        let picked = apply_pick_mode(
+            assignments,
+            &ctx,
+            &PickFlags {
+                mode: PickMode::PickAllele,
+                pick_order: vec![PickCriterion::Rank],
+            },
+            "A",
+        );
+
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].transcript_idx, Some(0));
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -7,7 +7,6 @@
 //! - otherwise falls back to phase-1.5 known-variant CSQ placeholders.
 
 use std::any::Any;
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::collections::VecDeque;

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -2281,18 +2281,19 @@ fn pick_transcript_length(tx: &TranscriptFeature, ctx: &PreparedContext<'_>) -> 
             .unwrap_or(0);
     }
 
-    tx.spliced_seq
-        .as_ref()
-        .map(|sequence| sequence.len())
-        .or_else(|| tx.cdna_seq.as_ref().map(|sequence| sequence.len()))
-        .or_else(|| {
-            ctx.exons_by_tx.get(tx.transcript_id.as_str()).map(|exons| {
-                exons
-                    .iter()
-                    .map(|exon| exon.end.saturating_sub(exon.start).saturating_add(1))
-                    .filter_map(|len| usize::try_from(len).ok())
-                    .sum()
-            })
+    // Traceability:
+    // - Ensembl VEP release 115 uses `$tr->length()` for transcripts without
+    //   translation in `OutputFactory::pick_worst_VariationFeatureOverlapAllele()`.
+    // - Ensembl core `Bio::EnsEMBL::Transcript::length()` sums exon lengths;
+    //   it does not rank non-coding transcripts by cached `spliced_seq`.
+    ctx.exons_by_tx
+        .get(tx.transcript_id.as_str())
+        .map(|exons| {
+            exons
+                .iter()
+                .map(|exon| exon.end.saturating_sub(exon.start).saturating_add(1))
+                .filter_map(|len| usize::try_from(len).ok())
+                .sum()
         })
         .unwrap_or_else(|| {
             usize::try_from(tx.end.saturating_sub(tx.start).saturating_add(1)).unwrap_or(0)
@@ -9728,23 +9729,22 @@ mod tests {
     }
 
     #[test]
-    fn test_mark_flag_pick_allele_gene_uses_spliced_length_for_noncoding_transcripts() {
-        let mut tx_shorter_spliced =
-            make_tx("ENST00000041", Some("GENE1"), Some("HGNC"), None, None);
-        tx_shorter_spliced.gene_stable_id = Some("ENSG00000041".to_string());
-        tx_shorter_spliced.biotype = "lncRNA".to_string();
-        // Genomic span is intentionally larger; exon length drives the pick.
-        tx_shorter_spliced.start = 1;
-        tx_shorter_spliced.end = 1000;
+    fn test_mark_flag_pick_allele_gene_uses_exon_length_for_noncoding_transcripts() {
+        let mut tx_shorter_exons = make_tx("ENST00000041", Some("GENE1"), Some("HGNC"), None, None);
+        tx_shorter_exons.gene_stable_id = Some("ENSG00000041".to_string());
+        tx_shorter_exons.biotype = "lncRNA".to_string();
+        tx_shorter_exons.start = 1;
+        tx_shorter_exons.end = 1000;
+        tx_shorter_exons.spliced_seq = Some("A".repeat(300));
+        tx_shorter_exons.cdna_seq = Some("A".repeat(300));
 
-        let mut tx_longer_spliced =
-            make_tx("ENST00000042", Some("GENE1"), Some("HGNC"), None, None);
-        tx_longer_spliced.gene_stable_id = Some("ENSG00000041".to_string());
-        tx_longer_spliced.biotype = "lncRNA".to_string();
-        tx_longer_spliced.start = 1;
-        tx_longer_spliced.end = 500;
+        let mut tx_longer_exons = make_tx("ENST00000042", Some("GENE1"), Some("HGNC"), None, None);
+        tx_longer_exons.gene_stable_id = Some("ENSG00000041".to_string());
+        tx_longer_exons.biotype = "lncRNA".to_string();
+        tx_longer_exons.start = 1;
+        tx_longer_exons.end = 500;
 
-        let transcripts = vec![tx_shorter_spliced, tx_longer_spliced];
+        let transcripts = vec![tx_shorter_exons, tx_longer_exons];
         let exons = vec![
             ExonFeature {
                 transcript_id: "ENST00000041".to_string(),

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -7575,6 +7575,71 @@ type PersistedBufferTranscripts =
 
 type FastaReader = fasta::io::indexed_reader::IndexedReader<fasta::io::BufReader<std::fs::File>>;
 
+#[derive(Default)]
+struct InputBufferAccumulator {
+    pending_batches: VecDeque<RecordBatch>,
+    pending_rows: usize,
+}
+
+impl InputBufferAccumulator {
+    fn pending_rows(&self) -> usize {
+        self.pending_rows
+    }
+
+    fn push_window_and_drain_ready(
+        &mut self,
+        batches: Vec<RecordBatch>,
+        row_limit: usize,
+        flush_partial: bool,
+    ) -> Vec<Vec<RecordBatch>> {
+        for batch in batches {
+            let rows = batch.num_rows();
+            if rows == 0 {
+                continue;
+            }
+            self.pending_rows += rows;
+            self.pending_batches.push_back(batch);
+        }
+
+        let row_limit = row_limit.max(1);
+        let mut ready = Vec::new();
+        while self.pending_rows >= row_limit {
+            ready.push(self.drain_rows(row_limit));
+        }
+        if flush_partial && self.pending_rows > 0 {
+            ready.push(self.drain_rows(self.pending_rows));
+        }
+        ready
+    }
+
+    fn drain_rows(&mut self, rows: usize) -> Vec<RecordBatch> {
+        debug_assert!(rows > 0);
+        debug_assert!(rows <= self.pending_rows);
+
+        let mut remaining = rows;
+        let mut drained = Vec::new();
+        while remaining > 0 {
+            let batch = self
+                .pending_batches
+                .pop_front()
+                .expect("pending row count must match pending batches");
+            let batch_rows = batch.num_rows();
+            if batch_rows <= remaining {
+                remaining -= batch_rows;
+                drained.push(batch);
+            } else {
+                drained.push(batch.slice(0, remaining));
+                self.pending_batches
+                    .push_front(batch.slice(remaining, batch_rows - remaining));
+                remaining = 0;
+            }
+        }
+
+        self.pending_rows -= rows;
+        drained
+    }
+}
+
 /// Everything needed to start streaming annotation for a contig.
 /// Produced by `prepare_contig_context()`.
 struct ContigReadyState {
@@ -7628,6 +7693,7 @@ struct ContigAnnotationState {
     engine: TranscriptConsequenceEngine,
     // Window buffer.
     window_buffer: Vec<RecordBatch>,
+    input_buffer_accumulator: InputBufferAccumulator,
     lookup_done: bool,
     // Cleanup + profiling.
     ephemeral_tables: Vec<String>,
@@ -7817,34 +7883,6 @@ fn hydrate_window(
     Ok(())
 }
 
-fn split_batches_by_row_limit(batches: &[RecordBatch], row_limit: usize) -> Vec<Vec<RecordBatch>> {
-    let mut out = Vec::new();
-    let mut current = Vec::new();
-    let mut current_rows = 0usize;
-
-    for batch in batches {
-        let mut offset = 0usize;
-        while offset < batch.num_rows() {
-            let remaining = row_limit.saturating_sub(current_rows);
-            let take = remaining.min(batch.num_rows() - offset);
-            current.push(batch.slice(offset, take));
-            current_rows += take;
-            offset += take;
-
-            if current_rows == row_limit {
-                out.push(std::mem::take(&mut current));
-                current_rows = 0;
-            }
-        }
-    }
-
-    if !current.is_empty() {
-        out.push(current);
-    }
-
-    out
-}
-
 fn buffer_variant_bounds(batches: &[RecordBatch]) -> Result<Option<(String, i64, i64)>> {
     let mut chrom: Option<String> = None;
     let mut min_start = i64::MAX;
@@ -7933,13 +7971,6 @@ fn transcript_cache_regions(transcript: &TranscriptFeature) -> Vec<TranscriptCac
     cache_regions_for_coords(&transcript.chrom, transcript.start, transcript.end, 0, 0)
 }
 
-fn transcript_start_cache_region(transcript: &TranscriptFeature) -> TranscriptCacheRegion {
-    TranscriptCacheRegion {
-        chrom: normalized_chrom_name(&transcript.chrom).to_string(),
-        region_index: cache_region_index(transcript.start),
-    }
-}
-
 fn collect_buffer_cache_regions(
     batches: &[RecordBatch],
     upstream_distance: i64,
@@ -8012,7 +8043,6 @@ fn select_buffer_local_transcripts(
     max_end: i64,
     upstream_distance: i64,
     downstream_distance: i64,
-    active_regions: &HashSet<TranscriptCacheRegion>,
 ) -> Vec<TranscriptFeature> {
     let chrom_norm = chrom.strip_prefix("chr").unwrap_or(chrom);
     // VEP's up_down_size = max(upstream, downstream), applied symmetrically.
@@ -8026,10 +8056,11 @@ fn select_buffer_local_transcripts(
         .filter(|tx| {
             let tx_chrom = tx.chrom.strip_prefix("chr").unwrap_or(&tx.chrom);
             tx_chrom == chrom_norm
-                // VEP populates transcript objects per 1 Mb cache region; same-region
-                // donor objects are needed for merge_features() HGNC propagation.
-                && ((tx.end >= query_start && tx.start <= query_end)
-                    || active_regions.contains(&transcript_start_cache_region(tx)))
+                // VEP fetches broad 1 Mb cache regions, but it filters those
+                // cached features against the input-buffer min/max window
+                // before merge_features() can propagate HGNC values.
+                && tx.end >= query_start
+                && tx.start <= query_end
         })
         .cloned()
         .collect()
@@ -8043,15 +8074,6 @@ fn build_buffer_local_transcripts(
     upstream_distance: i64,
     downstream_distance: i64,
 ) -> Vec<TranscriptFeature> {
-    let active_regions: HashSet<TranscriptCacheRegion> = cache_regions_for_coords(
-        chrom,
-        min_start,
-        max_end,
-        upstream_distance,
-        downstream_distance,
-    )
-    .into_iter()
-    .collect();
     let mut buffer_transcripts = select_buffer_local_transcripts(
         transcripts,
         chrom,
@@ -8059,7 +8081,6 @@ fn build_buffer_local_transcripts(
         max_end,
         upstream_distance,
         downstream_distance,
-        &active_regions,
     );
     reset_buffer_local_hgnc_effective_values(&mut buffer_transcripts);
     apply_buffer_local_hgnc_propagation(&mut buffer_transcripts);
@@ -8088,7 +8109,6 @@ fn build_stateful_buffer_local_transcripts(
         max_end,
         upstream_distance,
         downstream_distance,
-        &active_regions,
     );
 
     // Reuse the same transcript objects across adjacent input buffers while
@@ -8265,7 +8285,14 @@ fn annotate_window(
     let sift_enabled = ann.config.flags.everything;
     let mut out = VecDeque::with_capacity(window_batches.len());
 
-    for buffer_batches in split_batches_by_row_limit(window_batches, ann.config.input_buffer_size) {
+    let flush_partial = ann.lookup_done && ann.window_buffer.is_empty();
+    let ready_input_buffers = ann.input_buffer_accumulator.push_window_and_drain_ready(
+        window_batches.to_vec(),
+        ann.config.input_buffer_size,
+        flush_partial,
+    );
+
+    for buffer_batches in ready_input_buffers {
         let Some((chrom, min_start, max_end)) = buffer_variant_bounds(&buffer_batches)? else {
             continue;
         };
@@ -8573,6 +8600,7 @@ impl Stream for ContigAnnotationStream {
                             tmp_provider,
                             engine,
                             window_buffer: Vec::with_capacity(HYDRATION_WINDOW_SIZE),
+                            input_buffer_accumulator: InputBufferAccumulator::default(),
                             lookup_done: false,
                             ephemeral_tables: ready.ephemeral_tables,
                             chrom: ready.chrom,
@@ -8651,8 +8679,10 @@ impl Stream for ContigAnnotationStream {
 
                     // LIMIT pushdown: skip remaining windows if limit reached.
                     let limit_reached = fetch_limit.is_some_and(|limit| rows_emitted >= limit);
+                    let has_pending_input_buffer = ann.input_buffer_accumulator.pending_rows() > 0;
 
-                    if ann.window_buffer.is_empty() || limit_reached {
+                    if limit_reached || (ann.window_buffer.is_empty() && !has_pending_input_buffer)
+                    {
                         // No more data (or limit reached) — clean up.
                         // Drop heavy state eagerly before the async cleanup future runs.
                         profile_end!(
@@ -8696,21 +8726,23 @@ impl Stream for ContigAnnotationStream {
                         ann.window_buffer.drain(..window_end).collect();
 
                     // Window-based HGVS hydration (like SIFT sliding window).
-                    if let Err(e) = hydrate_window(
-                        &mut ann.transcripts,
-                        &ann.exons,
-                        &mut ann.translations,
-                        &ann.translateable_seq_by_tx,
-                        &mut ann.hgvs_reader,
-                        &mut ann.hydrated_cds_tx_ids,
-                        &window_batches,
-                    ) {
-                        let fut = make_cleanup_future(
-                            Arc::clone(&ann.session),
-                            std::mem::take(&mut ann.ephemeral_tables),
-                        );
-                        self.state = StreamState::ErrorCleaningUp(fut, e);
-                        continue;
+                    if !window_batches.is_empty() {
+                        if let Err(e) = hydrate_window(
+                            &mut ann.transcripts,
+                            &ann.exons,
+                            &mut ann.translations,
+                            &ann.translateable_seq_by_tx,
+                            &mut ann.hgvs_reader,
+                            &mut ann.hydrated_cds_tx_ids,
+                            &window_batches,
+                        ) {
+                            let fut = make_cleanup_future(
+                                Arc::clone(&ann.session),
+                                std::mem::take(&mut ann.ephemeral_tables),
+                            );
+                            self.state = StreamState::ErrorCleaningUp(fut, e);
+                            continue;
+                        }
                     }
 
                     // Annotate window.
@@ -10112,6 +10144,56 @@ mod tests {
         .unwrap()
     }
 
+    fn make_buffer_batch_many(chrom: &str, starts: &[i64]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![chrom; starts.len()])) as Arc<dyn Array>,
+                Arc::new(Int64Array::from(starts.to_vec())) as Arc<dyn Array>,
+                Arc::new(Int64Array::from(starts.to_vec())) as Arc<dyn Array>,
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_input_buffer_accumulator_carries_partial_rows_across_windows() {
+        let mut accumulator = InputBufferAccumulator::default();
+
+        let first_ready = accumulator.push_window_and_drain_ready(
+            vec![make_buffer_batch_many("chr2", &[1, 2, 3])],
+            5,
+            false,
+        );
+        assert!(first_ready.is_empty());
+        assert_eq!(accumulator.pending_rows(), 3);
+
+        let second_ready = accumulator.push_window_and_drain_ready(
+            vec![make_buffer_batch_many("chr2", &[4, 5, 6, 7])],
+            5,
+            false,
+        );
+        assert_eq!(second_ready.len(), 1);
+        assert_eq!(
+            buffer_variant_bounds(&second_ready[0]).unwrap(),
+            Some(("chr2".to_string(), 1, 5))
+        );
+        assert_eq!(accumulator.pending_rows(), 2);
+
+        let final_ready = accumulator.push_window_and_drain_ready(Vec::new(), 5, true);
+        assert_eq!(final_ready.len(), 1);
+        assert_eq!(
+            buffer_variant_bounds(&final_ready[0]).unwrap(),
+            Some(("chr2".to_string(), 6, 7))
+        );
+        assert_eq!(accumulator.pending_rows(), 0);
+    }
+
     #[test]
     fn test_transcript_selection_flags_reject_invalid_combinations() {
         let err =
@@ -10766,7 +10848,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_buffer_local_transcripts_includes_active_cache_region_starts() {
+    fn test_build_buffer_local_transcripts_filters_same_region_non_overlaps() {
         let mut tx_before = make_tx(
             "ENST00000000001",
             Some("ENSG_BEFORE"),
@@ -10819,13 +10901,13 @@ mod tests {
         );
 
         let scoped_ids: HashSet<&str> = scoped.iter().map(|tx| tx.transcript_id.as_str()).collect();
-        assert_eq!(scoped_ids.len(), 2);
+        assert_eq!(scoped_ids.len(), 1);
         assert!(scoped_ids.contains(tx_inside.transcript_id.as_str()));
-        assert!(scoped_ids.contains(tx_same_region_donor.transcript_id.as_str()));
+        assert!(!scoped_ids.contains(tx_same_region_donor.transcript_id.as_str()));
     }
 
     #[test]
-    fn test_stateful_buffer_local_transcripts_include_same_cache_region_hgnc_donor() {
+    fn test_stateful_buffer_local_transcripts_filters_same_region_hgnc_donor() {
         let mut tx_recipient = make_tx(
             "NR_160941.1",
             Some("106479023"),
@@ -10873,7 +10955,83 @@ mod tests {
             .iter()
             .find(|tx| tx.transcript_id == "NR_160941.1")
             .unwrap();
-        assert_eq!(recipient.gene_hgnc_id.as_deref(), Some("HGNC:43797"));
+        assert_eq!(recipient.gene_hgnc_id, None);
+    }
+
+    #[test]
+    fn test_stateful_buffer_local_transcripts_filters_anapc1p1_donor_before_boundary() {
+        let mut tx_recipient = make_tx(
+            "NR_037931.2",
+            Some("100286979"),
+            Some("ANAPC1P1"),
+            Some("EntrezGene"),
+            None,
+        );
+        tx_recipient.chrom = "chr2".to_string();
+        tx_recipient.start = 86_861_787;
+        tx_recipient.end = 86_912_978;
+
+        let mut tx_donor = make_tx(
+            "ENST00000426186",
+            Some("ENSG00000233673"),
+            Some("ANAPC1P1"),
+            Some("HGNC"),
+            Some("HGNC:44150"),
+        );
+        tx_donor.chrom = "chr2".to_string();
+        tx_donor.start = 86_871_301;
+        tx_donor.end = 86_912_978;
+
+        let transcripts = vec![tx_recipient, tx_donor];
+        let transcript_regions: HashMap<String, Vec<TranscriptCacheRegion>> = transcripts
+            .iter()
+            .map(|tx| (tx.transcript_id.clone(), transcript_cache_regions(tx)))
+            .collect();
+        let mut persisted_transcripts = HashMap::new();
+
+        let first_buffer = vec![make_buffer_batch_many(
+            "chr2",
+            &[
+                86_856_985, 86_857_793, 86_858_475, 86_858_518, 86_858_619, 86_859_060, 86_859_741,
+                86_860_097, 86_860_689, 86_861_077, 86_861_757, 86_861_841, 86_862_499,
+            ],
+        )];
+        let first_scoped = build_stateful_buffer_local_transcripts(
+            &transcripts,
+            &transcript_regions,
+            &mut persisted_transcripts,
+            &first_buffer,
+            "chr2",
+            86_856_985,
+            86_862_499,
+            5_000,
+            5_000,
+        )
+        .unwrap();
+        let first_recipient = first_scoped
+            .iter()
+            .find(|tx| tx.transcript_id == "NR_037931.2")
+            .unwrap();
+        assert_eq!(first_recipient.gene_hgnc_id, None);
+
+        let second_buffer = vec![make_buffer_batch_many("chr2", &[86_862_550, 86_871_302])];
+        let second_scoped = build_stateful_buffer_local_transcripts(
+            &transcripts,
+            &transcript_regions,
+            &mut persisted_transcripts,
+            &second_buffer,
+            "chr2",
+            86_862_550,
+            86_871_302,
+            5_000,
+            5_000,
+        )
+        .unwrap();
+        let second_recipient = second_scoped
+            .iter()
+            .find(|tx| tx.transcript_id == "NR_037931.2")
+            .unwrap();
+        assert_eq!(second_recipient.gene_hgnc_id.as_deref(), Some("HGNC:44150"));
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -7933,6 +7933,13 @@ fn transcript_cache_regions(transcript: &TranscriptFeature) -> Vec<TranscriptCac
     cache_regions_for_coords(&transcript.chrom, transcript.start, transcript.end, 0, 0)
 }
 
+fn transcript_start_cache_region(transcript: &TranscriptFeature) -> TranscriptCacheRegion {
+    TranscriptCacheRegion {
+        chrom: normalized_chrom_name(&transcript.chrom).to_string(),
+        region_index: cache_region_index(transcript.start),
+    }
+}
+
 fn collect_buffer_cache_regions(
     batches: &[RecordBatch],
     upstream_distance: i64,
@@ -8005,6 +8012,7 @@ fn select_buffer_local_transcripts(
     max_end: i64,
     upstream_distance: i64,
     downstream_distance: i64,
+    active_regions: &HashSet<TranscriptCacheRegion>,
 ) -> Vec<TranscriptFeature> {
     let chrom_norm = chrom.strip_prefix("chr").unwrap_or(chrom);
     // VEP's up_down_size = max(upstream, downstream), applied symmetrically.
@@ -8017,7 +8025,11 @@ fn select_buffer_local_transcripts(
         .iter()
         .filter(|tx| {
             let tx_chrom = tx.chrom.strip_prefix("chr").unwrap_or(&tx.chrom);
-            tx_chrom == chrom_norm && tx.end >= query_start && tx.start <= query_end
+            tx_chrom == chrom_norm
+                // VEP populates transcript objects per 1 Mb cache region; same-region
+                // donor objects are needed for merge_features() HGNC propagation.
+                && ((tx.end >= query_start && tx.start <= query_end)
+                    || active_regions.contains(&transcript_start_cache_region(tx)))
         })
         .cloned()
         .collect()
@@ -8031,6 +8043,15 @@ fn build_buffer_local_transcripts(
     upstream_distance: i64,
     downstream_distance: i64,
 ) -> Vec<TranscriptFeature> {
+    let active_regions: HashSet<TranscriptCacheRegion> = cache_regions_for_coords(
+        chrom,
+        min_start,
+        max_end,
+        upstream_distance,
+        downstream_distance,
+    )
+    .into_iter()
+    .collect();
     let mut buffer_transcripts = select_buffer_local_transcripts(
         transcripts,
         chrom,
@@ -8038,6 +8059,7 @@ fn build_buffer_local_transcripts(
         max_end,
         upstream_distance,
         downstream_distance,
+        &active_regions,
     );
     reset_buffer_local_hgnc_effective_values(&mut buffer_transcripts);
     apply_buffer_local_hgnc_propagation(&mut buffer_transcripts);
@@ -8066,6 +8088,7 @@ fn build_stateful_buffer_local_transcripts(
         max_end,
         upstream_distance,
         downstream_distance,
+        &active_regions,
     );
 
     // Reuse the same transcript objects across adjacent input buffers while
@@ -10743,7 +10766,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_buffer_local_transcripts_scopes_to_expanded_range() {
+    fn test_build_buffer_local_transcripts_includes_active_cache_region_starts() {
         let mut tx_before = make_tx(
             "ENST00000000001",
             Some("ENSG_BEFORE"),
@@ -10760,8 +10783,17 @@ mod tests {
             Some("HGNC"),
             Some("HGNC:2"),
         );
-        tx_inside.start = 120;
-        tx_inside.end = 180;
+        tx_inside.start = 1_000_120;
+        tx_inside.end = 1_000_180;
+        let mut tx_same_region_donor = make_tx(
+            "ENST00000000004",
+            Some("ENSG_DONOR"),
+            Some("GENE4"),
+            Some("HGNC"),
+            Some("HGNC:4"),
+        );
+        tx_same_region_donor.start = 1_900_000;
+        tx_same_region_donor.end = 1_900_050;
         let mut tx_after = make_tx(
             "ENST00000000003",
             Some("ENSG_AFTER"),
@@ -10769,20 +10801,79 @@ mod tests {
             Some("HGNC"),
             Some("HGNC:3"),
         );
-        tx_after.start = 400;
-        tx_after.end = 450;
+        tx_after.start = 2_000_400;
+        tx_after.end = 2_000_450;
 
         let scoped = build_buffer_local_transcripts(
-            &[tx_before, tx_inside.clone(), tx_after],
+            &[
+                tx_before,
+                tx_inside.clone(),
+                tx_same_region_donor.clone(),
+                tx_after,
+            ],
             "chr2",
-            140,
-            160,
+            1_000_140,
+            1_000_160,
             50,
             50,
         );
 
-        assert_eq!(scoped.len(), 1);
-        assert_eq!(scoped[0].transcript_id, tx_inside.transcript_id);
+        let scoped_ids: HashSet<&str> = scoped.iter().map(|tx| tx.transcript_id.as_str()).collect();
+        assert_eq!(scoped_ids.len(), 2);
+        assert!(scoped_ids.contains(tx_inside.transcript_id.as_str()));
+        assert!(scoped_ids.contains(tx_same_region_donor.transcript_id.as_str()));
+    }
+
+    #[test]
+    fn test_stateful_buffer_local_transcripts_include_same_cache_region_hgnc_donor() {
+        let mut tx_recipient = make_tx(
+            "NR_160941.1",
+            Some("106479023"),
+            Some("H3P4"),
+            Some("EntrezGene"),
+            None,
+        );
+        tx_recipient.chrom = "chr1".to_string();
+        tx_recipient.start = 121_059_763;
+        tx_recipient.end = 121_118_626;
+
+        let mut tx_donor = make_tx(
+            "ENST00000401004",
+            Some("ENSG00000213244"),
+            Some("H3P4"),
+            Some("HGNC"),
+            Some("HGNC:43797"),
+        );
+        tx_donor.chrom = "chr1".to_string();
+        tx_donor.start = 121_118_195;
+        tx_donor.end = 121_118_610;
+
+        let transcripts = vec![tx_recipient, tx_donor];
+        let transcript_regions: HashMap<String, Vec<TranscriptCacheRegion>> = transcripts
+            .iter()
+            .map(|tx| (tx.transcript_id.clone(), transcript_cache_regions(tx)))
+            .collect();
+        let mut persisted_transcripts = HashMap::new();
+
+        let buffer = vec![make_buffer_batch("chr1", 121_096_952, 121_096_952)];
+        let scoped = build_stateful_buffer_local_transcripts(
+            &transcripts,
+            &transcript_regions,
+            &mut persisted_transcripts,
+            &buffer,
+            "chr1",
+            121_096_952,
+            121_096_952,
+            5_000,
+            5_000,
+        )
+        .unwrap();
+
+        let recipient = scoped
+            .iter()
+            .find(|tx| tx.transcript_id == "NR_160941.1")
+            .unwrap();
+        assert_eq!(recipient.gene_hgnc_id.as_deref(), Some("HGNC:43797"));
     }
 
     #[test]
@@ -10846,9 +10937,11 @@ mod tests {
             50,
         )
         .unwrap();
-        assert_eq!(second_scoped.len(), 1);
-        assert_eq!(second_scoped[0].transcript_id, "XR_RECIPIENT");
-        assert_eq!(second_scoped[0].gene_hgnc_id.as_deref(), Some("HGNC:54298"));
+        let second_recipient = second_scoped
+            .iter()
+            .find(|tx| tx.transcript_id == "XR_RECIPIENT")
+            .unwrap();
+        assert_eq!(second_recipient.gene_hgnc_id.as_deref(), Some("HGNC:54298"));
     }
 
     #[test]
@@ -10914,9 +11007,11 @@ mod tests {
             50,
         )
         .unwrap();
-        assert_eq!(second_scoped.len(), 1);
-        assert_eq!(second_scoped[0].transcript_id, "XR_007060157.1");
-        assert_eq!(second_scoped[0].gene_hgnc_id.as_deref(), Some("HGNC:16001"));
+        let second_recipient = second_scoped
+            .iter()
+            .find(|tx| tx.transcript_id == "XR_007060157.1")
+            .unwrap();
+        assert_eq!(second_recipient.gene_hgnc_id.as_deref(), Some("HGNC:16001"));
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -2469,6 +2469,68 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_filter_pick_modes_reduce_csq_and_typed_columns() {
+        let backend = "parquet";
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_batch_to_cache(&tmpdir, "variation", &pick_cache_batch(None, None));
+        write_batch_to_cache(&tmpdir, "transcript", &pick_transcripts_batch());
+        write_batch_to_chrom(&tmpdir, "exon", "1", &pick_exons_batch());
+
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_pick_filter", Arc::new(pick_vcf_table()))
+            .expect("register pick-filter vcf");
+
+        let cache_path = tmpdir.path().to_str().expect("utf8 path");
+        let (_fasta_dir, fasta_path) = write_test_indexed_fasta("1", &"N".repeat(512));
+        for (mode_key, expected_features) in [
+            ("pick", vec!["ENSTPICK0001"]),
+            ("pick_allele", vec!["ENSTPICK0001"]),
+            ("per_gene", vec!["ENSTPICK0001", "ENSTPICK0003"]),
+            ("pick_allele_gene", vec!["ENSTPICK0001", "ENSTPICK0003"]),
+        ] {
+            let expected_features: Vec<String> =
+                expected_features.into_iter().map(str::to_string).collect();
+            let sql = format!(
+                "SELECT \"CSQ\", \"Feature\" \
+                 FROM annotate_vep( \
+                   'vcf_pick_filter', \
+                   '{cache_path}', \
+                   '{backend}', \
+                   '{{\"partitioned\":true,\"everything\":true,\"{mode_key}\":true,\
+                      \"pick_order\":\"mane_select,tsl,canonical\",\"reference_fasta_path\":\"{}\"}}' \
+                 )",
+                fasta_path.replace('\'', "''")
+            );
+            let batches = ctx
+                .sql(&sql)
+                .await
+                .expect("filter pick query should parse")
+                .collect()
+                .await
+                .expect("collect filter pick annotate_vep");
+            let batch = &batches[0];
+
+            let csq = string_values(batch.column_by_name("CSQ").expect("csq column exists"));
+            let csq0 = csq[0].as_ref().expect("csq should be present");
+            let transcript_features: Vec<String> = csq_entries(csq0)
+                .into_iter()
+                .filter(|fields| fields.len() == 80 && fields[5] == "Transcript")
+                .map(|fields| fields[6].to_string())
+                .collect();
+            assert_eq!(transcript_features, expected_features);
+
+            let typed_features = list_row_string_values(
+                batch
+                    .column_by_name("Feature")
+                    .expect("feature column exists"),
+                0,
+            );
+            let typed_features: Vec<String> = typed_features.into_iter().flatten().collect();
+            assert_eq!(typed_features, expected_features);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_annotate_vep_pick_order_changes_transcript_winner() {
         let backend = "parquet";
         let tmpdir = TempDir::new().expect("create temp dir");

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -726,6 +726,155 @@ mod tests {
         .expect("valid context exon batch")
     }
 
+    fn pick_vcf_table() -> MemTable {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("ref", DataType::Utf8, false),
+            Field::new("alt", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1"])),
+                Arc::new(Int64Array::from(vec![155])),
+                Arc::new(Int64Array::from(vec![155])),
+                Arc::new(StringArray::from(vec!["A"])),
+                Arc::new(StringArray::from(vec!["G"])),
+            ],
+        )
+        .expect("valid pick vcf batch");
+        MemTable::try_new(schema, vec![vec![batch]]).expect("valid pick vcf memtable")
+    }
+
+    fn pick_cache_batch(cached_csq: Option<&str>, cached_most: Option<&str>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("variation_name", DataType::Utf8, true),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("consequence_types", DataType::Utf8, true),
+            Field::new("most_severe_consequence", DataType::Utf8, true),
+            Field::new("failed", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["1"])),
+                Arc::new(Int64Array::from(vec![155])),
+                Arc::new(Int64Array::from(vec![155])),
+                Arc::new(StringArray::from(vec![Some("rs_pick")])),
+                Arc::new(StringArray::from(vec!["A/G"])),
+                Arc::new(StringArray::from(vec![cached_csq])),
+                Arc::new(StringArray::from(vec![cached_most])),
+                Arc::new(Int64Array::from(vec![0])),
+            ],
+        )
+        .expect("valid pick cache batch")
+    }
+
+    fn pick_transcripts_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("transcript_id", DataType::Utf8, false),
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("strand", DataType::Int64, false),
+            Field::new("biotype", DataType::Utf8, false),
+            Field::new("cds_start", DataType::Int64, true),
+            Field::new("cds_end", DataType::Int64, true),
+            Field::new("gene_stable_id", DataType::Utf8, true),
+            Field::new("gene_symbol", DataType::Utf8, true),
+            Field::new("is_canonical", DataType::Boolean, true),
+            Field::new("tsl", DataType::Int64, true),
+            Field::new("mane_select", DataType::Utf8, true),
+            Field::new("mane_plus_clinical", DataType::Utf8, true),
+            Field::new("ccds", DataType::Utf8, true),
+            Field::new("appris", DataType::Utf8, true),
+            Field::new("translation_stable_id", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "ENSTPICK0001",
+                    "ENSTPICK0002",
+                    "ENSTPICK0003",
+                ])),
+                Arc::new(StringArray::from(vec!["1", "1", "1"])),
+                Arc::new(Int64Array::from(vec![100, 100, 100])),
+                Arc::new(Int64Array::from(vec![250, 250, 250])),
+                Arc::new(Int64Array::from(vec![1, 1, 1])),
+                Arc::new(StringArray::from(vec![
+                    "protein_coding",
+                    "protein_coding",
+                    "protein_coding",
+                ])),
+                Arc::new(Int64Array::from(vec![120, 120, 120])),
+                Arc::new(Int64Array::from(vec![240, 240, 240])),
+                Arc::new(StringArray::from(vec![
+                    Some("ENSGPICK0001"),
+                    Some("ENSGPICK0001"),
+                    Some("ENSGPICK0002"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("GENE1"),
+                    Some("GENE1"),
+                    Some("GENE2"),
+                ])),
+                Arc::new(datafusion::arrow::array::BooleanArray::from(vec![
+                    Some(false),
+                    Some(true),
+                    Some(false),
+                ])),
+                Arc::new(Int64Array::from(vec![Some(5), Some(1), Some(3)])),
+                Arc::new(StringArray::from(vec![Some("NM_PICK_1"), None, None])),
+                Arc::new(StringArray::from(vec![None::<&str>, None, None])),
+                Arc::new(StringArray::from(vec![
+                    Some("CCDS1"),
+                    Some("CCDS2"),
+                    Some("CCDS3"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("principal2"),
+                    Some("principal1"),
+                    Some("alternative1"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("ENSPICK0001"),
+                    Some("ENSPICK0002"),
+                    Some("ENSPICK0003"),
+                ])),
+            ],
+        )
+        .expect("valid pick transcript batch")
+    }
+
+    fn pick_exons_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("transcript_id", DataType::Utf8, false),
+            Field::new("exon_number", DataType::Int64, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "ENSTPICK0001",
+                    "ENSTPICK0002",
+                    "ENSTPICK0003",
+                ])),
+                Arc::new(Int64Array::from(vec![1, 1, 1])),
+                Arc::new(Int64Array::from(vec![100, 100, 100])),
+                Arc::new(Int64Array::from(vec![250, 250, 250])),
+            ],
+        )
+        .expect("valid pick exon batch")
+    }
+
     fn context_regulatory_batch() -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
             Field::new("stable_id", DataType::Utf8, false),
@@ -1597,6 +1746,20 @@ mod tests {
         }
     }
 
+    fn list_row_string_values(
+        col: &Arc<dyn datafusion::arrow::array::Array>,
+        row: usize,
+    ) -> Vec<Option<String>> {
+        let arr = col
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("expected list array");
+        if !arr.is_valid(row) {
+            return Vec::new();
+        }
+        string_values(&arr.value(row))
+    }
+
     fn csq_entries(csq: &str) -> Vec<Vec<&str>> {
         csq.split(',')
             .map(|entry| entry.split('|').collect())
@@ -2141,6 +2304,258 @@ mod tests {
         .expect("transcript hgvs prediction entry should exist");
         assert_eq!(hgvs_prediction_entry[10], "");
         assert_eq!(hgvs_prediction_entry[11], "ENSPHGVS000001.1:p.(Ala2Thr)",);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_flag_pick_allele_gene_marks_one_pick_per_gene_and_aligns_flags_columns()
+     {
+        let backend = "parquet";
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_batch_to_cache(&tmpdir, "variation", &pick_cache_batch(None, None));
+        write_batch_to_cache(&tmpdir, "transcript", &pick_transcripts_batch());
+        write_batch_to_chrom(&tmpdir, "exon", "1", &pick_exons_batch());
+
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_pick", Arc::new(pick_vcf_table()))
+            .expect("register pick vcf");
+
+        let cache_path = tmpdir.path().to_str().expect("utf8 path");
+        let (_fasta_dir, fasta_path) = write_test_indexed_fasta("1", &"N".repeat(512));
+        let sql = format!(
+            "SELECT \"CSQ\", \"FLAGS\", \"Feature\" \
+             FROM annotate_vep( \
+               'vcf_pick', \
+               '{cache_path}', \
+               '{backend}', \
+               '{{\"partitioned\":true,\"everything\":true,\"flag_pick_allele_gene\":true,\
+                  \"pick_order\":\"mane_select,tsl,canonical\",\"reference_fasta_path\":\"{}\"}}' \
+             )",
+            fasta_path.replace('\'', "''")
+        );
+        let batches = ctx
+            .sql(&sql)
+            .await
+            .expect("pick query should parse")
+            .collect()
+            .await
+            .expect("collect pick annotate_vep");
+        let batch = &batches[0];
+        let csq = string_values(batch.column_by_name("CSQ").expect("csq column exists"));
+        let csq0 = csq[0].as_ref().expect("csq should be present");
+        let picked_features: Vec<String> = csq_entries(csq0)
+            .into_iter()
+            .filter(|fields| {
+                fields.len() == 80
+                    && fields[5] == "Transcript"
+                    && fields[20].split('&').any(|flag| flag == "PICK")
+            })
+            .map(|fields| fields[6].to_string())
+            .collect();
+        assert_eq!(
+            picked_features,
+            vec!["ENSTPICK0001".to_string(), "ENSTPICK0003".to_string()]
+        );
+
+        let flags = list_row_string_values(
+            batch.column_by_name("FLAGS").expect("flags column exists"),
+            0,
+        );
+        let features = list_row_string_values(
+            batch
+                .column_by_name("Feature")
+                .expect("feature column exists"),
+            0,
+        );
+        let picked_typed_features: Vec<String> = features
+            .iter()
+            .zip(flags.iter())
+            .filter_map(
+                |(feature, flags)| match (feature.as_deref(), flags.as_deref()) {
+                    (Some(feature), Some(flags)) if flags.split('&').any(|flag| flag == "PICK") => {
+                        Some(feature.to_string())
+                    }
+                    _ => None,
+                },
+            )
+            .collect();
+        assert_eq!(picked_typed_features, picked_features);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_pick_order_changes_transcript_winner() {
+        let backend = "parquet";
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_batch_to_cache(&tmpdir, "variation", &pick_cache_batch(None, None));
+        write_batch_to_cache(&tmpdir, "transcript", &pick_transcripts_batch());
+        write_batch_to_chrom(&tmpdir, "exon", "1", &pick_exons_batch());
+
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_pick_order", Arc::new(pick_vcf_table()))
+            .expect("register pick-order vcf");
+
+        let cache_path = tmpdir.path().to_str().expect("utf8 path");
+        let (_fasta_dir, fasta_path) = write_test_indexed_fasta("1", &"N".repeat(512));
+        let sql = format!(
+            "SELECT \"CSQ\" \
+             FROM annotate_vep( \
+               'vcf_pick_order', \
+               '{cache_path}', \
+               '{backend}', \
+               '{{\"partitioned\":true,\"everything\":true,\"flag_pick_allele_gene\":true,\
+                  \"pick_order\":\"tsl,mane_select,canonical\",\"reference_fasta_path\":\"{}\"}}' \
+             )",
+            fasta_path.replace('\'', "''")
+        );
+        let batches = ctx
+            .sql(&sql)
+            .await
+            .expect("pick-order query should parse")
+            .collect()
+            .await
+            .expect("collect pick-order annotate_vep");
+        let csq = string_values(batches[0].column_by_name("CSQ").expect("csq column exists"));
+        let csq0 = csq[0].as_ref().expect("csq should be present");
+        let picked_features: Vec<String> = csq_entries(csq0)
+            .into_iter()
+            .filter(|fields| {
+                fields.len() == 80
+                    && fields[5] == "Transcript"
+                    && fields[20].split('&').any(|flag| flag == "PICK")
+            })
+            .map(|fields| fields[6].to_string())
+            .collect();
+        assert_eq!(
+            picked_features,
+            vec!["ENSTPICK0002".to_string(), "ENSTPICK0003".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_flag_pick_allele_gene_bypasses_cache_hit_fast_path() {
+        let backend = "parquet";
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_batch_to_cache(
+            &tmpdir,
+            "variation",
+            &pick_cache_batch(Some("missense_variant"), Some("missense_variant")),
+        );
+        write_batch_to_cache(&tmpdir, "transcript", &pick_transcripts_batch());
+        write_batch_to_chrom(&tmpdir, "exon", "1", &pick_exons_batch());
+
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_pick_hit", Arc::new(pick_vcf_table()))
+            .expect("register pick-hit vcf");
+
+        let cache_path = tmpdir.path().to_str().expect("utf8 path");
+        let (_fasta_dir, fasta_path) = write_test_indexed_fasta("1", &"N".repeat(512));
+        let default_sql = format!(
+            "SELECT \"CSQ\" \
+             FROM annotate_vep( \
+               'vcf_pick_hit', \
+               '{cache_path}', \
+               '{backend}', \
+               '{{\"partitioned\":true,\"everything\":true,\"reference_fasta_path\":\"{}\"}}' \
+             )",
+            fasta_path.replace('\'', "''")
+        );
+        let default_batches = ctx
+            .sql(&default_sql)
+            .await
+            .expect("default cache-hit query should parse")
+            .collect()
+            .await
+            .expect("collect default cache-hit annotate_vep");
+        let default_csq = string_values(
+            default_batches[0]
+                .column_by_name("CSQ")
+                .expect("csq column exists"),
+        );
+        let default_entries = csq_entries(default_csq[0].as_ref().expect("default csq present"));
+        assert_eq!(default_entries.len(), 1);
+        assert_eq!(default_entries[0][5], "");
+        assert_eq!(default_entries[0][6], "");
+
+        let pick_sql = format!(
+            "SELECT \"CSQ\" \
+             FROM annotate_vep( \
+               'vcf_pick_hit', \
+               '{cache_path}', \
+               '{backend}', \
+               '{{\"partitioned\":true,\"everything\":true,\"flag_pick_allele_gene\":true,\
+                  \"pick_order\":\"mane_select,tsl,canonical\",\"reference_fasta_path\":\"{}\"}}' \
+             )",
+            fasta_path.replace('\'', "''")
+        );
+        let pick_batches = ctx
+            .sql(&pick_sql)
+            .await
+            .expect("pick cache-hit query should parse")
+            .collect()
+            .await
+            .expect("collect pick cache-hit annotate_vep");
+        let pick_csq = string_values(
+            pick_batches[0]
+                .column_by_name("CSQ")
+                .expect("csq column exists"),
+        );
+        let pick_entries = csq_entries(pick_csq[0].as_ref().expect("pick csq present"));
+        let pick_transcript_features: Vec<String> = pick_entries
+            .iter()
+            .filter(|fields| fields.len() == 80 && fields[5] == "Transcript")
+            .map(|fields| fields[6].to_string())
+            .collect();
+        let picked_features: Vec<String> = pick_entries
+            .iter()
+            .filter(|fields| {
+                fields.len() == 80
+                    && fields[5] == "Transcript"
+                    && fields[20].split('&').any(|flag| flag == "PICK")
+            })
+            .map(|fields| fields[6].to_string())
+            .collect();
+        assert_eq!(
+            pick_transcript_features,
+            vec![
+                "ENSTPICK0001".to_string(),
+                "ENSTPICK0002".to_string(),
+                "ENSTPICK0003".to_string(),
+            ]
+        );
+        assert_eq!(
+            picked_features,
+            vec!["ENSTPICK0001".to_string(), "ENSTPICK0003".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_rejects_invalid_pick_order() {
+        let backend = "parquet";
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_batch_to_cache(&tmpdir, "variation", &pick_cache_batch(None, None));
+
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_pick_invalid", Arc::new(pick_vcf_table()))
+            .expect("register invalid-pick vcf");
+
+        let cache_path = tmpdir.path().to_str().expect("utf8 path");
+        let sql = format!(
+            "SELECT \"CSQ\" \
+             FROM annotate_vep( \
+               'vcf_pick_invalid', \
+               '{cache_path}', \
+               '{backend}', \
+               '{{\"partitioned\":true,\"flag_pick_allele_gene\":true,\"pick_order\":\"mane_select,bogus\"}}' \
+             )"
+        );
+        let err = ctx
+            .sql(&sql)
+            .await
+            .expect("invalid pick-order query should parse")
+            .collect()
+            .await
+            .expect_err("invalid pick_order should fail")
+            .to_string();
+        assert!(err.contains("unsupported pick_order criterion 'bogus'"));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -2693,14 +2693,14 @@ mod tests {
                '{{\"partitioned\":true,\"flag_pick_allele_gene\":true,\"pick_order\":\"mane_select,bogus\"}}' \
              )"
         );
-        let err = ctx
-            .sql(&sql)
-            .await
-            .expect("invalid pick-order query should parse")
-            .collect()
-            .await
-            .expect_err("invalid pick_order should fail")
-            .to_string();
+        let err = match ctx.sql(&sql).await {
+            Ok(df) => df
+                .collect()
+                .await
+                .expect_err("invalid pick_order should fail")
+                .to_string(),
+            Err(err) => err.to_string(),
+        };
         assert!(err.contains("unsupported pick_order criterion 'bogus'"));
     }
 

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -794,6 +794,7 @@ mod tests {
             Field::new("ccds", DataType::Utf8, true),
             Field::new("appris", DataType::Utf8, true),
             Field::new("translation_stable_id", DataType::Utf8, true),
+            Field::new("raw_object_json", DataType::Utf8, true),
         ]));
         RecordBatch::try_new(
             schema,
@@ -847,9 +848,97 @@ mod tests {
                     Some("ENSPICK0002"),
                     Some("ENSPICK0003"),
                 ])),
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene_stable_id":"ENSGPICK0001"}}"#),
+                    Some(r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene_stable_id":"ENSGPICK0001"}}"#),
+                    Some(r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene_stable_id":"ENSGPICK0002"}}"#),
+                ])),
             ],
         )
         .expect("valid pick transcript batch")
+    }
+
+    fn pick_transcripts_batch_with_gene_id_only_in_raw_json() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("transcript_id", DataType::Utf8, false),
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("strand", DataType::Int64, false),
+            Field::new("biotype", DataType::Utf8, false),
+            Field::new("cds_start", DataType::Int64, true),
+            Field::new("cds_end", DataType::Int64, true),
+            Field::new("gene_stable_id", DataType::Utf8, true),
+            Field::new("gene_symbol", DataType::Utf8, true),
+            Field::new("is_canonical", DataType::Boolean, true),
+            Field::new("tsl", DataType::Int64, true),
+            Field::new("mane_select", DataType::Utf8, true),
+            Field::new("mane_plus_clinical", DataType::Utf8, true),
+            Field::new("ccds", DataType::Utf8, true),
+            Field::new("appris", DataType::Utf8, true),
+            Field::new("translation_stable_id", DataType::Utf8, true),
+            Field::new("raw_object_json", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "ENSTPICK0001",
+                    "ENSTPICK0002",
+                    "ENSTPICK0003",
+                ])),
+                Arc::new(StringArray::from(vec!["1", "1", "1"])),
+                Arc::new(Int64Array::from(vec![100, 100, 100])),
+                Arc::new(Int64Array::from(vec![250, 250, 250])),
+                Arc::new(Int64Array::from(vec![1, 1, 1])),
+                Arc::new(StringArray::from(vec![
+                    "protein_coding",
+                    "protein_coding",
+                    "protein_coding",
+                ])),
+                Arc::new(Int64Array::from(vec![120, 120, 120])),
+                Arc::new(Int64Array::from(vec![240, 240, 240])),
+                Arc::new(StringArray::from(vec![
+                    None::<&str>,
+                    None::<&str>,
+                    None::<&str>,
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("GENE1"),
+                    Some("GENE1"),
+                    Some("GENE2"),
+                ])),
+                Arc::new(datafusion::arrow::array::BooleanArray::from(vec![
+                    Some(false),
+                    Some(true),
+                    Some(false),
+                ])),
+                Arc::new(Int64Array::from(vec![Some(5), Some(1), Some(3)])),
+                Arc::new(StringArray::from(vec![Some("NM_PICK_1"), None, None])),
+                Arc::new(StringArray::from(vec![None::<&str>, None, None])),
+                Arc::new(StringArray::from(vec![
+                    Some("CCDS1"),
+                    Some("CCDS2"),
+                    Some("CCDS3"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("principal2"),
+                    Some("principal1"),
+                    Some("alternative1"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("ENSPICK0001"),
+                    Some("ENSPICK0002"),
+                    Some("ENSPICK0003"),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene":{"stable_id":"ENSGPICK0001"}}}"#),
+                    Some(r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene_stable_id":"ENSGPICK0001"}}"#),
+                    Some(r#"{"__class":"Bio::EnsEMBL::Transcript","__value":{"_gene":{"stable_id":"ENSGPICK0002"}}}"#),
+                ])),
+            ],
+        )
+        .expect("valid pick transcript batch with raw gene fallback")
     }
 
     fn pick_exons_batch() -> RecordBatch {
@@ -2322,7 +2411,7 @@ mod tests {
         let cache_path = tmpdir.path().to_str().expect("utf8 path");
         let (_fasta_dir, fasta_path) = write_test_indexed_fasta("1", &"N".repeat(512));
         let sql = format!(
-            "SELECT \"CSQ\", \"FLAGS\", \"Feature\" \
+            "SELECT \"CSQ\", \"PICK\", \"Feature\" \
              FROM annotate_vep( \
                'vcf_pick', \
                '{cache_path}', \
@@ -2342,12 +2431,14 @@ mod tests {
         let batch = &batches[0];
         let csq = string_values(batch.column_by_name("CSQ").expect("csq column exists"));
         let csq0 = csq[0].as_ref().expect("csq should be present");
+        let pick_field_idx = crate::golden_benchmark::csq_field_names(true, true)
+            .iter()
+            .position(|field| *field == "PICK")
+            .expect("pick field should be present");
         let picked_features: Vec<String> = csq_entries(csq0)
             .into_iter()
             .filter(|fields| {
-                fields.len() == 80
-                    && fields[5] == "Transcript"
-                    && fields[20].split('&').any(|flag| flag == "PICK")
+                fields.len() == 81 && fields[5] == "Transcript" && fields[pick_field_idx] == "1"
             })
             .map(|fields| fields[6].to_string())
             .collect();
@@ -2356,10 +2447,8 @@ mod tests {
             vec!["ENSTPICK0001".to_string(), "ENSTPICK0003".to_string()]
         );
 
-        let flags = list_row_string_values(
-            batch.column_by_name("FLAGS").expect("flags column exists"),
-            0,
-        );
+        let picks =
+            list_row_string_values(batch.column_by_name("PICK").expect("pick column exists"), 0);
         let features = list_row_string_values(
             batch
                 .column_by_name("Feature")
@@ -2368,12 +2457,10 @@ mod tests {
         );
         let picked_typed_features: Vec<String> = features
             .iter()
-            .zip(flags.iter())
+            .zip(picks.iter())
             .filter_map(
-                |(feature, flags)| match (feature.as_deref(), flags.as_deref()) {
-                    (Some(feature), Some(flags)) if flags.split('&').any(|flag| flag == "PICK") => {
-                        Some(feature.to_string())
-                    }
+                |(feature, pick)| match (feature.as_deref(), pick.as_deref()) {
+                    (Some(feature), Some("1")) => Some(feature.to_string()),
                     _ => None,
                 },
             )
@@ -2415,18 +2502,75 @@ mod tests {
             .expect("collect pick-order annotate_vep");
         let csq = string_values(batches[0].column_by_name("CSQ").expect("csq column exists"));
         let csq0 = csq[0].as_ref().expect("csq should be present");
+        let pick_field_idx = crate::golden_benchmark::csq_field_names(true, true)
+            .iter()
+            .position(|field| *field == "PICK")
+            .expect("pick field should be present");
         let picked_features: Vec<String> = csq_entries(csq0)
             .into_iter()
             .filter(|fields| {
-                fields.len() == 80
-                    && fields[5] == "Transcript"
-                    && fields[20].split('&').any(|flag| flag == "PICK")
+                fields.len() == 81 && fields[5] == "Transcript" && fields[pick_field_idx] == "1"
             })
             .map(|fields| fields[6].to_string())
             .collect();
         assert_eq!(
             picked_features,
             vec!["ENSTPICK0002".to_string(), "ENSTPICK0003".to_string()]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_flag_pick_allele_gene_uses_raw_json_gene_fallback() {
+        let backend = "parquet";
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_batch_to_cache(&tmpdir, "variation", &pick_cache_batch(None, None));
+        write_batch_to_cache(
+            &tmpdir,
+            "transcript",
+            &pick_transcripts_batch_with_gene_id_only_in_raw_json(),
+        );
+        write_batch_to_chrom(&tmpdir, "exon", "1", &pick_exons_batch());
+
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_pick_raw_gene", Arc::new(pick_vcf_table()))
+            .expect("register pick raw-gene vcf");
+
+        let cache_path = tmpdir.path().to_str().expect("utf8 path");
+        let (_fasta_dir, fasta_path) = write_test_indexed_fasta("1", &"N".repeat(512));
+        let sql = format!(
+            "SELECT \"CSQ\" \
+             FROM annotate_vep( \
+               'vcf_pick_raw_gene', \
+               '{cache_path}', \
+               '{backend}', \
+               '{{\"partitioned\":true,\"everything\":true,\"flag_pick_allele_gene\":true,\
+                  \"pick_order\":\"mane_select,tsl,canonical\",\"reference_fasta_path\":\"{}\"}}' \
+             )",
+            fasta_path.replace('\'', "''")
+        );
+        let batches = ctx
+            .sql(&sql)
+            .await
+            .expect("raw-gene pick query should parse")
+            .collect()
+            .await
+            .expect("collect raw-gene pick annotate_vep");
+        let csq = string_values(batches[0].column_by_name("CSQ").expect("csq column exists"));
+        let csq0 = csq[0].as_ref().expect("csq should be present");
+        let pick_field_idx = crate::golden_benchmark::csq_field_names(true, true)
+            .iter()
+            .position(|field| *field == "PICK")
+            .expect("pick field should be present");
+        let picked_features: Vec<String> = csq_entries(csq0)
+            .into_iter()
+            .filter(|fields| {
+                fields.len() == 81 && fields[5] == "Transcript" && fields[pick_field_idx] == "1"
+            })
+            .map(|fields| fields[6].to_string())
+            .collect();
+        assert_eq!(
+            picked_features,
+            vec!["ENSTPICK0001".to_string(), "ENSTPICK0003".to_string()]
         );
     }
 
@@ -2499,17 +2643,19 @@ mod tests {
                 .expect("csq column exists"),
         );
         let pick_entries = csq_entries(pick_csq[0].as_ref().expect("pick csq present"));
+        let pick_field_idx = crate::golden_benchmark::csq_field_names(true, true)
+            .iter()
+            .position(|field| *field == "PICK")
+            .expect("pick field should be present");
         let pick_transcript_features: Vec<String> = pick_entries
             .iter()
-            .filter(|fields| fields.len() == 80 && fields[5] == "Transcript")
+            .filter(|fields| fields.len() == 81 && fields[5] == "Transcript")
             .map(|fields| fields[6].to_string())
             .collect();
         let picked_features: Vec<String> = pick_entries
             .iter()
             .filter(|fields| {
-                fields.len() == 80
-                    && fields[5] == "Transcript"
-                    && fields[20].split('&').any(|flag| flag == "PICK")
+                fields.len() == 81 && fields[5] == "Transcript" && fields[pick_field_idx] == "1"
             })
             .map(|fields| fields[6].to_string())
             .collect();

--- a/datafusion/bio-function-vep/src/golden_benchmark.rs
+++ b/datafusion/bio-function-vep/src/golden_benchmark.rs
@@ -649,12 +649,26 @@ pub const CSQ_FIELD_NAMES_EVERYTHING: &[&str] = &[
 /// The `everything` profile inserts the RefSeq-specific fields next to the
 /// transcript metadata block, after `UNIPROT_ISOFORM`, matching VEP's flag
 /// expansion order more closely.
-pub fn csq_field_names_for_mode(everything: bool, refseq: bool, merged: bool) -> Vec<&'static str> {
+///
+/// `flag_pick_allele_gene` contributes a standalone `PICK` field immediately
+/// after `FLAGS`, not a synthetic token inside `FLAGS`.
+pub fn csq_field_names_for_mode(
+    everything: bool,
+    refseq: bool,
+    merged: bool,
+    include_pick: bool,
+) -> Vec<&'static str> {
     let mut fields = if everything {
         CSQ_FIELD_NAMES_EVERYTHING.to_vec()
     } else {
         CSQ_FIELD_NAMES.to_vec()
     };
+
+    if include_pick {
+        if let Some(flags_idx) = fields.iter().position(|field| *field == "FLAGS") {
+            fields.insert(flags_idx + 1, "PICK");
+        }
+    }
 
     if everything {
         if let Some(insert_at) = fields.iter().position(|field| *field == "GENE_PHENO") {
@@ -714,6 +728,10 @@ pub fn csq_field_names_for_mode(everything: bool, refseq: bool, merged: bool) ->
     }
 
     fields
+}
+
+pub fn csq_field_names(everything: bool, include_pick: bool) -> Vec<&'static str> {
+    csq_field_names_for_mode(everything, false, false, include_pick)
 }
 
 /// Sample of a field-level mismatch for debugging.
@@ -1313,7 +1331,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
 
     #[test]
     fn csq_field_names_for_refseq_and_merged_modes_insert_expected_fields() {
-        let refseq = csq_field_names_for_mode(false, true, false);
+        let refseq = csq_field_names_for_mode(false, true, false, false);
         assert_eq!(refseq.len(), 78);
         assert_eq!(refseq[28], "REFSEQ_MATCH");
         assert_eq!(refseq[29], "REFSEQ_OFFSET");
@@ -1322,7 +1340,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(refseq[32], "BAM_EDIT");
         assert_eq!(refseq[33], "VARIANT_CLASS");
 
-        let merged = csq_field_names_for_mode(false, false, true);
+        let merged = csq_field_names_for_mode(false, false, true, false);
         assert_eq!(merged.len(), 79);
         assert_eq!(merged[28], "REFSEQ_MATCH");
         assert_eq!(merged[29], "SOURCE");
@@ -1332,7 +1350,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(merged[33], "BAM_EDIT");
         assert_eq!(merged[34], "VARIANT_CLASS");
 
-        let everything_refseq = csq_field_names_for_mode(true, true, false);
+        let everything_refseq = csq_field_names_for_mode(true, true, false, false);
         assert_eq!(everything_refseq.len(), 85);
         assert_eq!(everything_refseq[36], "REFSEQ_MATCH");
         assert_eq!(everything_refseq[37], "REFSEQ_OFFSET");
@@ -1341,7 +1359,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(everything_refseq[40], "BAM_EDIT");
         assert_eq!(everything_refseq[41], "GENE_PHENO");
 
-        let everything_merged = csq_field_names_for_mode(true, false, true);
+        let everything_merged = csq_field_names_for_mode(true, false, true, false);
         assert_eq!(everything_merged.len(), 86);
         assert_eq!(everything_merged[36], "REFSEQ_MATCH");
         assert_eq!(everything_merged[37], "SOURCE");
@@ -1350,6 +1368,21 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(everything_merged[40], "USED_REF");
         assert_eq!(everything_merged[41], "BAM_EDIT");
         assert_eq!(everything_merged[42], "GENE_PHENO");
+    }
+
+    #[test]
+    fn csq_field_names_pick_inserts_standalone_pick_after_flags() {
+        let default_fields = csq_field_names(false, true);
+        assert_eq!(default_fields.len(), 75);
+        assert_eq!(default_fields[20], "FLAGS");
+        assert_eq!(default_fields[21], "PICK");
+        assert_eq!(default_fields[22], "SYMBOL_SOURCE");
+
+        let everything_fields = csq_field_names(true, true);
+        assert_eq!(everything_fields.len(), 81);
+        assert_eq!(everything_fields[20], "FLAGS");
+        assert_eq!(everything_fields[21], "PICK");
+        assert_eq!(everything_fields[22], "VARIANT_CLASS");
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/golden_benchmark.rs
+++ b/datafusion/bio-function-vep/src/golden_benchmark.rs
@@ -650,9 +650,15 @@ pub const CSQ_FIELD_NAMES_EVERYTHING: &[&str] = &[
 /// transcript metadata block, after `UNIPROT_ISOFORM`, matching VEP's flag
 /// expansion order more closely.
 ///
+pub fn csq_field_names_for_mode(everything: bool, refseq: bool, merged: bool) -> Vec<&'static str> {
+    csq_field_names_for_mode_with_pick(everything, refseq, merged, false)
+}
+
+/// Like [`csq_field_names_for_mode`], plus optional VEP `PICK` output.
+///
 /// `flag_pick_allele_gene` contributes a standalone `PICK` field immediately
 /// after `FLAGS`, not a synthetic token inside `FLAGS`.
-pub fn csq_field_names_for_mode(
+pub fn csq_field_names_for_mode_with_pick(
     everything: bool,
     refseq: bool,
     merged: bool,
@@ -731,7 +737,7 @@ pub fn csq_field_names_for_mode(
 }
 
 pub fn csq_field_names(everything: bool, include_pick: bool) -> Vec<&'static str> {
-    csq_field_names_for_mode(everything, false, false, include_pick)
+    csq_field_names_for_mode_with_pick(everything, false, false, include_pick)
 }
 
 /// Sample of a field-level mismatch for debugging.
@@ -1331,7 +1337,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
 
     #[test]
     fn csq_field_names_for_refseq_and_merged_modes_insert_expected_fields() {
-        let refseq = csq_field_names_for_mode(false, true, false, false);
+        let refseq = csq_field_names_for_mode_with_pick(false, true, false, false);
         assert_eq!(refseq.len(), 78);
         assert_eq!(refseq[28], "REFSEQ_MATCH");
         assert_eq!(refseq[29], "REFSEQ_OFFSET");
@@ -1340,7 +1346,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(refseq[32], "BAM_EDIT");
         assert_eq!(refseq[33], "VARIANT_CLASS");
 
-        let merged = csq_field_names_for_mode(false, false, true, false);
+        let merged = csq_field_names_for_mode_with_pick(false, false, true, false);
         assert_eq!(merged.len(), 79);
         assert_eq!(merged[28], "REFSEQ_MATCH");
         assert_eq!(merged[29], "SOURCE");
@@ -1350,7 +1356,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(merged[33], "BAM_EDIT");
         assert_eq!(merged[34], "VARIANT_CLASS");
 
-        let everything_refseq = csq_field_names_for_mode(true, true, false, false);
+        let everything_refseq = csq_field_names_for_mode_with_pick(true, true, false, false);
         assert_eq!(everything_refseq.len(), 85);
         assert_eq!(everything_refseq[36], "REFSEQ_MATCH");
         assert_eq!(everything_refseq[37], "REFSEQ_OFFSET");
@@ -1359,7 +1365,7 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(everything_refseq[40], "BAM_EDIT");
         assert_eq!(everything_refseq[41], "GENE_PHENO");
 
-        let everything_merged = csq_field_names_for_mode(true, false, true, false);
+        let everything_merged = csq_field_names_for_mode_with_pick(true, false, true, false);
         assert_eq!(everything_merged.len(), 86);
         assert_eq!(everything_merged[36], "REFSEQ_MATCH");
         assert_eq!(everything_merged[37], "SOURCE");

--- a/datafusion/bio-function-vep/src/hgvs.rs
+++ b/datafusion/bio-function-vep/src/hgvs.rs
@@ -2072,6 +2072,7 @@ mod tests {
             gene_hgnc_id: None,
             display_xref_id: None,
             source: None,
+            source_cache: None,
             refseq_match: None,
             refseq_edits: Vec::new(),
             is_gencode_basic: false,

--- a/datafusion/bio-function-vep/src/lookup_provider.rs
+++ b/datafusion/bio-function-vep/src/lookup_provider.rs
@@ -880,6 +880,84 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_lookup_preserves_vcf_row_order_when_cache_rows_are_reversed() {
+        let ctx = create_vep_session();
+
+        let vcf_schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("ref", DataType::Utf8, false),
+            Field::new("alt", DataType::Utf8, false),
+        ]));
+        let vcf_batch = RecordBatch::try_new(
+            vcf_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1", "1"])),
+                Arc::new(Int64Array::from(vec![100, 200, 300])),
+                Arc::new(Int64Array::from(vec![100, 200, 300])),
+                Arc::new(StringArray::from(vec!["A", "C", "G"])),
+                Arc::new(StringArray::from(vec!["T", "A", "C"])),
+            ],
+        )
+        .unwrap();
+        let vcf = MemTable::try_new(vcf_schema, vec![vec![vcf_batch]]).unwrap();
+
+        let cache_schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("variation_name", DataType::Utf8, true),
+            Field::new("failed", DataType::Int64, false),
+        ]));
+        let cache_batch = RecordBatch::try_new(
+            cache_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1", "1"])),
+                Arc::new(Int64Array::from(vec![300, 200, 100])),
+                Arc::new(Int64Array::from(vec![300, 200, 100])),
+                Arc::new(StringArray::from(vec!["G/C", "C/A", "A/T"])),
+                Arc::new(StringArray::from(vec!["rs300", "rs200", "rs100"])),
+                Arc::new(Int64Array::from(vec![0, 0, 0])),
+            ],
+        )
+        .unwrap();
+        let cache = MemTable::try_new(cache_schema, vec![vec![cache_batch]]).unwrap();
+
+        ctx.register_table("vcf_ordered", Arc::new(vcf)).unwrap();
+        ctx.register_table("cache_reversed", Arc::new(cache))
+            .unwrap();
+
+        let batches = ctx
+            .sql("SELECT * FROM lookup_variants('vcf_ordered', 'cache_reversed', 'variation_name')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let mut starts = Vec::new();
+        let mut variation_names = Vec::new();
+        for batch in &batches {
+            let start_col = batch
+                .column_by_name("start")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let names = string_values(batch.column_by_name("cache_variation_name").unwrap());
+            for row in 0..batch.num_rows() {
+                starts.push(start_col.value(row));
+                variation_names.push(names[row].clone().unwrap());
+            }
+        }
+
+        assert_eq!(starts, vec![100, 200, 300]);
+        assert_eq!(variation_names, vec!["rs100", "rs200", "rs300"]);
+    }
+
     /// Regression test: equi-join ensures VCF rows only match cache entries
     /// at exactly the same (chrom, start, end) coordinates. Decoy entries at
     /// adjacent positions must NOT produce output rows.

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -221,6 +221,8 @@ pub struct TranscriptFeature {
     /// Transcript source normalized to VEP-facing labels (`Ensembl` / `RefSeq`)
     /// when available.
     pub source: Option<String>,
+    /// Raw VEP `_source_cache` label used for exact pick-order source ranking.
+    pub source_cache: Option<String>,
     /// Pre-formatted REFSEQ_MATCH field, joined with `&` like VEP's VCF output.
     pub refseq_match: Option<String>,
     /// Parsed `_rna_edit*` transcript attributes used for VEP `REFSEQ_OFFSET`.
@@ -8307,6 +8309,7 @@ mod tests {
             gene_hgnc_id: None,
             display_xref_id: None,
             source: None,
+            source_cache: None,
             refseq_match: None,
             refseq_edits: Vec::new(),
             is_gencode_basic: false,

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -573,6 +573,8 @@ pub struct TranscriptConsequence {
     pub distance: Option<i64>,
     /// FLAGS: e.g. "cds_start_NF", "cds_end_NF".
     pub flags: Option<String>,
+    /// VEP `PICK` output flag emitted when this consequence wins a pick mode.
+    pub picked: bool,
     /// Override biotype for non-transcript features (e.g. regulatory feature_type).
     pub biotype_override: Option<String>,
     /// HGVSc notation (e.g. "ENST00000379410.6:c.1043G>A").

--- a/datafusion/bio-function-vep/src/variant_lookup_exec.rs
+++ b/datafusion/bio-function-vep/src/variant_lookup_exec.rs
@@ -17,8 +17,9 @@ use std::task::{Context, Poll};
 
 use coitrees::{COITree, GenericInterval, Interval, IntervalTree};
 use datafusion::arrow::array::{
-    Array, ArrayRef, Int8Array, Int16Array, Int32Array, Int64Array, LargeStringArray, RecordBatch,
-    StringArray, StringViewArray, UInt32Array, UInt64Array,
+    Array, ArrayRef, Int8Array, Int16Array, Int32Array, Int64Array, LargeStringArray,
+    MutableArrayData, RecordBatch, StringArray, StringViewArray, UInt32Array, UInt64Array,
+    make_array,
 };
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result};
@@ -745,6 +746,11 @@ struct BuildSide {
     matched: Vec<bool>,
 }
 
+struct MatchedBatch {
+    batch: RecordBatch,
+    vcf_indices: Vec<u32>,
+}
+
 /// Cached column indices for the cache (probe) schema, resolved once on first batch.
 struct CacheIndices {
     chrom: usize,
@@ -765,13 +771,13 @@ enum StreamState {
     /// emitted, so that the colocated sink is fully populated before any
     /// downstream consumer sees the first batch.
     ProcessProbe,
-    /// Emitting buffered matched rows (probe complete, sink is final).
-    EmitMatched,
-    /// Emitting unmatched build rows.
-    EmitUnmatched,
+    /// Emitting ordered lookup output (probe complete, sink is final).
+    EmitOrdered,
     /// Done.
     Done,
 }
+
+const LOOKUP_OUTPUT_BATCH_SIZE: usize = 8192;
 
 /// Cached column indices for co-located metadata in the cache schema.
 struct ColocIndices {
@@ -813,12 +819,14 @@ struct VariantLookupStream {
     colocated_sink: Option<ColocatedSink>,
     /// Cached column indices for co-located collection.
     coloc_indices: Option<ColocIndices>,
-    /// Matched batches buffered during probe (emitted after probe completes
-    /// so that the colocated sink is fully populated).
+    /// Matched batches buffered during probe so that the colocated sink is
+    /// fully populated before downstream annotation uses it.
     /// Note: peaks at the full chromosome result set size (~300K rows for
     /// chr1 WGS). This is inherent — the colocated sink must be complete
     /// before downstream annotation can use it.
-    matched_batches: VecDeque<RecordBatch>,
+    matched_batches: VecDeque<MatchedBatch>,
+    /// Final lookup output in original VCF row order, including unmatched rows.
+    ordered_batches: VecDeque<RecordBatch>,
 }
 
 impl VariantLookupStream {
@@ -853,6 +861,7 @@ impl VariantLookupStream {
             colocated_sink,
             coloc_indices: None,
             matched_batches: VecDeque::new(),
+            ordered_batches: VecDeque::new(),
         }
     }
 
@@ -1166,7 +1175,7 @@ impl VariantLookupStream {
     /// unusable cache rows, match by exact hash or overlap window, and collect
     /// colocated entries during the same scan with identical compare-existing
     /// semantics.
-    fn process_probe_batch(&mut self, cache_batch: &RecordBatch) -> Result<Option<RecordBatch>> {
+    fn process_probe_batch(&mut self, cache_batch: &RecordBatch) -> Result<Option<MatchedBatch>> {
         let cache_schema = cache_batch.schema();
         self.resolve_cache_indices(&cache_schema)?;
         self.resolve_coloc_indices(&cache_schema);
@@ -1452,6 +1461,7 @@ impl VariantLookupStream {
         }
 
         // Build output batch: VCF columns via take + cache columns via take.
+        let matched_vcf_indices = vcf_indices.clone();
         let vcf_take = UInt32Array::from(vcf_indices);
         let cache_take = UInt32Array::from(cache_indices_buf);
 
@@ -1485,53 +1495,91 @@ impl VariantLookupStream {
         }
 
         RecordBatch::try_new(self.schema.clone(), output_columns)
-            .map(Some)
+            .map(|batch| {
+                Some(MatchedBatch {
+                    batch,
+                    vcf_indices: matched_vcf_indices,
+                })
+            })
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
     }
 
-    /// Emit unmatched VCF rows with NULL cache columns.
-    fn emit_unmatched(&mut self) -> Result<Option<RecordBatch>> {
-        let build = match self.build.as_ref() {
-            Some(b) => b,
-            None => return Ok(None),
+    fn prepare_ordered_output_batches(&mut self) -> Result<()> {
+        let Some(build) = self.build.as_ref() else {
+            return Ok(());
         };
+        let total_rows = build.vcf_batch.num_rows();
+        let matched_batches: Vec<MatchedBatch> = self.matched_batches.drain(..).collect();
+        let mut matched_by_vcf: Vec<Option<(usize, usize)>> = vec![None; total_rows];
 
-        let unmatched_indices: Vec<u32> = build
-            .matched
-            .iter()
-            .enumerate()
-            .filter(|(_, m)| !**m)
-            .map(|(i, _)| i as u32)
+        for (batch_idx, matched) in matched_batches.iter().enumerate() {
+            for (row_idx, &vcf_idx) in matched.vcf_indices.iter().enumerate() {
+                let vcf_idx = vcf_idx as usize;
+                if vcf_idx < total_rows {
+                    matched_by_vcf[vcf_idx] = Some((batch_idx, row_idx));
+                }
+            }
+        }
+
+        let matched_data_by_cache_col: Vec<Vec<_>> = (0..self.cache_columns.len())
+            .map(|cache_col_offset| {
+                matched_batches
+                    .iter()
+                    .map(|matched| {
+                        matched
+                            .batch
+                            .column(self.num_vcf_cols + cache_col_offset)
+                            .to_data()
+                    })
+                    .collect()
+            })
             .collect();
 
-        if unmatched_indices.is_empty() {
-            return Ok(None);
+        for chunk_start in (0..total_rows).step_by(LOOKUP_OUTPUT_BATCH_SIZE) {
+            let chunk_end = (chunk_start + LOOKUP_OUTPUT_BATCH_SIZE).min(total_rows);
+            let chunk_len = chunk_end - chunk_start;
+            let take_indices =
+                UInt32Array::from_iter_values((chunk_start..chunk_end).map(|idx| idx as u32));
+            let mut output_columns: Vec<ArrayRef> = Vec::with_capacity(self.schema.fields().len());
+
+            for col_idx in 0..self.num_vcf_cols {
+                let taken = datafusion::arrow::compute::take(
+                    build.vcf_batch.column(col_idx),
+                    &take_indices,
+                    None,
+                )
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                output_columns.push(taken);
+            }
+
+            for (cache_col_offset, source_data) in matched_data_by_cache_col.iter().enumerate() {
+                if source_data.is_empty() {
+                    let field = self.schema.field(self.num_vcf_cols + cache_col_offset);
+                    output_columns.push(datafusion::arrow::array::new_null_array(
+                        field.data_type(),
+                        chunk_len,
+                    ));
+                } else {
+                    let source_refs: Vec<_> = source_data.iter().collect();
+                    let mut mutable = MutableArrayData::new(source_refs, true, chunk_len);
+                    for row_idx in chunk_start..chunk_end {
+                        if let Some((matched_batch_idx, matched_row_idx)) = matched_by_vcf[row_idx]
+                        {
+                            mutable.extend(matched_batch_idx, matched_row_idx, matched_row_idx + 1);
+                        } else {
+                            mutable.extend_nulls(1);
+                        }
+                    }
+                    output_columns.push(make_array(mutable.freeze()));
+                }
+            }
+
+            let batch = RecordBatch::try_new(self.schema.clone(), output_columns)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+            self.ordered_batches.push_back(batch);
         }
 
-        let take_indices = UInt32Array::from(unmatched_indices);
-        let mut output_columns: Vec<ArrayRef> = Vec::with_capacity(self.schema.fields().len());
-
-        for col_idx in 0..self.num_vcf_cols {
-            let taken = datafusion::arrow::compute::take(
-                build.vcf_batch.column(col_idx),
-                &take_indices,
-                None,
-            )
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-            output_columns.push(taken);
-        }
-
-        let num_unmatched = take_indices.len();
-        for i in 0..self.cache_columns.len() {
-            let field = self.schema.field(self.num_vcf_cols + i);
-            let null_array =
-                datafusion::arrow::array::new_null_array(field.data_type(), num_unmatched);
-            output_columns.push(null_array);
-        }
-
-        RecordBatch::try_new(self.schema.clone(), output_columns)
-            .map(Some)
-            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+        Ok(())
     }
 }
 
@@ -1588,27 +1636,21 @@ impl Stream for VariantLookupStream {
                         Poll::Ready(None) => {
                             self.cache_stream = None;
                             // Probe complete — colocated sink is final.
-                            self.state = StreamState::EmitMatched;
+                            if let Err(e) = self.prepare_ordered_output_batches() {
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                            self.state = StreamState::EmitOrdered;
                             continue;
                         }
                         Poll::Pending => return Poll::Pending,
                     }
                 }
-                StreamState::EmitMatched => {
-                    if let Some(batch) = self.matched_batches.pop_front() {
+                StreamState::EmitOrdered => {
+                    if let Some(batch) = self.ordered_batches.pop_front() {
                         return Poll::Ready(Some(Ok(batch)));
                     }
-                    // All matched emitted — continue to unmatched.
-                    self.state = StreamState::EmitUnmatched;
-                    continue;
-                }
-                StreamState::EmitUnmatched => {
                     self.state = StreamState::Done;
-                    match self.emit_unmatched() {
-                        Ok(Some(batch)) => return Poll::Ready(Some(Ok(batch))),
-                        Ok(None) => return Poll::Ready(None),
-                        Err(e) => return Poll::Ready(Some(Err(e))),
-                    }
+                    return Poll::Ready(None);
                 }
                 StreamState::Done => return Poll::Ready(None),
             }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -24,7 +24,8 @@ pub type OnBatchWritten = Box<dyn Fn(usize, usize, usize) + Send + Sync>;
 pub struct AnnotateVcfConfig {
     /// Enable all annotation features (80-field CSQ, SIFT, PolyPhen, etc.).
     pub everything: bool,
-    /// Add standalone `PICK=1` markers for the chosen transcript per allele+gene.
+    /// Add standalone `PICK=1` markers for VEP `--flag_pick_allele_gene`.
+    /// VEP also marks retained non-transcript regulatory/motif/intergenic rows.
     pub flag_pick_allele_gene: bool,
     /// Override Ensembl VEP's default pick-order ranking.
     pub pick_order: Option<String>,
@@ -200,14 +201,14 @@ impl AnnotateVcfConfig {
 }
 
 fn csq_header_description(config: &AnnotateVcfConfig) -> String {
-    let field_names = crate::golden_benchmark::csq_field_names_for_mode(
+    let field_names = crate::golden_benchmark::csq_field_names_for_mode_with_pick(
         config.everything,
         config.refseq,
         config.merged,
         config.flag_pick_allele_gene,
     );
     let format_list = field_names.join("|");
-    format!("Consequence annotations from Ensembl VEP. Format: {format_list}")
+    format!("Consequence annotations from annotate_vep. Format: {format_list}")
 }
 
 /// Annotate a VCF file and write results to an output VCF.
@@ -472,7 +473,7 @@ mod tests {
         };
 
         let description = csq_header_description(&config);
-        assert!(description.starts_with("Consequence annotations from Ensembl VEP. Format: "));
+        assert!(description.starts_with("Consequence annotations from annotate_vep. Format: "));
         assert!(description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
     }
 }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -24,6 +24,18 @@ pub type OnBatchWritten = Box<dyn Fn(usize, usize, usize) + Send + Sync>;
 pub struct AnnotateVcfConfig {
     /// Enable all annotation features (80-field CSQ, SIFT, PolyPhen, etc.).
     pub everything: bool,
+    /// Emit one consequence per variant (`--pick`).
+    pub pick: bool,
+    /// Emit one consequence per allele (`--pick_allele`).
+    pub pick_allele: bool,
+    /// Emit one consequence per gene and retain non-transcript rows (`--per_gene`).
+    pub per_gene: bool,
+    /// Emit one consequence per allele and gene (`--pick_allele_gene`).
+    pub pick_allele_gene: bool,
+    /// Add standalone `PICK=1` marker for one consequence per variant.
+    pub flag_pick: bool,
+    /// Add standalone `PICK=1` marker for one consequence per allele.
+    pub flag_pick_allele: bool,
     /// Add standalone `PICK=1` markers for VEP `--flag_pick_allele_gene`.
     /// VEP also marks retained non-transcript regulatory/motif/intergenic rows.
     pub flag_pick_allele_gene: bool,
@@ -79,6 +91,12 @@ impl Default for AnnotateVcfConfig {
     fn default() -> Self {
         Self {
             everything: false,
+            pick: false,
+            pick_allele: false,
+            per_gene: false,
+            pick_allele_gene: false,
+            flag_pick: false,
+            flag_pick_allele: false,
             flag_pick_allele_gene: false,
             pick_order: None,
             extended_probes: false,
@@ -124,11 +142,18 @@ impl AnnotateVcfConfig {
         if self.everything {
             opts.insert("everything".into(), serde_json::Value::Bool(true));
         }
-        if self.flag_pick_allele_gene {
-            opts.insert(
-                "flag_pick_allele_gene".into(),
-                serde_json::Value::Bool(true),
-            );
+        for (key, enabled) in [
+            ("pick", self.pick),
+            ("pick_allele", self.pick_allele),
+            ("per_gene", self.per_gene),
+            ("pick_allele_gene", self.pick_allele_gene),
+            ("flag_pick", self.flag_pick),
+            ("flag_pick_allele", self.flag_pick_allele),
+            ("flag_pick_allele_gene", self.flag_pick_allele_gene),
+        ] {
+            if enabled {
+                opts.insert(key.into(), serde_json::Value::Bool(true));
+            }
         }
         if let Some(ref pick_order) = self.pick_order {
             opts.insert(
@@ -198,6 +223,10 @@ impl AnnotateVcfConfig {
         }
         serde_json::to_string(&serde_json::Value::Object(opts)).unwrap()
     }
+
+    fn include_pick_output(&self) -> bool {
+        self.flag_pick || self.flag_pick_allele || self.flag_pick_allele_gene
+    }
 }
 
 fn csq_header_description(config: &AnnotateVcfConfig) -> String {
@@ -205,7 +234,7 @@ fn csq_header_description(config: &AnnotateVcfConfig) -> String {
         config.everything,
         config.refseq,
         config.merged,
-        config.flag_pick_allele_gene,
+        config.include_pick_output(),
     );
     let format_list = field_names.join("|");
     format!("Consequence annotations from annotate_vep. Format: {format_list}")
@@ -453,6 +482,12 @@ mod tests {
     fn test_to_options_json_emits_pick_flags() {
         let config = AnnotateVcfConfig {
             everything: true,
+            pick: true,
+            pick_allele: true,
+            per_gene: true,
+            pick_allele_gene: true,
+            flag_pick: true,
+            flag_pick_allele: true,
             flag_pick_allele_gene: true,
             pick_order: Some("mane_select,tsl,canonical".to_string()),
             ..Default::default()
@@ -460,6 +495,12 @@ mod tests {
 
         let json = config.to_options_json();
         assert!(json.contains("\"everything\":true"));
+        assert!(json.contains("\"pick\":true"));
+        assert!(json.contains("\"pick_allele\":true"));
+        assert!(json.contains("\"per_gene\":true"));
+        assert!(json.contains("\"pick_allele_gene\":true"));
+        assert!(json.contains("\"flag_pick\":true"));
+        assert!(json.contains("\"flag_pick_allele\":true"));
         assert!(json.contains("\"flag_pick_allele_gene\":true"));
         assert!(json.contains("\"pick_order\":\"mane_select,tsl,canonical\""));
     }
@@ -475,5 +516,17 @@ mod tests {
         let description = csq_header_description(&config);
         assert!(description.starts_with("Consequence annotations from annotate_vep. Format: "));
         assert!(description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
+    }
+
+    #[test]
+    fn test_csq_header_description_omits_pick_for_filter_modes() {
+        let config = AnnotateVcfConfig {
+            everything: true,
+            pick_allele_gene: true,
+            ..Default::default()
+        };
+
+        let description = csq_header_description(&config);
+        assert!(!description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
     }
 }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -24,6 +24,10 @@ pub type OnBatchWritten = Box<dyn Fn(usize, usize, usize) + Send + Sync>;
 pub struct AnnotateVcfConfig {
     /// Enable all annotation features (80-field CSQ, SIFT, PolyPhen, etc.).
     pub everything: bool,
+    /// Add standalone `PICK=1` markers for the chosen transcript per allele+gene.
+    pub flag_pick_allele_gene: bool,
+    /// Override Ensembl VEP's default pick-order ranking.
+    pub pick_order: Option<String>,
     /// Use interval-overlap fallback for shifted indels.
     pub extended_probes: bool,
     /// Path to indexed reference FASTA (required for `everything` / `hgvs`).
@@ -74,6 +78,8 @@ impl Default for AnnotateVcfConfig {
     fn default() -> Self {
         Self {
             everything: false,
+            flag_pick_allele_gene: false,
+            pick_order: None,
             extended_probes: false,
             reference_fasta_path: None,
             use_fjall: false,
@@ -116,6 +122,18 @@ impl AnnotateVcfConfig {
         opts.insert("partitioned".into(), serde_json::Value::Bool(true));
         if self.everything {
             opts.insert("everything".into(), serde_json::Value::Bool(true));
+        }
+        if self.flag_pick_allele_gene {
+            opts.insert(
+                "flag_pick_allele_gene".into(),
+                serde_json::Value::Bool(true),
+            );
+        }
+        if let Some(ref pick_order) = self.pick_order {
+            opts.insert(
+                "pick_order".into(),
+                serde_json::Value::String(pick_order.clone()),
+            );
         }
         if self.extended_probes {
             opts.insert("extended_probes".into(), serde_json::Value::Bool(true));
@@ -179,6 +197,17 @@ impl AnnotateVcfConfig {
         }
         serde_json::to_string(&serde_json::Value::Object(opts)).unwrap()
     }
+}
+
+fn csq_header_description(config: &AnnotateVcfConfig) -> String {
+    let field_names = crate::golden_benchmark::csq_field_names_for_mode(
+        config.everything,
+        config.refseq,
+        config.merged,
+        config.flag_pick_allele_gene,
+    );
+    let format_list = field_names.join("|");
+    format!("Consequence annotations from Ensembl VEP. Format: {format_list}")
 }
 
 /// Annotate a VCF file and write results to an output VCF.
@@ -356,14 +385,7 @@ pub async fn annotate_to_vcf(
                 }
                 arrow_field.with_metadata(merged_metadata)
             } else if name == "CSQ" {
-                let field_names = crate::golden_benchmark::csq_field_names_for_mode(
-                    config.everything,
-                    config.refseq,
-                    config.merged,
-                );
-                let format_list = field_names.join("|");
-                let description =
-                    format!("Consequence annotations from annotate_vep. Format: {format_list}");
+                let description = csq_header_description(config);
                 let mut meta = std::collections::HashMap::new();
                 meta.insert("bio.vcf.field.field_type".to_string(), "INFO".to_string());
                 meta.insert("bio.vcf.field.description".to_string(), description);
@@ -420,4 +442,37 @@ pub async fn annotate_to_vcf(
     pb.finish_and_clear();
 
     Ok(total_rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_options_json_emits_pick_flags() {
+        let config = AnnotateVcfConfig {
+            everything: true,
+            flag_pick_allele_gene: true,
+            pick_order: Some("mane_select,tsl,canonical".to_string()),
+            ..Default::default()
+        };
+
+        let json = config.to_options_json();
+        assert!(json.contains("\"everything\":true"));
+        assert!(json.contains("\"flag_pick_allele_gene\":true"));
+        assert!(json.contains("\"pick_order\":\"mane_select,tsl,canonical\""));
+    }
+
+    #[test]
+    fn test_csq_header_description_matches_vep_pick_layout() {
+        let config = AnnotateVcfConfig {
+            everything: true,
+            flag_pick_allele_gene: true,
+            ..Default::default()
+        };
+
+        let description = csq_header_description(&config);
+        assert!(description.starts_with("Consequence annotations from Ensembl VEP. Format: "));
+        assert!(description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
+    }
 }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -20,6 +20,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 /// Used by Python wrappers (vepyr) to drive tqdm progress bars in Jupyter.
 pub type OnBatchWritten = Box<dyn Fn(usize, usize, usize) + Send + Sync>;
 
+/// Ensembl VEP release/115 default `--buffer_size`.
+pub const VEP_DEFAULT_BUFFER_SIZE: usize = 5000;
+
 /// Configuration for VCF annotation output.
 pub struct AnnotateVcfConfig {
     /// Enable all annotation features (80-field CSQ, SIFT, PolyPhen, etc.).
@@ -77,6 +80,8 @@ pub struct AnnotateVcfConfig {
     pub failed: Option<i64>,
     /// Upstream/downstream distance for transcript overlap.
     pub distance: Option<String>,
+    /// Number of input variants per VEP-style annotation buffer.
+    pub buffer_size: usize,
     /// Output compression type.
     pub compression: VcfCompressionType,
     /// Show an indicatif progress bar on stderr (for Rust CLI).
@@ -117,6 +122,7 @@ impl Default for AnnotateVcfConfig {
             exclude_predicted: false,
             failed: None,
             distance: None,
+            buffer_size: VEP_DEFAULT_BUFFER_SIZE,
             compression: VcfCompressionType::Plain,
             show_progress: false,
             on_batch_written: None,
@@ -128,6 +134,7 @@ impl std::fmt::Debug for AnnotateVcfConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AnnotateVcfConfig")
             .field("everything", &self.everything)
+            .field("buffer_size", &self.buffer_size)
             .field("compression", &self.compression)
             .field("show_progress", &self.show_progress)
             .field("on_batch_written", &self.on_batch_written.is_some())
@@ -221,6 +228,10 @@ impl AnnotateVcfConfig {
         if let Some(ref dist) = self.distance {
             opts.insert("distance".into(), serde_json::Value::String(dist.clone()));
         }
+        opts.insert(
+            "buffer_size".into(),
+            serde_json::Value::Number(serde_json::Number::from(self.buffer_size)),
+        );
         serde_json::to_string(&serde_json::Value::Object(opts)).unwrap()
     }
 
@@ -503,6 +514,17 @@ mod tests {
         assert!(json.contains("\"flag_pick_allele\":true"));
         assert!(json.contains("\"flag_pick_allele_gene\":true"));
         assert!(json.contains("\"pick_order\":\"mane_select,tsl,canonical\""));
+    }
+
+    #[test]
+    fn test_to_options_json_emits_buffer_size() {
+        let config = AnnotateVcfConfig {
+            buffer_size: 1234,
+            ..Default::default()
+        };
+
+        let json = config.to_options_json();
+        assert!(json.contains("\"buffer_size\":1234"));
     }
 
     #[test]

--- a/openspec/changes/add-vep-pick-modes/.openspec.yaml
+++ b/openspec/changes/add-vep-pick-modes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-25

--- a/openspec/changes/add-vep-pick-modes/README.md
+++ b/openspec/changes/add-vep-pick-modes/README.md
@@ -1,0 +1,3 @@
+# add-vep-pick-modes
+
+Support Ensembl VEP pick and flag-pick modes in annotate_vep

--- a/openspec/changes/add-vep-pick-modes/design.md
+++ b/openspec/changes/add-vep-pick-modes/design.md
@@ -1,0 +1,159 @@
+## Context
+
+Ensembl VEP release 115 implements all pick and flag-pick modes in `Bio::EnsEMBL::VEP::OutputFactory`. The modes share one ranking function (`pick_worst_VariationFeatureOverlapAllele`) and differ mainly by grouping policy and whether selected entries replace or merely mark the full consequence set.
+
+The current Rust implementation already has the difficult ranking pieces:
+- `PickCriterion` and `pick_order` parsing
+- VEP-style default order: `mane_select,mane_plus_clinical,canonical,appris,tsl,biotype,ccds,rank,length,ensembl,refseq`
+- progressive tie filtering in `pick_worst_assignment`
+- transcript length, APPRIS, TSL, source, rank, MANE, canonical, CCDS, and biotype scoring
+- `flag_pick_allele_gene` marking with a standalone CSQ `PICK` field
+
+The missing piece is the full option matrix: all grouping modes, filtering modes, flagging modes, schema/header behavior, and downstream API exposure.
+
+The current `vepyr` fast e2e runner normalizes input with `bcftools norm -m -both` before annotation. That means benchmark rows are split into one ALT allele per row, so `pick` and `pick_allele` behave the same in the current e2e path, as do `per_gene` and `pick_allele_gene`. The upstream implementation should still use VEP-compatible allele grouping so it does not encode the normalized-input assumption into the core picker.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Match Ensembl VEP release 115 pick/flag-pick behavior for small variants in `annotate_vep`.
+- Reuse the existing ranking criteria implementation instead of introducing a second picker.
+- Preserve default output when no pick mode is enabled.
+- Keep CSQ and typed list columns aligned after filtering or flagging.
+- Expose the full option surface through `AnnotateVcfConfig` and `vepyr.annotate`.
+- Validate against normalized `bcftools norm -m -both` e2e inputs first.
+
+**Non-Goals:**
+- Implement `--most_severe` or `--summary`; those are separate output-shaping modes.
+- Change consequence classification or HGVS generation.
+- Guarantee byte-for-byte VCF parity with Ensembl VEP; comparison remains CSQ field/entry parity.
+- Add unsplit multi-allelic e2e parity as a blocking requirement for the first implementation. The core grouping design must not prevent it later.
+- Add new cache formats or dependencies.
+
+## Decisions
+
+### Decision 1: Represent pick behavior as a single `PickMode`
+
+Introduce:
+
+```rust
+enum PickMode {
+    None,
+    Pick,
+    PickAllele,
+    PerGene,
+    PickAlleleGene,
+    FlagPick,
+    FlagPickAllele,
+    FlagPickAlleleGene,
+}
+```
+
+`PickFlags` becomes a configuration container with `mode: PickMode` and `pick_order: Vec<PickCriterion>`.
+
+When multiple mode booleans are present, use Ensembl VEP release 115 precedence from `OutputFactory.pm`:
+
+1. `pick`
+2. `pick_allele`
+3. `per_gene`
+4. `pick_allele_gene`
+5. `flag_pick`
+6. `flag_pick_allele`
+7. `flag_pick_allele_gene`
+
+Rationale: VEP's implementation uses an `if`/`elsif` chain rather than rejecting combinations. Mirroring that precedence avoids surprising comparison differences for users who pass multiple flags.
+
+### Decision 2: Use one selector for all modes
+
+Replace `mark_flag_pick_allele_gene` with a generic function that computes selected assignment indices:
+
+```rust
+fn apply_pick_mode(
+    assignments: Vec<TranscriptConsequence>,
+    ctx: &PreparedContext<'_>,
+    pick_flags: &PickFlags,
+    row_allele: &str,
+) -> Vec<TranscriptConsequence>
+```
+
+The function should:
+- build groups according to `PickMode`
+- use the existing `pick_worst_assignment` for each group
+- for filter modes, return only selected entries plus VEP-retained non-transcript entries for per-gene modes
+- for flag modes, set `picked = true` on selected entries and return all entries
+
+The grouping policies are:
+- `Pick` / `FlagPick`: all assignments for the row
+- `PickAllele` / `FlagPickAllele`: assignments grouped by CSQ allele
+- `PerGene`: transcript assignments grouped by gene, with non-transcript assignments retained
+- `PickAlleleGene` / `FlagPickAlleleGene`: first group by CSQ allele, then apply per-gene selection within each allele group
+
+For current normalized e2e inputs, all assignments in a row share the same `row_allele`. If future unsplit multi-allelic parsing produces multiple assignment alleles in one row, the grouping key must come from the assignment's CSQ allele, not from the row-level fallback.
+
+### Decision 3: Filter before CSQ serialization and typed-column population
+
+Filtering modes must modify `row_assignments` before `sorted_indices` is built. That keeps:
+- CSQ entries
+- typed list columns (`Feature`, `Consequence`, `PICK`, etc.)
+- feature ordering
+
+aligned by construction.
+
+Flag modes keep all assignments but set `picked = true` before serialization and typed-column population.
+
+### Decision 4: `PICK` field is emitted only for flag modes
+
+Ensembl VEP adds `PICK` as an output field for `flag_pick`, `flag_pick_allele`, and `flag_pick_allele_gene`. Plain filtering modes (`pick`, `pick_allele`, `per_gene`, `pick_allele_gene`) reduce the consequence set and do not require a `PICK` field.
+
+Therefore:
+- `include_pick_output` should be true only for `PickMode::Flag*`.
+- `golden_benchmark::csq_field_names_for_mode(..., include_pick)` remains the source of CSQ field layout.
+- The VCF CSQ header must include `|FLAGS|PICK|...` only for flag modes.
+
+### Decision 5: All pick modes bypass the synthetic cache-hit path
+
+The cache-hit fast path can synthesize a CSQ row from variation-cache consequence strings, but pick modes require ranking transcript/regulatory/motif assignment candidates. All modes except `None` must force transcript-engine evaluation when CSQ or typed annotation columns are requested.
+
+This generalizes the current `flag_pick_allele_gene` bypass.
+
+### Decision 6: Downstream exposure is a thin pass-through
+
+Add booleans to `AnnotateVcfConfig` and `vepyr.annotate` rather than adding a single stringly typed mode. This matches Ensembl VEP CLI names and keeps e2e profiles readable:
+
+```python
+vepyr.annotate(..., pick=True)
+vepyr.annotate(..., flag_pick_allele_gene=True, pick_order="...")
+```
+
+The Rust side remains responsible for VEP precedence if multiple booleans are true.
+
+### Decision 7: E2E validation starts from normalized input
+
+The e2e scripts already call `bcftools norm -m -both` unless `--no-normalize` is passed. Initial validation should explicitly record that:
+- `pick` and `pick_allele` are equivalent on normalized input
+- `per_gene` and `pick_allele_gene` are equivalent on normalized input
+- full unsplit multi-ALT parity can be added later without blocking this capability
+
+## Risks / Trade-offs
+
+- **Risk: multiple pick flags are passed together** -> Mitigation: mirror VEP release 115 precedence and add tests documenting the precedence.
+- **Risk: non-transcript entries in per-gene modes differ from VEP** -> Mitigation: port Ensembl's `pick_VariationFeatureOverlapAllele_per_gene` behavior: non-transcript assignments are retained, and flag per-gene modes mark retained non-transcript entries.
+- **Risk: filtered typed columns drift from CSQ ordering** -> Mitigation: apply filtering before `sorted_indices` and reuse the same `sorted_indices` for CSQ and typed columns.
+- **Risk: current rows are biallelic but future parser behavior changes** -> Mitigation: design grouping around CSQ allele value, using row-level allele only as the current fallback.
+- **Risk: e2e comparison hides unsplit multi-allelic bugs** -> Mitigation: document normalized e2e scope and add a small unit/integration fixture for allele grouping even before full unsplit VCF e2e.
+
+## Migration Plan
+
+1. Implement the upstream generalized picker behind existing option parsing.
+2. Preserve `flag_pick_allele_gene` behavior and tests as a compatibility baseline.
+3. Add new unit tests for each pick mode and precedence.
+4. Add `AnnotateVcfConfig` fields and update `vepyr` dependency pin.
+5. Add downstream wrapper parameters and e2e cache profiles.
+6. Run local upstream tests, downstream `cargo check`, and at least one normalized `chr22` e2e profile against Ensembl VEP.
+
+Rollback is straightforward: disable the new options in downstream profiles or revert the upstream change; default `annotate_vep` behavior is unchanged when no pick mode is set.
+
+## Open Questions
+
+- Should `most_severe_consequence` in `annotate_vep` remain based on all computed assignments for filter modes, or should it be recomputed from emitted assignments? Ensembl VEP VCF output has no equivalent scalar column, so this is a local API decision.
+- Should we add full unsplit multi-allelic VCF e2e parity now, or defer until `datafusion-bio-format-vcf` row semantics for multi-ALT records are explicitly specified?

--- a/openspec/changes/add-vep-pick-modes/proposal.md
+++ b/openspec/changes/add-vep-pick-modes/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+`annotate_vep` currently supports only the `flag_pick_allele_gene` subset of Ensembl VEP's pick-mode surface. To compare reliably against Ensembl VEP runs that use `--pick`, `--pick_allele`, `--per_gene`, `--pick_allele_gene`, or their flagging variants, the Rust VEP implementation needs the same grouping, filtering, and `PICK` emission behavior.
+
+The downstream `vepyr` e2e flow normalizes benchmark input with `bcftools norm -m -both`, so the first validation target can use split biallelic rows while the upstream implementation still models VEP's allele grouping semantics.
+
+## What Changes
+
+- Generalize the existing `PickFlags` / `mark_flag_pick_allele_gene` path into a shared VEP pick-mode engine.
+- Parse and support these `options_json` booleans:
+  - `pick`
+  - `pick_allele`
+  - `per_gene`
+  - `pick_allele_gene`
+  - `flag_pick`
+  - `flag_pick_allele`
+  - `flag_pick_allele_gene`
+- Keep the existing `pick_order` parser and ranking criteria, and use it for every pick/flag-pick mode.
+- Apply VEP release 115 mode precedence when multiple pick modes are enabled.
+- For filtering modes, emit only selected CSQ/typed annotation entries.
+- For flagging modes, retain all entries and add the standalone `PICK` field after `FLAGS`, marking selected entries with `PICK=1`.
+- Bypass the cache-hit synthetic CSQ fast path for all pick/flag-pick modes because ranking requires transcript-level consequence candidates.
+- Expose the full pick-mode option surface in the VCF sink and downstream `vepyr` wrapper.
+- Add e2e comparison profiles for at least the normalized merged-cache pick modes used by the current benchmark workflow.
+
+## Capabilities
+
+### New Capabilities
+
+- `vep-pick-modes`: Ensembl VEP-compatible pick and flag-pick modes for transcript consequence selection, CSQ shaping, typed annotation columns, and downstream VCF output.
+
+### Modified Capabilities
+
+- None. No archived base specs exist yet in `openspec/specs/`; this change introduces a new capability delta.
+
+## Impact
+
+- Affected upstream code:
+  - `datafusion/bio-function-vep/src/annotate_provider.rs`
+  - `datafusion/bio-function-vep/src/transcript_consequence.rs` if assignment-level allele metadata is needed beyond the current normalized-row path
+  - `datafusion/bio-function-vep/src/golden_benchmark.rs`
+  - `datafusion/bio-function-vep/src/vcf_sink.rs`
+  - `datafusion/bio-function-vep/src/annotate_table_function.rs` tests
+- Affected downstream code:
+  - `/Users/mwiewior/research/git/vepyr/src/annotate.rs`
+  - `/Users/mwiewior/research/git/vepyr/src/lib.rs`
+  - `/Users/mwiewior/research/git/vepyr/e2e-testing/scripts/run_annotation_fast.py`
+  - `/Users/mwiewior/research/git/vepyr/e2e-testing/scripts/run_annotation.py`
+- No new external dependencies.
+- No breaking change for existing default `annotate_vep` output when no pick mode is enabled.

--- a/openspec/changes/add-vep-pick-modes/specs/vep-pick-modes/spec.md
+++ b/openspec/changes/add-vep-pick-modes/specs/vep-pick-modes/spec.md
@@ -1,0 +1,195 @@
+## ADDED Requirements
+
+### Requirement: VEP Pick Mode Option Parsing
+The system SHALL parse Ensembl VEP-compatible pick and flag-pick options from `annotate_vep` `options_json`.
+
+The supported boolean options MUST include:
+- `pick`
+- `pick_allele`
+- `per_gene`
+- `pick_allele_gene`
+- `flag_pick`
+- `flag_pick_allele`
+- `flag_pick_allele_gene`
+
+The system MUST continue to parse `pick_order` as a comma-separated list of VEP ranking criteria.
+
+#### Scenario: No pick mode enabled
+- **WHEN** no pick or flag-pick option is set
+- **THEN** the system uses normal unfiltered consequence output
+- **AND** the CSQ schema does not include `PICK`
+
+#### Scenario: Single pick mode enabled
+- **WHEN** `options_json` contains `{"pick": true}`
+- **THEN** the system selects `PickMode::Pick`
+- **AND** it uses the configured or default `pick_order`
+
+#### Scenario: Multiple pick modes enabled
+- **WHEN** more than one pick or flag-pick option is set
+- **THEN** the system applies Ensembl VEP release 115 precedence: `pick`, `pick_allele`, `per_gene`, `pick_allele_gene`, `flag_pick`, `flag_pick_allele`, `flag_pick_allele_gene`
+- **AND** only the highest-precedence enabled mode controls output shaping
+
+#### Scenario: Invalid pick order criterion
+- **WHEN** `pick_order` contains an unsupported criterion
+- **THEN** `annotate_vep` fails with an execution error naming the invalid criterion
+
+#### Scenario: Empty pick order
+- **WHEN** `pick_order` parses to no criteria
+- **THEN** `annotate_vep` fails with an execution error stating that `pick_order` must contain at least one criterion
+
+### Requirement: Shared VEP Ranking Engine
+The system SHALL use one shared ranking engine for every pick and flag-pick mode.
+
+The ranking engine MUST:
+- use the default order `mane_select,mane_plus_clinical,canonical,appris,tsl,biotype,ccds,rank,length,ensembl,refseq`
+- allow callers to override the order via `pick_order`
+- apply criteria progressively, retaining only tied best candidates after each criterion
+- select the first remaining candidate after all criteria if ties remain
+- score lower values as better, matching Ensembl VEP release 115
+- use VEP-compatible transcript length scoring where longer transcripts rank better
+- rank `rank` by the most severe Sequence Ontology consequence on the assignment
+
+#### Scenario: Default ranking selects one candidate
+- **WHEN** multiple transcript consequences are candidates for one pick group
+- **AND** default `pick_order` yields a unique best candidate
+- **THEN** the system selects that candidate
+
+#### Scenario: Custom pick order changes winner
+- **WHEN** `pick_order` changes the leading criterion from `mane_select` to `rank`
+- **THEN** the system ranks candidates by consequence severity before later criteria
+- **AND** the selected candidate can differ from the default-order winner
+
+#### Scenario: Ties fall through to later criteria
+- **WHEN** two candidates tie on the first configured criterion
+- **THEN** the system keeps both candidates
+- **AND** evaluates the next configured criterion only on that tied subset
+
+#### Scenario: Ties remain after all criteria
+- **WHEN** candidates tie on every configured criterion
+- **THEN** the system selects the first candidate in deterministic feature-order input order
+
+### Requirement: Filtering Pick Modes
+The system SHALL support VEP-compatible filtering pick modes that reduce emitted consequence entries.
+
+Filtering modes MUST NOT add a `PICK` field to CSQ by default.
+
+#### Scenario: Pick one consequence per variant
+- **WHEN** `pick` is enabled
+- **THEN** the system emits exactly one selected consequence entry for the input variant
+- **AND** all non-selected consequence entries are omitted from CSQ and typed list columns
+
+#### Scenario: Pick one consequence per allele
+- **WHEN** `pick_allele` is enabled
+- **THEN** the system groups candidate consequences by CSQ allele value
+- **AND** emits exactly one selected consequence entry per allele group
+
+#### Scenario: Pick one consequence per gene
+- **WHEN** `per_gene` is enabled
+- **THEN** the system groups transcript consequence candidates by gene stable ID
+- **AND** emits one selected transcript consequence per gene group
+- **AND** retains non-transcript consequence entries that Ensembl VEP retains outside transcript gene groups
+
+#### Scenario: Pick one consequence per allele and gene
+- **WHEN** `pick_allele_gene` is enabled
+- **THEN** the system groups candidates by CSQ allele value
+- **AND** within each allele group, groups transcript candidates by gene stable ID
+- **AND** emits one selected transcript consequence per allele-plus-gene group
+- **AND** retains non-transcript consequence entries for each allele group according to VEP per-gene behavior
+
+#### Scenario: Normalized biallelic e2e input
+- **WHEN** input has been normalized with `bcftools norm -m -both`
+- **THEN** each VCF row has one ALT allele
+- **AND** `pick` and `pick_allele` select the same number of entries for that row
+- **AND** `per_gene` and `pick_allele_gene` select the same transcript groups for that row
+
+### Requirement: Flag Pick Modes
+The system SHALL support VEP-compatible flag-pick modes that retain all consequence entries and mark selected entries with `PICK=1`.
+
+Flag-pick modes MUST include a standalone `PICK` CSQ field immediately after `FLAGS`, and typed annotation output MUST expose a corresponding `PICK` list column aligned with other transcript-level list columns.
+
+#### Scenario: Flag one consequence per variant
+- **WHEN** `flag_pick` is enabled
+- **THEN** the system retains every consequence entry
+- **AND** marks exactly one selected entry with `PICK=1`
+- **AND** leaves unselected entries with an empty CSQ `PICK` field and null typed `PICK` value
+
+#### Scenario: Flag one consequence per allele
+- **WHEN** `flag_pick_allele` is enabled
+- **THEN** the system retains every consequence entry
+- **AND** marks exactly one selected entry per CSQ allele group with `PICK=1`
+
+#### Scenario: Flag one consequence per allele and gene
+- **WHEN** `flag_pick_allele_gene` is enabled
+- **THEN** the system retains every consequence entry
+- **AND** marks one selected transcript consequence per allele-plus-gene group with `PICK=1`
+- **AND** marks retained non-transcript entries according to VEP per-gene flagging behavior
+
+#### Scenario: CSQ header includes PICK for flag modes
+- **WHEN** any flag-pick mode is enabled
+- **THEN** the CSQ header field list includes `PICK`
+- **AND** `PICK` appears immediately after `FLAGS`
+
+### Requirement: Pick Modes Use Transcript Consequence Evaluation
+The system SHALL evaluate transcript consequences for all pick and flag-pick modes instead of using synthetic variation-cache CSQ rows.
+
+#### Scenario: Cache hit with pick mode
+- **WHEN** an input variant has a variation-cache consequence hit
+- **AND** any pick or flag-pick mode is enabled
+- **THEN** the system bypasses the synthetic cache-hit CSQ fast path
+- **AND** computes transcript/regulatory/motif assignments through the transcript consequence engine
+
+#### Scenario: Cache hit without pick mode
+- **WHEN** an input variant has a variation-cache consequence hit
+- **AND** no pick or flag-pick mode is enabled
+- **THEN** the system MAY use the existing synthetic cache-hit CSQ fast path
+
+### Requirement: CSQ and Typed Column Alignment
+The system SHALL keep CSQ entries and typed list annotation columns aligned after applying pick or flag-pick modes.
+
+#### Scenario: Filtering mode alignment
+- **WHEN** a filtering pick mode removes non-selected assignments
+- **THEN** the Nth emitted CSQ entry corresponds to the Nth element in typed list columns such as `Feature`, `Consequence`, `BIOTYPE`, and `PICK` when present
+
+#### Scenario: Flag mode alignment
+- **WHEN** a flag-pick mode retains all assignments
+- **THEN** typed list column order matches CSQ entry order
+- **AND** the typed `PICK` list marks the same entries that have CSQ `PICK=1`
+
+#### Scenario: Deterministic output order
+- **WHEN** selected assignments are emitted
+- **THEN** the system orders entries using the existing VEP-compatible CSQ sort order: transcript entries first, regulatory entries next, motif entries next, and deterministic feature ID ordering within feature type
+
+### Requirement: Downstream VCF and Python API Exposure
+The system SHALL expose the full pick and flag-pick option surface through the VCF sink and downstream `vepyr` wrapper.
+
+#### Scenario: Rust VCF sink emits pick options
+- **WHEN** an `AnnotateVcfConfig` enables any pick or flag-pick option
+- **THEN** `AnnotateVcfConfig::to_options_json` serializes the corresponding boolean option
+- **AND** serializes `pick_order` when provided
+
+#### Scenario: Python annotate passes pick options
+- **WHEN** `vepyr.annotate` is called with a pick or flag-pick keyword argument
+- **THEN** the downstream wrapper passes the option through to the Rust VCF annotation config
+
+#### Scenario: Existing downstream behavior remains compatible
+- **WHEN** existing code calls `vepyr.annotate(..., flag_pick_allele_gene=True, pick_order=...)`
+- **THEN** the call continues to work
+- **AND** produces the same PICK semantics as before unless corrected for VEP parity by this change
+
+### Requirement: Normalized E2E Pick-Mode Comparison
+The system SHALL provide e2e comparison coverage for pick and flag-pick modes using the existing normalized VCF workflow.
+
+#### Scenario: Fast runner normalizes input
+- **WHEN** `e2e-testing/scripts/run_annotation_fast.py` is run without `--no-normalize`
+- **THEN** it normalizes the input VCF with `bcftools norm -m -both`
+- **AND** annotates the chromosome-extracted normalized VCF
+
+#### Scenario: Flag-pick comparison reports PICK parity
+- **WHEN** a fast e2e profile enables a flag-pick mode
+- **THEN** the generated comparison report includes shared CSQ field comparison for `PICK`
+- **AND** `PICK` mismatches are counted in `field_mismatch_counts` when present
+
+#### Scenario: Filtering pick comparison reports selected-entry parity
+- **WHEN** a fast e2e profile enables a filtering pick mode
+- **THEN** the generated comparison report compares selected CSQ entries against the matching Ensembl VEP output
+- **AND** reports CSQ entry-count mismatches when selected entry counts differ

--- a/openspec/changes/add-vep-pick-modes/tasks.md
+++ b/openspec/changes/add-vep-pick-modes/tasks.md
@@ -36,16 +36,16 @@
 
 ## 5. Downstream vepyr Integration
 
-- [ ] 5.1 Update `/Users/mwiewior/research/git/vepyr` dependency pin after upstream commit lands
-- [ ] 5.2 Add `pick`, `pick_allele`, `per_gene`, `pick_allele_gene`, `flag_pick`, and `flag_pick_allele` parameters to `vepyr.annotate`
-- [ ] 5.3 Keep existing `flag_pick_allele_gene` and `pick_order` downstream API behavior
-- [ ] 5.4 Pass all new parameters through to `AnnotateVcfConfig`
-- [ ] 5.5 Add or update downstream tests/checks for Python API parameter forwarding
+- [x] 5.1 Update `/Users/mwiewior/research/git/vepyr` dependency pin after upstream commit lands
+- [x] 5.2 Add `pick`, `pick_allele`, `per_gene`, `pick_allele_gene`, `flag_pick`, and `flag_pick_allele` parameters to `vepyr.annotate`
+- [x] 5.3 Keep existing `flag_pick_allele_gene` and `pick_order` downstream API behavior
+- [x] 5.4 Pass all new parameters through to `AnnotateVcfConfig`
+- [x] 5.5 Add or update downstream tests/checks for Python API parameter forwarding
 
 ## 6. E2E Validation
 
-- [ ] 6.1 Add `run_annotation_fast.py` cache profiles for at least `merged_pick`, `merged_pick_allele`, `merged_per_gene`, and `merged_pick_allele_gene`
-- [ ] 6.2 Document that the fast e2e runner normalizes input with `bcftools norm -m -both`
+- [x] 6.1 Add `run_annotation_fast.py` cache profiles for at least `merged_pick`, `merged_pick_allele`, `merged_per_gene`, and `merged_pick_allele_gene`
+- [x] 6.2 Document that the fast e2e runner normalizes input with `bcftools norm -m -both`
 - [ ] 6.3 Run `chr22` normalized comparisons against Ensembl VEP for flag and filtering modes
 - [ ] 6.4 Verify `PICK` field parity for flag modes
 - [ ] 6.5 Verify selected CSQ entry parity for filtering modes
@@ -53,8 +53,8 @@
 
 ## 7. Final Verification
 
-- [ ] 7.1 Run `cargo fmt --all -- --check`
+- [x] 7.1 Run `cargo fmt --all -- --check`
 - [x] 7.2 Run `cargo test -p datafusion-bio-function-vep --lib`
-- [ ] 7.3 Run `cargo check -p datafusion-bio-function-vep --all-targets`
-- [ ] 7.4 Run downstream `cargo check` in `/Users/mwiewior/research/git/vepyr`
+- [x] 7.3 Run `cargo check -p datafusion-bio-function-vep --all-targets`
+- [x] 7.4 Run downstream `cargo check` in `/Users/mwiewior/research/git/vepyr`
 - [ ] 7.5 Push upstream and downstream commits

--- a/openspec/changes/add-vep-pick-modes/tasks.md
+++ b/openspec/changes/add-vep-pick-modes/tasks.md
@@ -57,4 +57,4 @@
 - [x] 7.2 Run `cargo test -p datafusion-bio-function-vep --lib`
 - [x] 7.3 Run `cargo check -p datafusion-bio-function-vep --all-targets`
 - [x] 7.4 Run downstream `cargo check` in `/Users/mwiewior/research/git/vepyr`
-- [ ] 7.5 Push upstream and downstream commits
+- [x] 7.5 Push upstream and downstream commits

--- a/openspec/changes/add-vep-pick-modes/tasks.md
+++ b/openspec/changes/add-vep-pick-modes/tasks.md
@@ -1,0 +1,60 @@
+## 1. Upstream Picker Configuration
+
+- [x] 1.1 Replace `PickFlags.flag_pick_allele_gene` with `PickMode` plus `pick_order`
+- [x] 1.2 Parse `pick`, `pick_allele`, `per_gene`, `pick_allele_gene`, `flag_pick`, `flag_pick_allele`, and `flag_pick_allele_gene` from `options_json`
+- [x] 1.3 Preserve existing `pick_order` parsing and error messages for invalid or empty criteria
+- [x] 1.4 Implement VEP release 115 precedence when multiple pick modes are enabled
+- [x] 1.5 Add unit tests for mode parsing, default mode, and multi-flag precedence
+
+## 2. Upstream Selection Engine
+
+- [x] 2.1 Replace `mark_flag_pick_allele_gene` with a generic `apply_pick_mode` / selection helper
+- [x] 2.2 Implement all-assignment grouping for `pick` and `flag_pick`
+- [x] 2.3 Implement allele grouping for `pick_allele` and `flag_pick_allele`
+- [x] 2.4 Implement per-gene grouping for `per_gene`
+- [x] 2.5 Implement allele-plus-gene grouping for `pick_allele_gene` and `flag_pick_allele_gene`
+- [x] 2.6 Preserve VEP behavior for non-transcript assignments in per-gene modes
+- [x] 2.7 Apply filtering before CSQ sorting and typed-column population
+- [x] 2.8 Add unit tests for every mode using small synthetic assignments
+
+## 3. CSQ Schema and Annotation Output
+
+- [x] 3.1 Compute `include_pick_output` from flag modes only
+- [x] 3.2 Ensure `PICK` is inserted after `FLAGS` in CSQ headers for `flag_pick`, `flag_pick_allele`, and `flag_pick_allele_gene`
+- [x] 3.3 Ensure filtering modes do not emit a `PICK` CSQ field by default
+- [x] 3.4 Generalize cache-hit fast-path bypass from `flag_pick_allele_gene` to all non-`None` pick modes
+- [x] 3.5 Add `annotate_table_function` tests for CSQ entry counts and selected features per mode
+- [x] 3.6 Add tests that typed list columns stay aligned with CSQ entries after filtering and flagging
+- [x] 3.7 Decide and document `most_severe_consequence` behavior for filter modes
+
+## 4. VCF Sink and Benchmark Helpers
+
+- [x] 4.1 Add all pick/flag-pick booleans to `AnnotateVcfConfig`
+- [x] 4.2 Serialize all enabled pick/flag-pick booleans in `AnnotateVcfConfig::to_options_json`
+- [x] 4.3 Update `vcf_sink` tests for CSQ header layout in flag modes
+- [x] 4.4 Update golden comparison helpers if they need to select CSQ field names by pick mode instead of a single boolean
+
+## 5. Downstream vepyr Integration
+
+- [ ] 5.1 Update `/Users/mwiewior/research/git/vepyr` dependency pin after upstream commit lands
+- [ ] 5.2 Add `pick`, `pick_allele`, `per_gene`, `pick_allele_gene`, `flag_pick`, and `flag_pick_allele` parameters to `vepyr.annotate`
+- [ ] 5.3 Keep existing `flag_pick_allele_gene` and `pick_order` downstream API behavior
+- [ ] 5.4 Pass all new parameters through to `AnnotateVcfConfig`
+- [ ] 5.5 Add or update downstream tests/checks for Python API parameter forwarding
+
+## 6. E2E Validation
+
+- [ ] 6.1 Add `run_annotation_fast.py` cache profiles for at least `merged_pick`, `merged_pick_allele`, `merged_per_gene`, and `merged_pick_allele_gene`
+- [ ] 6.2 Document that the fast e2e runner normalizes input with `bcftools norm -m -both`
+- [ ] 6.3 Run `chr22` normalized comparisons against Ensembl VEP for flag and filtering modes
+- [ ] 6.4 Verify `PICK` field parity for flag modes
+- [ ] 6.5 Verify selected CSQ entry parity for filtering modes
+- [ ] 6.6 Capture report JSON paths and summary metrics in the implementation PR
+
+## 7. Final Verification
+
+- [ ] 7.1 Run `cargo fmt --all -- --check`
+- [x] 7.2 Run `cargo test -p datafusion-bio-function-vep --lib`
+- [ ] 7.3 Run `cargo check -p datafusion-bio-function-vep --all-targets`
+- [ ] 7.4 Run downstream `cargo check` in `/Users/mwiewior/research/git/vepyr`
+- [ ] 7.5 Push upstream and downstream commits


### PR DESCRIPTION
## Summary
- add `annotate_vep` support for `flag_pick_allele_gene` and configurable `pick_order`
- bypass the cache-hit synthetic CSQ fast path when pick mode needs transcript-level evaluation
- align the picker with Ensembl VEP release 115 ranking semantics and add traceability comments
- preserve raw `_source_cache` for exact source ranking while keeping normalized `SOURCE` output
- keep the public `csq_field_names_for_mode(everything, refseq, merged)` API and add a pick-aware helper
- add integration and unit coverage for custom ordering, cache-hit behavior, exact source matching, APPRIS grading, CDS-length ranking, and missing-gene handling

## Testing
- `cargo fmt --all`
- `cargo test -p datafusion-bio-function-vep --lib pick`
- `cargo test -p datafusion-bio-function-vep --lib parse_transcript_raw_metadata`
- `cargo test -p datafusion-bio-function-vep --lib csq_field_names`
- `cargo test -p datafusion-bio-function-vep --lib`
- `cargo test -p datafusion-bio-function-vep --examples`

## Note
- `flag_pick_allele_gene` emits a standalone `PICK` CSQ sub-field and typed `PICK` column. Matching VEP, retained non-transcript regulatory/motif/intergenic rows are also marked with `PICK=1`.