### PR TITLE
Fix partitioned range UDTF correctness for merge/complement/subtract

### DIFF
--- a/datafusion/bio-function-ranges/src/complement.rs
+++ b/datafusion/bio-function-ranges/src/complement.rs
@@ -13,7 +13,7 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
@@ -190,6 +190,20 @@ impl ExecutionPlan for ComplementExec {
 
     fn properties(&self) -> &PlanProperties {
         &self.cache
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        let mut distributions = vec![Distribution::HashPartitioned(vec![Arc::new(Column::new(
+            self.columns.0.as_str(),
+            0,
+        ))])];
+        if self.view.is_some() {
+            distributions.push(Distribution::HashPartitioned(vec![Arc::new(Column::new(
+                self.view_columns.0.as_str(),
+                0,
+            ))]));
+        }
+        distributions
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/datafusion/bio-function-ranges/src/complement.rs
+++ b/datafusion/bio-function-ranges/src/complement.rs
@@ -15,7 +15,6 @@ use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskCo
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
@@ -92,32 +91,12 @@ impl TableProvider for ComplementProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let target_partitions = self
-            .session
-            .state()
-            .config()
-            .options()
-            .execution
-            .target_partitions;
-
         let input_df = self.session.table(&self.table).await?.select_columns(&[
             &self.columns.0,
             &self.columns.1,
             &self.columns.2,
         ])?;
         let input_plan = input_df.create_physical_plan().await?;
-        let input_partitions = input_plan.output_partitioning().partition_count();
-        let input_plan: Arc<dyn ExecutionPlan> = if input_partitions > 1 || target_partitions > 1 {
-            Arc::new(RepartitionExec::try_new(
-                input_plan,
-                Partitioning::Hash(
-                    vec![Arc::new(Column::new(self.columns.0.as_str(), 0))],
-                    target_partitions.max(1),
-                ),
-            )?)
-        } else {
-            input_plan
-        };
 
         let view_plan = if let Some(view_name) = &self.view_table {
             let view_df = self.session.table(view_name).await?.select_columns(&[
@@ -126,18 +105,6 @@ impl TableProvider for ComplementProvider {
                 &self.view_columns.2,
             ])?;
             let plan = view_df.create_physical_plan().await?;
-            let view_partitions = plan.output_partitioning().partition_count();
-            let plan: Arc<dyn ExecutionPlan> = if view_partitions > 1 || target_partitions > 1 {
-                Arc::new(RepartitionExec::try_new(
-                    plan,
-                    Partitioning::Hash(
-                        vec![Arc::new(Column::new(self.view_columns.0.as_str(), 0))],
-                        target_partitions.max(1),
-                    ),
-                )?)
-            } else {
-                plan
-            };
             Some(plan)
         } else {
             None

--- a/datafusion/bio-function-ranges/src/merge.rs
+++ b/datafusion/bio-function-ranges/src/merge.rs
@@ -12,7 +12,7 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
@@ -165,6 +165,13 @@ impl ExecutionPlan for MergeExec {
 
     fn properties(&self) -> &PlanProperties {
         &self.cache
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::HashPartitioned(vec![Arc::new(Column::new(
+            self.columns.0.as_str(),
+            0,
+        ))])]
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/datafusion/bio-function-ranges/src/merge.rs
+++ b/datafusion/bio-function-ranges/src/merge.rs
@@ -14,7 +14,6 @@ use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskCo
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
@@ -89,33 +88,12 @@ impl TableProvider for MergeProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let target_partitions = self
-            .session
-            .state()
-            .config()
-            .options()
-            .execution
-            .target_partitions;
-
         let input_df = self.session.table(&self.table).await?.select_columns(&[
             &self.columns.0,
             &self.columns.1,
             &self.columns.2,
         ])?;
         let input_plan = input_df.create_physical_plan().await?;
-        let input_partitions = input_plan.output_partitioning().partition_count();
-        let input_plan: Arc<dyn ExecutionPlan> = if input_partitions > 1 || target_partitions > 1 {
-            Arc::new(RepartitionExec::try_new(
-                input_plan,
-                Partitioning::Hash(
-                    vec![Arc::new(Column::new(self.columns.0.as_str(), 0))],
-                    target_partitions.max(1),
-                ),
-            )?)
-        } else {
-            input_plan
-        };
-
         let output_partitions = input_plan.output_partitioning().partition_count();
 
         Ok(Arc::new(MergeExec {

--- a/datafusion/bio-function-ranges/src/subtract.rs
+++ b/datafusion/bio-function-ranges/src/subtract.rs
@@ -14,7 +14,7 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
@@ -196,6 +196,7 @@ impl TableProvider for SubtractProvider {
             right: right_plan,
             left_columns: Arc::new(self.left_columns.clone()),
             right_columns: Arc::new(self.right_columns.clone()),
+            left_contig_col_idx: contig_col_idx,
             strict: self.filter_op == FilterOp::Strict,
             has_extra_cols: self.has_extra_cols,
             cache: PlanProperties::new(
@@ -215,6 +216,7 @@ struct SubtractExec {
     right: Arc<dyn ExecutionPlan>,
     left_columns: Arc<(String, String, String)>,
     right_columns: Arc<(String, String, String)>,
+    left_contig_col_idx: usize,
     strict: bool,
     has_extra_cols: bool,
     cache: PlanProperties,
@@ -239,6 +241,19 @@ impl ExecutionPlan for SubtractExec {
         &self.cache
     }
 
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![
+            Distribution::HashPartitioned(vec![Arc::new(Column::new(
+                self.left_columns.0.as_str(),
+                self.left_contig_col_idx,
+            ))]),
+            Distribution::HashPartitioned(vec![Arc::new(Column::new(
+                self.right_columns.0.as_str(),
+                0,
+            ))]),
+        ]
+    }
+
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.left, &self.right]
     }
@@ -259,6 +274,7 @@ impl ExecutionPlan for SubtractExec {
             right: Arc::clone(&children[1]),
             left_columns: Arc::clone(&self.left_columns),
             right_columns: Arc::clone(&self.right_columns),
+            left_contig_col_idx: self.left_contig_col_idx,
             strict: self.strict,
             has_extra_cols: self.has_extra_cols,
             cache: PlanProperties::new(

--- a/datafusion/bio-function-ranges/src/subtract.rs
+++ b/datafusion/bio-function-ranges/src/subtract.rs
@@ -16,7 +16,6 @@ use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskCo
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
@@ -120,14 +119,6 @@ impl TableProvider for SubtractProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let target_partitions = self
-            .session
-            .state()
-            .config()
-            .options()
-            .execution
-            .target_partitions;
-
         let left_df = if self.has_extra_cols {
             self.session.table(&self.left_table).await?
         } else {
@@ -148,22 +139,6 @@ impl TableProvider for SubtractProvider {
             0
         };
 
-        let left_partitions = left_plan.output_partitioning().partition_count();
-        let left_plan: Arc<dyn ExecutionPlan> = if left_partitions > 1 || target_partitions > 1 {
-            Arc::new(RepartitionExec::try_new(
-                left_plan,
-                Partitioning::Hash(
-                    vec![Arc::new(Column::new(
-                        self.left_columns.0.as_str(),
-                        contig_col_idx,
-                    ))],
-                    target_partitions.max(1),
-                ),
-            )?)
-        } else {
-            left_plan
-        };
-
         // Right table always selects only 3 range columns
         let right_df = self
             .session
@@ -175,18 +150,6 @@ impl TableProvider for SubtractProvider {
                 &self.right_columns.2,
             ])?;
         let right_plan = right_df.create_physical_plan().await?;
-        let right_partitions = right_plan.output_partitioning().partition_count();
-        let right_plan: Arc<dyn ExecutionPlan> = if right_partitions > 1 || target_partitions > 1 {
-            Arc::new(RepartitionExec::try_new(
-                right_plan,
-                Partitioning::Hash(
-                    vec![Arc::new(Column::new(self.right_columns.0.as_str(), 0))],
-                    target_partitions.max(1),
-                ),
-            )?)
-        } else {
-            right_plan
-        };
 
         let output_partitions = left_plan.output_partitioning().partition_count();
 

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -3431,24 +3431,29 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
     write_parquet_parts(
         &left_dir,
         &[
-            build_interval_batch(&[("chr1", 0, 10), ("chr1", 20, 30)])?,
-            build_interval_batch(&[("chr1", 8, 25)])?,
+            build_interval_batch(&[("chr1", 0, 10), ("chr1", 20, 30), ("chr2", 10, 20)])?,
+            build_interval_batch(&[("chr1", 8, 25), ("chr2", 30, 40)])?,
         ],
     )?;
     write_parquet_parts(
         &right_dir,
         &[
-            build_interval_batch(&[("chr1", 5, 10)])?,
-            build_interval_batch(&[("chr1", 20, 25)])?,
+            build_interval_batch(&[("chr1", 5, 10), ("chr2", 12, 15)])?,
+            build_interval_batch(&[("chr1", 20, 25), ("chr2", 35, 36)])?,
         ],
     )?;
-    write_parquet_parts(&view_dir, &[build_interval_batch(&[("chr1", 0, 40)])?])?;
+    write_parquet_parts(
+        &view_dir,
+        &[build_interval_batch(&[("chr1", 0, 40), ("chr2", 0, 50)])?],
+    )?;
 
     let expected_merge = [
         "+--------+-----------+---------+-------------+",
         "| contig | pos_start | pos_end | n_intervals |",
         "+--------+-----------+---------+-------------+",
         "| chr1   | 0         | 30      | 3           |",
+        "| chr2   | 10        | 20      | 1           |",
+        "| chr2   | 30        | 40      | 1           |",
         "+--------+-----------+---------+-------------+",
     ];
     let expected_complement = [
@@ -3456,7 +3461,20 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
         "| contig | pos_start | pos_end |",
         "+--------+-----------+---------+",
         "| chr1   | 30        | 40      |",
+        "| chr2   | 0         | 10      |",
+        "| chr2   | 20        | 30      |",
+        "| chr2   | 40        | 50      |",
         "+--------+-----------+---------+",
+    ];
+    let expected_complement_no_view = [
+        "+--------+-----------+---------------------+",
+        "| contig | pos_start | pos_end             |",
+        "+--------+-----------+---------------------+",
+        "| chr1   | 30        | 9223372036854775807 |",
+        "| chr2   | 0         | 10                  |",
+        "| chr2   | 20        | 30                  |",
+        "| chr2   | 40        | 9223372036854775807 |",
+        "+--------+-----------+---------------------+",
     ];
     let expected_subtract = [
         "+--------+-----------+---------+",
@@ -3465,6 +3483,10 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
         "| chr1   | 0         | 5       |",
         "| chr1   | 10        | 20      |",
         "| chr1   | 25        | 30      |",
+        "| chr2   | 10        | 12      |",
+        "| chr2   | 15        | 20      |",
+        "| chr2   | 30        | 35      |",
+        "| chr2   | 36        | 40      |",
         "+--------+-----------+---------+",
     ];
 
@@ -3488,6 +3510,13 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
             .await?;
         assert_batches_sorted_eq!(expected_complement, &complement);
 
+        let complement_no_view = ctx
+            .sql("SELECT * FROM complement('left_t') ORDER BY contig, pos_start, pos_end")
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(expected_complement_no_view, &complement_no_view);
+
         let subtract = ctx
             .sql("SELECT * FROM subtract('left_t', 'right_t') ORDER BY contig, pos_start, pos_end")
             .await?
@@ -3509,15 +3538,21 @@ async fn test_subtract_partitioned_parquet_preserves_extra_columns_with_custom_o
     write_parquet_parts(
         &left_dir,
         &[
-            build_left_extra_batch(&[("BRCA1", "chr1", 0, 30, 0.95)])?,
-            build_left_extra_batch(&[("TP53", "chr1", 40, 60, 0.75)])?,
+            build_left_extra_batch(&[
+                ("BRCA1", "chr1", 0, 30, 0.95),
+                ("EGFR", "chr2", 10, 20, 0.80),
+            ])?,
+            build_left_extra_batch(&[
+                ("TP53", "chr1", 40, 60, 0.75),
+                ("MYC", "chr2", 30, 40, 0.65),
+            ])?,
         ],
     )?;
     write_parquet_parts(
         &right_dir,
         &[
-            build_interval_batch(&[("chr1", 5, 25)])?,
-            build_interval_batch(&[("chr1", 45, 50)])?,
+            build_interval_batch(&[("chr1", 5, 25), ("chr2", 12, 15)])?,
+            build_interval_batch(&[("chr1", 45, 50), ("chr2", 35, 36)])?,
         ],
     )?;
 
@@ -3529,6 +3564,10 @@ async fn test_subtract_partitioned_parquet_preserves_extra_columns_with_custom_o
         "| BRCA1 | chr1   | 25        | 30      | 0.95  |",
         "| TP53  | chr1   | 40        | 45      | 0.75  |",
         "| TP53  | chr1   | 50        | 60      | 0.75  |",
+        "| EGFR  | chr2   | 10        | 12      | 0.8   |",
+        "| EGFR  | chr2   | 15        | 20      | 0.8   |",
+        "| MYC   | chr2   | 30        | 35      | 0.65  |",
+        "| MYC   | chr2   | 36        | 40      | 0.65  |",
         "+-------+--------+-----------+---------+-------+",
     ];
 
@@ -3560,18 +3599,21 @@ async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result
     write_parquet_parts(
         &left_dir,
         &[
-            build_interval_batch(&[("chr1", 0, 10), ("chr1", 20, 30)])?,
-            build_interval_batch(&[("chr1", 8, 25)])?,
+            build_interval_batch(&[("chr1", 0, 10), ("chr1", 20, 30), ("chr2", 10, 20)])?,
+            build_interval_batch(&[("chr1", 8, 25), ("chr2", 30, 40)])?,
         ],
     )?;
     write_parquet_parts(
         &right_dir,
         &[
-            build_interval_batch(&[("chr1", 5, 10)])?,
-            build_interval_batch(&[("chr1", 20, 25)])?,
+            build_interval_batch(&[("chr1", 5, 10), ("chr2", 12, 15)])?,
+            build_interval_batch(&[("chr1", 20, 25), ("chr2", 35, 36)])?,
         ],
     )?;
-    write_parquet_parts(&view_dir, &[build_interval_batch(&[("chr1", 0, 40)])?])?;
+    write_parquet_parts(
+        &view_dir,
+        &[build_interval_batch(&[("chr1", 0, 40), ("chr2", 0, 50)])?],
+    )?;
 
     let ctx = create_bio_session_with_target_partitions_and_batch_size(4, 1);
     register_partitioned_parquet_table(&ctx, "left_t", &left_dir).await?;
@@ -3582,7 +3624,7 @@ async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result
     assert_contains!(merge_plan.as_str(), "MergeExec");
     assert_contains!(
         merge_plan.as_str(),
-        "RepartitionExec: partitioning=Hash([contig@0], 4)"
+        "RepartitionExec: partitioning=Hash([contig@0]"
     );
 
     let complement_plan =
@@ -3590,7 +3632,7 @@ async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result
     assert_contains!(complement_plan.as_str(), "ComplementExec");
     assert!(
         complement_plan
-            .matches("RepartitionExec: partitioning=Hash([contig@0], 4)")
+            .matches("RepartitionExec: partitioning=Hash([contig@0]")
             .count()
             >= 2,
         "expected two hash repartitions in complement plan, got:\n{complement_plan}"
@@ -3600,7 +3642,7 @@ async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result
     assert_contains!(subtract_plan.as_str(), "SubtractExec");
     assert!(
         subtract_plan
-            .matches("RepartitionExec: partitioning=Hash([contig@0], 4)")
+            .matches("RepartitionExec: partitioning=Hash([contig@0]")
             .count()
             >= 2,
         "expected two hash repartitions in subtract plan, got:\n{subtract_plan}"

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1,11 +1,16 @@
+use std::fs::{self, File};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use datafusion::arrow::array::{Int64Array, RecordBatch};
+use datafusion::arrow::array::{Float64Array, Int64Array, RecordBatch, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::assert_batches_sorted_eq;
 use datafusion::common::assert_contains;
 use datafusion::config::ConfigOptions;
 use datafusion::error::Result;
+use datafusion::parquet::arrow::ArrowWriter;
 use datafusion::prelude::{SessionConfig, SessionContext};
 
 use datafusion_bio_function_ranges::session_context::{Algorithm, BioConfig, BioSessionExt};
@@ -437,6 +442,21 @@ fn create_bio_session_with_target_partitions(target_partitions: usize) -> Sessio
     ctx
 }
 
+fn create_bio_session_with_target_partitions_and_batch_size(
+    target_partitions: usize,
+    batch_size: usize,
+) -> SessionContext {
+    let config = SessionConfig::from(ConfigOptions::new())
+        .with_option_extension(BioConfig::default())
+        .with_information_schema(true)
+        .with_repartition_joins(false)
+        .with_target_partitions(target_partitions)
+        .with_batch_size(batch_size);
+    let ctx = SessionContext::new_with_bio(config);
+    register_ranges_functions(&ctx);
+    ctx
+}
+
 async fn collect_udtf_query_with_partitions(
     target_partitions: usize,
     query: &str,
@@ -444,6 +464,114 @@ async fn collect_udtf_query_with_partitions(
     let ctx = create_bio_session_with_target_partitions(target_partitions);
     init_ranges_tables(&ctx).await?;
     ctx.sql(query).await?.collect().await
+}
+
+struct TempDirGuard {
+    path: PathBuf,
+}
+
+impl TempDirGuard {
+    fn new(prefix: &str) -> Result<Self> {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{prefix}-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn build_interval_batch(rows: &[(&str, i64, i64)]) -> Result<RecordBatch> {
+    let schema = Arc::new(Schema::new(vec![
+        Arc::new(Field::new("contig", DataType::Utf8, false)),
+        Arc::new(Field::new("pos_start", DataType::Int64, false)),
+        Arc::new(Field::new("pos_end", DataType::Int64, false)),
+    ]));
+    let contigs = StringArray::from_iter_values(rows.iter().map(|(contig, _, _)| *contig));
+    let starts = Int64Array::from(rows.iter().map(|(_, start, _)| *start).collect::<Vec<_>>());
+    let ends = Int64Array::from(rows.iter().map(|(_, _, end)| *end).collect::<Vec<_>>());
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![Arc::new(contigs), Arc::new(starts), Arc::new(ends)],
+    )?)
+}
+
+fn build_left_extra_batch(rows: &[(&str, &str, i64, i64, f64)]) -> Result<RecordBatch> {
+    let schema = Arc::new(Schema::new(vec![
+        Arc::new(Field::new("gene", DataType::Utf8, false)),
+        Arc::new(Field::new("contig", DataType::Utf8, false)),
+        Arc::new(Field::new("pos_start", DataType::Int64, false)),
+        Arc::new(Field::new("pos_end", DataType::Int64, false)),
+        Arc::new(Field::new("score", DataType::Float64, false)),
+    ]));
+    let genes = StringArray::from_iter_values(rows.iter().map(|(gene, _, _, _, _)| *gene));
+    let contigs = StringArray::from_iter_values(rows.iter().map(|(_, contig, _, _, _)| *contig));
+    let starts = Int64Array::from(
+        rows.iter()
+            .map(|(_, _, start, _, _)| *start)
+            .collect::<Vec<_>>(),
+    );
+    let ends = Int64Array::from(
+        rows.iter()
+            .map(|(_, _, _, end, _)| *end)
+            .collect::<Vec<_>>(),
+    );
+    let scores = Float64Array::from(
+        rows.iter()
+            .map(|(_, _, _, _, score)| *score)
+            .collect::<Vec<_>>(),
+    );
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(genes),
+            Arc::new(contigs),
+            Arc::new(starts),
+            Arc::new(ends),
+            Arc::new(scores),
+        ],
+    )?)
+}
+
+fn write_parquet_parts(dir: &Path, batches: &[RecordBatch]) -> Result<()> {
+    fs::create_dir_all(dir)?;
+    for (idx, batch) in batches.iter().enumerate() {
+        let file = File::create(dir.join(format!("part-{idx:02}.parquet")))?;
+        let mut writer = ArrowWriter::try_new(file, batch.schema(), None)?;
+        writer.write(batch)?;
+        writer.close()?;
+    }
+    Ok(())
+}
+
+async fn register_partitioned_parquet_table(
+    ctx: &SessionContext,
+    name: &str,
+    dir: &Path,
+) -> Result<()> {
+    let create = format!(
+        "CREATE EXTERNAL TABLE {name} STORED AS PARQUET LOCATION '{}'",
+        dir.display()
+    );
+    ctx.sql(&create).await?;
+    Ok(())
+}
+
+async fn explain_query(ctx: &SessionContext, query: &str) -> Result<String> {
+    let explain = format!("EXPLAIN VERBOSE {query}");
+    let plan = ctx.sql(&explain).await?.collect().await?;
+    Ok(pretty_format_batches(&plan)?.to_string())
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -3289,6 +3417,194 @@ async fn test_range_udtfs_target_partitions_invariant() -> Result<()> {
             "partition-invariance failed for {name}"
         );
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> Result<()> {
+    let tmp = TempDirGuard::new("df-bio-issue-372")?;
+    let left_dir = tmp.path().join("left");
+    let right_dir = tmp.path().join("right");
+    let view_dir = tmp.path().join("view");
+
+    write_parquet_parts(
+        &left_dir,
+        &[
+            build_interval_batch(&[("chr1", 0, 10), ("chr1", 20, 30)])?,
+            build_interval_batch(&[("chr1", 8, 25)])?,
+        ],
+    )?;
+    write_parquet_parts(
+        &right_dir,
+        &[
+            build_interval_batch(&[("chr1", 5, 10)])?,
+            build_interval_batch(&[("chr1", 20, 25)])?,
+        ],
+    )?;
+    write_parquet_parts(&view_dir, &[build_interval_batch(&[("chr1", 0, 40)])?])?;
+
+    let expected_merge = [
+        "+--------+-----------+---------+-------------+",
+        "| contig | pos_start | pos_end | n_intervals |",
+        "+--------+-----------+---------+-------------+",
+        "| chr1   | 0         | 30      | 3           |",
+        "+--------+-----------+---------+-------------+",
+    ];
+    let expected_complement = [
+        "+--------+-----------+---------+",
+        "| contig | pos_start | pos_end |",
+        "+--------+-----------+---------+",
+        "| chr1   | 30        | 40      |",
+        "+--------+-----------+---------+",
+    ];
+    let expected_subtract = [
+        "+--------+-----------+---------+",
+        "| contig | pos_start | pos_end |",
+        "+--------+-----------+---------+",
+        "| chr1   | 0         | 5       |",
+        "| chr1   | 10        | 20      |",
+        "| chr1   | 25        | 30      |",
+        "+--------+-----------+---------+",
+    ];
+
+    for target_partitions in [1, 2, 4] {
+        let ctx = create_bio_session_with_target_partitions_and_batch_size(target_partitions, 1);
+        register_partitioned_parquet_table(&ctx, "left_t", &left_dir).await?;
+        register_partitioned_parquet_table(&ctx, "right_t", &right_dir).await?;
+        register_partitioned_parquet_table(&ctx, "view_t", &view_dir).await?;
+
+        let merge = ctx
+            .sql("SELECT * FROM merge('left_t') ORDER BY contig, pos_start, pos_end, n_intervals")
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(expected_merge, &merge);
+
+        let complement = ctx
+            .sql("SELECT * FROM complement('left_t', 'view_t') ORDER BY contig, pos_start, pos_end")
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(expected_complement, &complement);
+
+        let subtract = ctx
+            .sql("SELECT * FROM subtract('left_t', 'right_t') ORDER BY contig, pos_start, pos_end")
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(expected_subtract, &subtract);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subtract_partitioned_parquet_preserves_extra_columns_with_custom_order() -> Result<()>
+{
+    let tmp = TempDirGuard::new("df-bio-issue-372-extra-cols")?;
+    let left_dir = tmp.path().join("left-extra");
+    let right_dir = tmp.path().join("right-mask");
+
+    write_parquet_parts(
+        &left_dir,
+        &[
+            build_left_extra_batch(&[("BRCA1", "chr1", 0, 30, 0.95)])?,
+            build_left_extra_batch(&[("TP53", "chr1", 40, 60, 0.75)])?,
+        ],
+    )?;
+    write_parquet_parts(
+        &right_dir,
+        &[
+            build_interval_batch(&[("chr1", 5, 25)])?,
+            build_interval_batch(&[("chr1", 45, 50)])?,
+        ],
+    )?;
+
+    let expected = [
+        "+-------+--------+-----------+---------+-------+",
+        "| gene  | contig | pos_start | pos_end | score |",
+        "+-------+--------+-----------+---------+-------+",
+        "| BRCA1 | chr1   | 0         | 5       | 0.95  |",
+        "| BRCA1 | chr1   | 25        | 30      | 0.95  |",
+        "| TP53  | chr1   | 40        | 45      | 0.75  |",
+        "| TP53  | chr1   | 50        | 60      | 0.75  |",
+        "+-------+--------+-----------+---------+-------+",
+    ];
+
+    for target_partitions in [1, 2, 4] {
+        let ctx = create_bio_session_with_target_partitions_and_batch_size(target_partitions, 1);
+        register_partitioned_parquet_table(&ctx, "left_extra", &left_dir).await?;
+        register_partitioned_parquet_table(&ctx, "right_mask", &right_dir).await?;
+
+        let result = ctx
+            .sql(
+                "SELECT * FROM subtract('left_extra', 'right_mask', 'contig', 'pos_start', 'pos_end') ORDER BY contig, pos_start, gene",
+            )
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(expected, &result);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result<()> {
+    let tmp = TempDirGuard::new("df-bio-issue-372-explain")?;
+    let left_dir = tmp.path().join("left");
+    let right_dir = tmp.path().join("right");
+    let view_dir = tmp.path().join("view");
+
+    write_parquet_parts(
+        &left_dir,
+        &[
+            build_interval_batch(&[("chr1", 0, 10), ("chr1", 20, 30)])?,
+            build_interval_batch(&[("chr1", 8, 25)])?,
+        ],
+    )?;
+    write_parquet_parts(
+        &right_dir,
+        &[
+            build_interval_batch(&[("chr1", 5, 10)])?,
+            build_interval_batch(&[("chr1", 20, 25)])?,
+        ],
+    )?;
+    write_parquet_parts(&view_dir, &[build_interval_batch(&[("chr1", 0, 40)])?])?;
+
+    let ctx = create_bio_session_with_target_partitions_and_batch_size(4, 1);
+    register_partitioned_parquet_table(&ctx, "left_t", &left_dir).await?;
+    register_partitioned_parquet_table(&ctx, "right_t", &right_dir).await?;
+    register_partitioned_parquet_table(&ctx, "view_t", &view_dir).await?;
+
+    let merge_plan = explain_query(&ctx, "SELECT * FROM merge('left_t')").await?;
+    assert_contains!(merge_plan.as_str(), "MergeExec");
+    assert_contains!(
+        merge_plan.as_str(),
+        "RepartitionExec: partitioning=Hash([contig@0], 4)"
+    );
+
+    let complement_plan =
+        explain_query(&ctx, "SELECT * FROM complement('left_t', 'view_t')").await?;
+    assert_contains!(complement_plan.as_str(), "ComplementExec");
+    assert!(
+        complement_plan
+            .matches("RepartitionExec: partitioning=Hash([contig@0], 4)")
+            .count()
+            >= 2,
+        "expected two hash repartitions in complement plan, got:\n{complement_plan}"
+    );
+
+    let subtract_plan = explain_query(&ctx, "SELECT * FROM subtract('left_t', 'right_t')").await?;
+    assert_contains!(subtract_plan.as_str(), "SubtractExec");
+    assert!(
+        subtract_plan
+            .matches("RepartitionExec: partitioning=Hash([contig@0], 4)")
+            .count()
+            >= 2,
+        "expected two hash repartitions in subtract plan, got:\n{subtract_plan}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fix correctness bugs in range UDTFs on physically partitioned input when `datafusion.execution.target_partitions > 1`.

Affected operators:
- `merge`
- `complement`
- `subtract`

This addresses the upstream execution-layer bug reported from `biodatageeks/polars-bio#372`.

## Root cause

These operators execute partition-locally, but they rely on contig co-location to be correct.

Previously they inserted `RepartitionExec(Hash(contig))` manually during `scan()`. DataFusion's physical optimizer strips top-level distribution-changing operators and rebuilds them from each exec node's declared requirements. Because these custom execs did not declare `required_input_distribution()`, the optimizer was free to replace the needed hash co-location with ordinary partition-local execution / parallelism.

## Fix

Declare `required_input_distribution()` on:
- `MergeExec`
- `ComplementExec`
- `SubtractExec`

so DataFusion preserves or reconstructs `HashPartitioned(contig)` before execution.

The `subtract` fix also covers the extra-columns path where the left-side `contig` column is not at index `0`.

## Tests

Added regression coverage for:
1. multi-file parquet correctness for `merge` / `complement` / `subtract` at `target_partitions = 1, 2, 4`
2. partitioned parquet `subtract` with extra left-side columns and non-leading `contig`
3. `EXPLAIN VERBOSE` assertions that the physical plan contains the required `Hash(contig)` repartition

## Verification

```bash
cargo fmt --all
cargo test -p datafusion-bio-function-ranges
```