### PR TITLE
chore: update lz4_flex security dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,7 +1223,7 @@ dependencies = [
  "futures",
  "indicatif",
  "log",
- "lz4_flex 0.12.0",
+ "lz4_flex 0.12.1",
  "noodles-core 0.16.0",
  "noodles-fasta",
  "noodles-vcf 0.80.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
@@ -2909,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
 dependencies = [
  "twox-hash",
 ]

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -16,7 +16,7 @@ log.workspace = true
 async-trait = "0.1.88"
 fjall = { version = "3.1.1", optional = true }
 arrow-ipc = { version = "56", features = ["lz4", "zstd"], optional = true }
-lz4_flex = { version = "0.12.0", optional = true }
+lz4_flex = { version = "0.12.1", optional = true }
 zstd = { version = "0.13.3", optional = true }
 ahash = { version = "0.8.6", optional = true }
 flate2 = "1.1.0"


### PR DESCRIPTION
## Summary
- bump `lz4_flex` from `0.12.0` to `0.12.1`
- refresh `Cargo.lock`

## Verification
- `cargo check`
