### PR TITLE
fix: cluster partition invariance

### DIFF
--- a/datafusion/bio-function-ranges/src/cluster.rs
+++ b/datafusion/bio-function-ranges/src/cluster.rs
@@ -13,9 +13,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_expr::{Distribution, EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
-use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
@@ -110,14 +109,6 @@ impl TableProvider for ClusterProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let target_partitions = self
-            .session
-            .state()
-            .config()
-            .options()
-            .execution
-            .target_partitions;
-
         let input_df = if self.has_extra_cols {
             self.session.table(&self.table).await?
         } else {
@@ -135,28 +126,13 @@ impl TableProvider for ClusterProvider {
             0
         };
 
-        let input_partitions = input_plan.output_partitioning().partition_count();
-        let input_plan: Arc<dyn ExecutionPlan> = if input_partitions > 1 || target_partitions > 1 {
-            Arc::new(RepartitionExec::try_new(
-                input_plan,
-                Partitioning::Hash(
-                    vec![Arc::new(Column::new(
-                        self.columns.0.as_str(),
-                        contig_col_idx,
-                    ))],
-                    target_partitions.max(1),
-                ),
-            )?)
-        } else {
-            input_plan
-        };
-
         let output_partitions = input_plan.output_partitioning().partition_count();
 
         Ok(Arc::new(ClusterExec {
             schema: self.schema.clone(),
             input: input_plan,
             columns: Arc::new(self.columns.clone()),
+            contig_col_idx,
             min_dist: self.min_dist,
             strict: self.filter_op == FilterOp::Strict,
             has_extra_cols: self.has_extra_cols,
@@ -175,6 +151,7 @@ struct ClusterExec {
     schema: SchemaRef,
     input: Arc<dyn ExecutionPlan>,
     columns: Arc<(String, String, String)>,
+    contig_col_idx: usize,
     min_dist: i64,
     strict: bool,
     has_extra_cols: bool,
@@ -204,6 +181,13 @@ impl ExecutionPlan for ClusterExec {
         &self.cache
     }
 
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::HashPartitioned(vec![Arc::new(Column::new(
+            self.columns.0.as_str(),
+            self.contig_col_idx,
+        ))])]
+    }
+
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
     }
@@ -222,6 +206,7 @@ impl ExecutionPlan for ClusterExec {
             schema: self.schema.clone(),
             input: Arc::clone(&children[0]),
             columns: Arc::clone(&self.columns),
+            contig_col_idx: self.contig_col_idx,
             min_dist: self.min_dist,
             strict: self.strict,
             has_extra_cols: self.has_extra_cols,

--- a/datafusion/bio-function-ranges/src/cluster.rs
+++ b/datafusion/bio-function-ranges/src/cluster.rs
@@ -374,7 +374,9 @@ impl ClusterIdCoordinator {
             }
         }
 
-        state.wakers.push(cx.waker().clone());
+        if !state.wakers.iter().any(|waker| waker.will_wake(cx.waker())) {
+            state.wakers.push(cx.waker().clone());
+        }
         Poll::Pending
     }
 
@@ -945,5 +947,31 @@ impl Stream for ClusterStreamExtra {
 impl RecordBatchStream for ClusterStreamExtra {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::task::noop_waker;
+
+    #[test]
+    fn poll_cluster_offsets_deduplicates_repeated_wakers() {
+        let coordinator = ClusterIdCoordinator::new(2);
+        let counts = vec![("chr1".to_string(), 1)];
+        let waker = noop_waker();
+        let cx = &mut Context::from_waker(&waker);
+
+        assert!(matches!(
+            coordinator.poll_cluster_offsets(0, &counts, cx),
+            Poll::Pending
+        ));
+        assert_eq!(coordinator.state.lock().wakers.len(), 1);
+
+        assert!(matches!(
+            coordinator.poll_cluster_offsets(0, &counts, cx),
+            Poll::Pending
+        ));
+        assert_eq!(coordinator.state.lock().wakers.len(), 1);
     }
 }

--- a/datafusion/bio-function-ranges/src/cluster.rs
+++ b/datafusion/bio-function-ranges/src/cluster.rs
@@ -2,8 +2,9 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::{Context, Poll, Waker};
 
+use ahash::AHashMap;
 use async_trait::async_trait;
 use datafusion::arrow::array::{Int64Array, Int64Builder, RecordBatch, StringBuilder, UInt32Array};
 use datafusion::arrow::compute::take;
@@ -20,6 +21,7 @@ use datafusion::physical_plan::{
 };
 use datafusion::prelude::{Expr, SessionContext};
 use futures::{Stream, ready};
+use parking_lot::Mutex;
 
 use crate::filter_op::FilterOp;
 use crate::grouped_stream::{FullBatchCollector, IndexedGroups, StreamCollector};
@@ -132,6 +134,7 @@ impl TableProvider for ClusterProvider {
             schema: self.schema.clone(),
             input: input_plan,
             columns: Arc::new(self.columns.clone()),
+            cluster_id_coordinator: Arc::new(ClusterIdCoordinator::new(output_partitions)),
             contig_col_idx,
             min_dist: self.min_dist,
             strict: self.filter_op == FilterOp::Strict,
@@ -151,6 +154,7 @@ struct ClusterExec {
     schema: SchemaRef,
     input: Arc<dyn ExecutionPlan>,
     columns: Arc<(String, String, String)>,
+    cluster_id_coordinator: Arc<ClusterIdCoordinator>,
     contig_col_idx: usize,
     min_dist: i64,
     strict: bool,
@@ -206,6 +210,9 @@ impl ExecutionPlan for ClusterExec {
             schema: self.schema.clone(),
             input: Arc::clone(&children[0]),
             columns: Arc::clone(&self.columns),
+            cluster_id_coordinator: Arc::new(ClusterIdCoordinator::new(
+                children[0].output_partitioning().partition_count(),
+            )),
             contig_col_idx: self.contig_col_idx,
             min_dist: self.min_dist,
             strict: self.strict,
@@ -228,17 +235,22 @@ impl ExecutionPlan for ClusterExec {
     ) -> Result<SendableRecordBatchStream> {
         let batch_size = context.session_config().batch_size();
         let input = self.input.execute(partition, context)?;
+        let cluster_id_coordinator = Arc::clone(&self.cluster_id_coordinator);
 
         if self.has_extra_cols {
             let input_schema = input.schema();
             Ok(Box::pin(ClusterStreamExtra {
                 schema: self.schema.clone(),
                 collector: FullBatchCollector::new(input, Arc::clone(&self.columns), input_schema),
+                cluster_id_coordinator,
+                cluster_counts: None,
+                cluster_offsets: None,
                 min_dist: self.min_dist,
                 strict: self.strict,
                 phase: ClusterPhase::Collecting,
                 groups: Vec::new(),
                 concatenated: None,
+                partition,
                 group_idx: 0,
                 interval_idx: 0,
                 cluster_id: 0,
@@ -256,10 +268,14 @@ impl ExecutionPlan for ClusterExec {
             Ok(Box::pin(ClusterStream {
                 schema: self.schema.clone(),
                 collector: StreamCollector::new(input, Arc::clone(&self.columns)),
+                cluster_id_coordinator,
+                cluster_counts: None,
+                cluster_offsets: None,
                 min_dist: self.min_dist,
                 strict: self.strict,
                 phase: ClusterPhase::Collecting,
                 groups: Vec::new(),
+                partition,
                 group_idx: 0,
                 interval_idx: 0,
                 cluster_id: 0,
@@ -281,8 +297,217 @@ impl ExecutionPlan for ClusterExec {
 
 enum ClusterPhase {
     Collecting,
+    AwaitingOffsets,
     Emitting,
     Done,
+}
+
+struct ClusterIdCoordinator {
+    state: Mutex<ClusterIdCoordinatorState>,
+}
+
+impl ClusterIdCoordinator {
+    fn new(partition_count: usize) -> Self {
+        Self {
+            state: Mutex::new(ClusterIdCoordinatorState {
+                reports: vec![None; partition_count],
+                registered: 0,
+                offsets: None,
+                error: None,
+                wakers: Vec::new(),
+            }),
+        }
+    }
+
+    fn poll_cluster_offsets(
+        &self,
+        partition: usize,
+        counts: &[(String, usize)],
+        cx: &Context<'_>,
+    ) -> Poll<Result<Arc<AHashMap<String, i64>>>> {
+        let mut state = self.state.lock();
+
+        if let Some(offsets) = &state.offsets {
+            return Poll::Ready(Ok(Arc::clone(offsets)));
+        }
+
+        if let Some(error) = &state.error {
+            return Poll::Ready(Err(DataFusionError::Internal(error.clone())));
+        }
+
+        if partition >= state.reports.len() {
+            return Poll::Ready(Err(DataFusionError::Internal(format!(
+                "cluster partition {partition} out of range for {} output partitions",
+                state.reports.len()
+            ))));
+        }
+
+        if let Some(existing) = &state.reports[partition] {
+            if existing.as_slice() != counts {
+                return Poll::Ready(Err(DataFusionError::Internal(format!(
+                    "cluster partition {partition} reported inconsistent cluster counts"
+                ))));
+            }
+        } else {
+            state.reports[partition] = Some(counts.to_vec());
+            state.registered += 1;
+        }
+
+        if state.registered == state.reports.len() {
+            match Self::build_offsets(&state.reports) {
+                Ok(offsets) => {
+                    let offsets = Arc::new(offsets);
+                    state.offsets = Some(Arc::clone(&offsets));
+                    for waker in state.wakers.drain(..) {
+                        waker.wake();
+                    }
+                    return Poll::Ready(Ok(offsets));
+                }
+                Err(error) => {
+                    let message = error.to_string();
+                    state.error = Some(message.clone());
+                    for waker in state.wakers.drain(..) {
+                        waker.wake();
+                    }
+                    return Poll::Ready(Err(DataFusionError::Internal(message)));
+                }
+            }
+        }
+
+        state.wakers.push(cx.waker().clone());
+        Poll::Pending
+    }
+
+    fn build_offsets(reports: &[Option<Vec<(String, usize)>>]) -> Result<AHashMap<String, i64>> {
+        let mut contig_counts = Vec::with_capacity(reports.iter().flatten().map(Vec::len).sum());
+        for report in reports {
+            let report = report.as_ref().ok_or_else(|| {
+                DataFusionError::Internal(
+                    "cluster offset coordinator finalized before all partitions reported"
+                        .to_string(),
+                )
+            })?;
+            contig_counts.extend(report.iter().cloned());
+        }
+
+        contig_counts.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+
+        let mut offsets = AHashMap::with_capacity(contig_counts.len());
+        let mut next_cluster_id = 0_i64;
+
+        for (contig, cluster_count) in contig_counts {
+            if offsets.contains_key(&contig) {
+                return Err(DataFusionError::Internal(format!(
+                    "cluster offset coordinator received duplicate contig '{contig}' across partitions"
+                )));
+            }
+
+            offsets.insert(contig, next_cluster_id);
+            let cluster_count = i64::try_from(cluster_count).map_err(|_| {
+                DataFusionError::Internal(
+                    "cluster count exceeded i64::MAX while computing global offsets".to_string(),
+                )
+            })?;
+            next_cluster_id = next_cluster_id.checked_add(cluster_count).ok_or_else(|| {
+                DataFusionError::Internal(
+                    "cluster id overflow while computing global offsets".to_string(),
+                )
+            })?;
+        }
+
+        Ok(offsets)
+    }
+}
+
+impl Debug for ClusterIdCoordinator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let state = self.state.lock();
+        f.debug_struct("ClusterIdCoordinator")
+            .field("partition_count", &state.reports.len())
+            .field("registered", &state.registered)
+            .field("ready", &state.offsets.is_some())
+            .finish()
+    }
+}
+
+struct ClusterIdCoordinatorState {
+    reports: Vec<Option<Vec<(String, usize)>>>,
+    registered: usize,
+    offsets: Option<Arc<AHashMap<String, i64>>>,
+    error: Option<String>,
+    wakers: Vec<Waker>,
+}
+
+fn count_clusters<I>(intervals: I, min_dist: i64, strict: bool) -> usize
+where
+    I: Iterator<Item = (i64, i64)>,
+{
+    let mut cluster_count = 0;
+    let mut cluster_end = None;
+
+    for (start, end) in intervals {
+        match cluster_end {
+            None => {
+                cluster_count += 1;
+                cluster_end = Some(end);
+            }
+            Some(current_end) => {
+                let boundary = current_end.saturating_add(min_dist);
+                let merge_condition = if strict {
+                    start < boundary
+                } else {
+                    start <= boundary
+                };
+
+                if merge_condition {
+                    if end > current_end {
+                        cluster_end = Some(end);
+                    }
+                } else {
+                    cluster_count += 1;
+                    cluster_end = Some(end);
+                }
+            }
+        }
+    }
+
+    cluster_count
+}
+
+fn collect_cluster_counts(
+    groups: &[(String, Vec<(i64, i64)>)],
+    min_dist: i64,
+    strict: bool,
+) -> Vec<(String, usize)> {
+    groups
+        .iter()
+        .map(|(contig, intervals)| {
+            (
+                contig.clone(),
+                count_clusters(intervals.iter().copied(), min_dist, strict),
+            )
+        })
+        .collect()
+}
+
+fn collect_indexed_cluster_counts(
+    groups: &IndexedGroups,
+    min_dist: i64,
+    strict: bool,
+) -> Vec<(String, usize)> {
+    groups
+        .iter()
+        .map(|(contig, intervals)| {
+            (
+                contig.clone(),
+                count_clusters(
+                    intervals.iter().map(|&(start, end, _)| (start, end)),
+                    min_dist,
+                    strict,
+                ),
+            )
+        })
+        .collect()
 }
 
 // ─── Fast path: 3-column input (no extra columns) ───────────────────────────
@@ -290,10 +515,14 @@ enum ClusterPhase {
 struct ClusterStream {
     schema: SchemaRef,
     collector: StreamCollector,
+    cluster_id_coordinator: Arc<ClusterIdCoordinator>,
+    cluster_counts: Option<Vec<(String, usize)>>,
+    cluster_offsets: Option<Arc<AHashMap<String, i64>>>,
     min_dist: i64,
     strict: bool,
     phase: ClusterPhase,
     groups: Vec<(String, Vec<(i64, i64)>)>,
+    partition: usize,
     group_idx: usize,
     interval_idx: usize,
     cluster_id: i64,
@@ -328,6 +557,18 @@ impl ClusterStream {
         self.cluster_id += 1;
     }
 
+    fn set_group_cluster_base(&mut self, contig: &str) -> Result<()> {
+        let cluster_offsets = self.cluster_offsets.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("cluster stream missing global cluster offsets".to_string())
+        })?;
+        self.cluster_id = *cluster_offsets.get(contig).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "cluster stream missing global cluster offset for contig '{contig}'"
+            ))
+        })?;
+        Ok(())
+    }
+
     fn flush_builders(&mut self) -> Result<RecordBatch> {
         self.pending_rows = 0;
         RecordBatch::try_new(
@@ -356,9 +597,12 @@ impl Stream for ClusterStream {
                 ClusterPhase::Collecting => match ready!(this.collector.poll_collect(cx)) {
                     Ok(true) => {
                         this.groups = this.collector.take_groups();
-                        this.group_idx = 0;
-                        this.interval_idx = 0;
-                        this.phase = ClusterPhase::Emitting;
+                        this.cluster_counts = Some(collect_cluster_counts(
+                            &this.groups,
+                            this.min_dist,
+                            this.strict,
+                        ));
+                        this.phase = ClusterPhase::AwaitingOffsets;
                     }
                     Ok(false) => unreachable!(),
                     Err(e) => {
@@ -366,10 +610,50 @@ impl Stream for ClusterStream {
                         return Poll::Ready(Some(Err(e)));
                     }
                 },
+                ClusterPhase::AwaitingOffsets => {
+                    let cluster_counts = this.cluster_counts.as_deref().ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "cluster stream missing local cluster counts".to_string(),
+                        )
+                    });
+                    let cluster_counts = match cluster_counts {
+                        Ok(cluster_counts) => cluster_counts,
+                        Err(error) => {
+                            this.phase = ClusterPhase::Done;
+                            return Poll::Ready(Some(Err(error)));
+                        }
+                    };
+
+                    match this.cluster_id_coordinator.poll_cluster_offsets(
+                        this.partition,
+                        cluster_counts,
+                        cx,
+                    ) {
+                        Poll::Ready(Ok(cluster_offsets)) => {
+                            this.cluster_offsets = Some(cluster_offsets);
+                            this.group_idx = 0;
+                            this.interval_idx = 0;
+                            this.phase = ClusterPhase::Emitting;
+                        }
+                        Poll::Ready(Err(error)) => {
+                            this.phase = ClusterPhase::Done;
+                            return Poll::Ready(Some(Err(error)));
+                        }
+                        Poll::Pending => return Poll::Pending,
+                    }
+                }
                 ClusterPhase::Emitting => {
                     while this.group_idx < this.groups.len() {
                         let contig = this.groups[this.group_idx].0.clone();
                         let interval_count = this.groups[this.group_idx].1.len();
+
+                        if this.interval_idx == 0
+                            && this.pending_intervals.is_empty()
+                            && let Err(error) = this.set_group_cluster_base(&contig)
+                        {
+                            this.phase = ClusterPhase::Done;
+                            return Poll::Ready(Some(Err(error)));
+                        }
 
                         while this.interval_idx < interval_count {
                             let (s, e) = this.groups[this.group_idx].1[this.interval_idx];
@@ -442,11 +726,15 @@ impl RecordBatchStream for ClusterStream {
 struct ClusterStreamExtra {
     schema: SchemaRef,
     collector: FullBatchCollector,
+    cluster_id_coordinator: Arc<ClusterIdCoordinator>,
+    cluster_counts: Option<Vec<(String, usize)>>,
+    cluster_offsets: Option<Arc<AHashMap<String, i64>>>,
     min_dist: i64,
     strict: bool,
     phase: ClusterPhase,
     groups: IndexedGroups,
     concatenated: Option<RecordBatch>,
+    partition: usize,
     group_idx: usize,
     interval_idx: usize,
     cluster_id: i64,
@@ -479,6 +767,20 @@ impl ClusterStreamExtra {
         self.pending_rows += self.pending_intervals.len();
         self.pending_intervals.clear();
         self.cluster_id += 1;
+    }
+
+    fn set_group_cluster_base(&mut self, contig: &str) -> Result<()> {
+        let cluster_offsets = self.cluster_offsets.as_ref().ok_or_else(|| {
+            DataFusionError::Internal(
+                "cluster stream with extra columns missing global cluster offsets".to_string(),
+            )
+        })?;
+        self.cluster_id = *cluster_offsets.get(contig).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "cluster stream with extra columns missing global cluster offset for contig '{contig}'"
+            ))
+        })?;
+        Ok(())
     }
 
     fn flush_builders(&mut self) -> Result<RecordBatch> {
@@ -521,9 +823,12 @@ impl Stream for ClusterStreamExtra {
                     Ok(true) => {
                         this.groups = this.collector.take_groups();
                         this.concatenated = this.collector.take_concatenated();
-                        this.group_idx = 0;
-                        this.interval_idx = 0;
-                        this.phase = ClusterPhase::Emitting;
+                        this.cluster_counts = Some(collect_indexed_cluster_counts(
+                            &this.groups,
+                            this.min_dist,
+                            this.strict,
+                        ));
+                        this.phase = ClusterPhase::AwaitingOffsets;
                     }
                     Ok(false) => unreachable!(),
                     Err(e) => {
@@ -531,9 +836,51 @@ impl Stream for ClusterStreamExtra {
                         return Poll::Ready(Some(Err(e)));
                     }
                 },
+                ClusterPhase::AwaitingOffsets => {
+                    let cluster_counts = this.cluster_counts.as_deref().ok_or_else(|| {
+                        DataFusionError::Internal(
+                            "cluster stream with extra columns missing local cluster counts"
+                                .to_string(),
+                        )
+                    });
+                    let cluster_counts = match cluster_counts {
+                        Ok(cluster_counts) => cluster_counts,
+                        Err(error) => {
+                            this.phase = ClusterPhase::Done;
+                            return Poll::Ready(Some(Err(error)));
+                        }
+                    };
+
+                    match this.cluster_id_coordinator.poll_cluster_offsets(
+                        this.partition,
+                        cluster_counts,
+                        cx,
+                    ) {
+                        Poll::Ready(Ok(cluster_offsets)) => {
+                            this.cluster_offsets = Some(cluster_offsets);
+                            this.group_idx = 0;
+                            this.interval_idx = 0;
+                            this.phase = ClusterPhase::Emitting;
+                        }
+                        Poll::Ready(Err(error)) => {
+                            this.phase = ClusterPhase::Done;
+                            return Poll::Ready(Some(Err(error)));
+                        }
+                        Poll::Pending => return Poll::Pending,
+                    }
+                }
                 ClusterPhase::Emitting => {
                     while this.group_idx < this.groups.len() {
+                        let contig = this.groups[this.group_idx].0.clone();
                         let interval_count = this.groups[this.group_idx].1.len();
+
+                        if this.interval_idx == 0
+                            && this.pending_intervals.is_empty()
+                            && let Err(error) = this.set_group_cluster_base(&contig)
+                        {
+                            this.phase = ClusterPhase::Done;
+                            return Poll::Ready(Some(Err(error)));
+                        }
 
                         while this.interval_idx < interval_count {
                             let (s, e, row_idx) = this.groups[this.group_idx].1[this.interval_idx];

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -574,6 +574,33 @@ async fn explain_query(ctx: &SessionContext, query: &str) -> Result<String> {
     Ok(pretty_format_batches(&plan)?.to_string())
 }
 
+fn project_batches_by_name(
+    batches: &[RecordBatch],
+    column_names: &[&str],
+) -> Result<Vec<RecordBatch>> {
+    batches
+        .iter()
+        .map(|batch| {
+            let indices = column_names
+                .iter()
+                .map(|name| batch.schema().index_of(name))
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            let fields = indices
+                .iter()
+                .map(|&idx| batch.schema().field(idx).clone())
+                .collect::<Vec<_>>();
+            let columns = indices
+                .iter()
+                .map(|&idx| batch.column(idx).clone())
+                .collect::<Vec<_>>();
+            Ok(RecordBatch::try_new(
+                Arc::new(Schema::new(fields)),
+                columns,
+            )?)
+        })
+        .collect()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 #[rstest::rstest]
 async fn test_count_overlaps(ctx: SessionContext) -> Result<()> {
@@ -3394,7 +3421,7 @@ async fn test_range_udtfs_target_partitions_invariant() -> Result<()> {
         ),
         (
             "cluster",
-            "SELECT * FROM cluster('reads') ORDER BY contig, pos_start, pos_end, cluster",
+            "SELECT contig, pos_start, pos_end, cluster_start, cluster_end FROM (SELECT * FROM cluster('reads')) cluster_rows ORDER BY contig, pos_start, pos_end, cluster_start, cluster_end",
         ),
         (
             "complement",
@@ -3407,8 +3434,20 @@ async fn test_range_udtfs_target_partitions_invariant() -> Result<()> {
     ];
 
     for (name, query) in cases {
-        let result_1 = collect_udtf_query_with_partitions(1, query).await?;
-        let result_4 = collect_udtf_query_with_partitions(4, query).await?;
+        let mut result_1 = collect_udtf_query_with_partitions(1, query).await?;
+        let mut result_4 = collect_udtf_query_with_partitions(4, query).await?;
+
+        if name == "cluster" {
+            let semantic_cols = [
+                "contig",
+                "pos_start",
+                "pos_end",
+                "cluster_start",
+                "cluster_end",
+            ];
+            result_1 = project_batches_by_name(&result_1, &semantic_cols)?;
+            result_4 = project_batches_by_name(&result_4, &semantic_cols)?;
+        }
 
         let formatted_1 = pretty_format_batches(&result_1)?.to_string();
         let formatted_4 = pretty_format_batches(&result_4)?.to_string();
@@ -3456,6 +3495,17 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
         "| chr2   | 30        | 40      | 1           |",
         "+--------+-----------+---------+-------------+",
     ];
+    let expected_cluster = [
+        "+--------+-----------+---------+---------------+-------------+",
+        "| contig | pos_start | pos_end | cluster_start | cluster_end |",
+        "+--------+-----------+---------+---------------+-------------+",
+        "| chr1   | 0         | 10      | 0             | 30          |",
+        "| chr1   | 8         | 25      | 0             | 30          |",
+        "| chr1   | 20        | 30      | 0             | 30          |",
+        "| chr2   | 10        | 20      | 10            | 20          |",
+        "| chr2   | 30        | 40      | 30            | 40          |",
+        "+--------+-----------+---------+---------------+-------------+",
+    ];
     let expected_complement = [
         "+--------+-----------+---------+",
         "| contig | pos_start | pos_end |",
@@ -3502,6 +3552,25 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
             .collect()
             .await?;
         assert_batches_sorted_eq!(expected_merge, &merge);
+
+        let cluster = ctx
+            .sql(
+                "SELECT contig, pos_start, pos_end, cluster_start, cluster_end FROM (SELECT * FROM cluster('left_t')) cluster_rows ORDER BY contig, pos_start, pos_end, cluster_start, cluster_end",
+            )
+            .await?
+            .collect()
+            .await?;
+        let cluster = project_batches_by_name(
+            &cluster,
+            &[
+                "contig",
+                "pos_start",
+                "pos_end",
+                "cluster_start",
+                "cluster_end",
+            ],
+        )?;
+        assert_batches_sorted_eq!(expected_cluster, &cluster);
 
         let complement = ctx
             .sql("SELECT * FROM complement('left_t', 'view_t') ORDER BY contig, pos_start, pos_end")
@@ -3627,6 +3696,13 @@ async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result
         "RepartitionExec: partitioning=Hash([contig@0]"
     );
 
+    let cluster_plan = explain_query(&ctx, "SELECT * FROM cluster('left_t')").await?;
+    assert_contains!(cluster_plan.as_str(), "ClusterExec");
+    assert_contains!(
+        cluster_plan.as_str(),
+        "RepartitionExec: partitioning=Hash([contig@0]"
+    );
+
     let complement_plan =
         explain_query(&ctx, "SELECT * FROM complement('left_t', 'view_t')").await?;
     assert_contains!(complement_plan.as_str(), "ComplementExec");
@@ -3647,6 +3723,65 @@ async fn test_partitioned_parquet_explain_preserves_hash_repartition() -> Result
             >= 2,
         "expected two hash repartitions in subtract plan, got:\n{subtract_plan}"
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cluster_exons_issue_373_target_partitions_preserve_boundaries() -> Result<()> {
+    let query = r#"
+        SELECT contig, pos_start, pos_end, cluster_start, cluster_end
+        FROM (SELECT * FROM cluster('exons')) cluster_rows
+        WHERE
+            (contig = 'chr11' AND pos_start = 62379907 AND pos_end = 62380237) OR
+            (contig = 'chr11' AND pos_start = 62380212 AND pos_end = 62381343) OR
+            (contig = 'chr12' AND pos_start = 53776037 AND pos_end = 53777406) OR
+            (contig = 'chr15' AND pos_start = 89074843 AND pos_end = 89074946) OR
+            (contig = 'chr18' AND pos_start = 52946781 AND pos_end = 52946887)
+        ORDER BY contig, pos_start, pos_end, cluster_start, cluster_end
+    "#;
+
+    let expected = [
+        "+--------+-----------+----------+---------------+-------------+",
+        "| contig | pos_start | pos_end  | cluster_start | cluster_end |",
+        "+--------+-----------+----------+---------------+-------------+",
+        "| chr11  | 62379907  | 62380237 | 62379907      | 62381343    |",
+        "| chr11  | 62380212  | 62381343 | 62379907      | 62381343    |",
+        "| chr12  | 53776037  | 53777406 | 53775893      | 53777406    |",
+        "| chr15  | 89074843  | 89074946 | 89073853      | 89074946    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "| chr18  | 52946781  | 52946887 | 52946781      | 52946905    |",
+        "+--------+-----------+----------+---------------+-------------+",
+    ];
+
+    for target_partitions in [1, 4] {
+        let ctx = create_bio_session_with_target_partitions(target_partitions);
+        let exons =
+            format!("CREATE EXTERNAL TABLE exons STORED AS PARQUET LOCATION '{EXONS_PATH}'");
+        ctx.sql(exons.as_str()).await?;
+
+        let result = ctx.sql(query).await?.collect().await?;
+        let result = project_batches_by_name(
+            &result,
+            &[
+                "contig",
+                "pos_start",
+                "pos_end",
+                "cluster_start",
+                "cluster_end",
+            ],
+        )?;
+        assert_batches_sorted_eq!(expected, &result);
+    }
 
     Ok(())
 }

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -2524,6 +2525,66 @@ async fn test_cluster_udtf_reads_csv() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cluster_issue_146_target_partitions_preserve_ids() -> Result<()> {
+    let query = "SELECT * FROM cluster('reads') ORDER BY contig, pos_start, pos_end, cluster, cluster_start, cluster_end";
+
+    let result_1 = collect_udtf_query_with_partitions(1, query).await?;
+    let result_4 = collect_udtf_query_with_partitions(4, query).await?;
+
+    assert_eq!(
+        pretty_format_batches(&result_1)?.to_string(),
+        pretty_format_batches(&result_4)?.to_string()
+    );
+
+    let mut cluster_extents = BTreeMap::new();
+    for batch in &result_4 {
+        let contig = batch
+            .column_by_name("contig")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let cluster = batch
+            .column_by_name("cluster")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let cluster_start = batch
+            .column_by_name("cluster_start")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let cluster_end = batch
+            .column_by_name("cluster_end")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+
+        for row_idx in 0..batch.num_rows() {
+            let extent = (
+                contig.value(row_idx).to_string(),
+                cluster_start.value(row_idx),
+                cluster_end.value(row_idx),
+            );
+            if let Some(existing) = cluster_extents.insert(cluster.value(row_idx), extent.clone()) {
+                assert_eq!(
+                    existing,
+                    extent,
+                    "cluster id {} reused for different extents",
+                    cluster.value(row_idx)
+                );
+            }
+        }
+    }
+
+    assert_eq!(cluster_extents.len(), 7);
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Complement UDTF tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3421,7 +3482,7 @@ async fn test_range_udtfs_target_partitions_invariant() -> Result<()> {
         ),
         (
             "cluster",
-            "SELECT contig, pos_start, pos_end, cluster_start, cluster_end FROM (SELECT * FROM cluster('reads')) cluster_rows ORDER BY contig, pos_start, pos_end, cluster_start, cluster_end",
+            "SELECT * FROM cluster('reads') ORDER BY contig, pos_start, pos_end, cluster, cluster_start, cluster_end",
         ),
         (
             "complement",
@@ -3442,6 +3503,7 @@ async fn test_range_udtfs_target_partitions_invariant() -> Result<()> {
                 "contig",
                 "pos_start",
                 "pos_end",
+                "cluster",
                 "cluster_start",
                 "cluster_end",
             ];
@@ -3496,15 +3558,15 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
         "+--------+-----------+---------+-------------+",
     ];
     let expected_cluster = [
-        "+--------+-----------+---------+---------------+-------------+",
-        "| contig | pos_start | pos_end | cluster_start | cluster_end |",
-        "+--------+-----------+---------+---------------+-------------+",
-        "| chr1   | 0         | 10      | 0             | 30          |",
-        "| chr1   | 8         | 25      | 0             | 30          |",
-        "| chr1   | 20        | 30      | 0             | 30          |",
-        "| chr2   | 10        | 20      | 10            | 20          |",
-        "| chr2   | 30        | 40      | 30            | 40          |",
-        "+--------+-----------+---------+---------------+-------------+",
+        "+--------+-----------+---------+---------+---------------+-------------+",
+        "| contig | pos_start | pos_end | cluster | cluster_start | cluster_end |",
+        "+--------+-----------+---------+---------+---------------+-------------+",
+        "| chr1   | 0         | 10      | 0       | 0             | 30          |",
+        "| chr1   | 8         | 25      | 0       | 0             | 30          |",
+        "| chr1   | 20        | 30      | 0       | 0             | 30          |",
+        "| chr2   | 10        | 20      | 1       | 10            | 20          |",
+        "| chr2   | 30        | 40      | 2       | 30            | 40          |",
+        "+--------+-----------+---------+---------+---------------+-------------+",
     ];
     let expected_complement = [
         "+--------+-----------+---------+",
@@ -3555,7 +3617,7 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
 
         let cluster = ctx
             .sql(
-                "SELECT contig, pos_start, pos_end, cluster_start, cluster_end FROM (SELECT * FROM cluster('left_t')) cluster_rows ORDER BY contig, pos_start, pos_end, cluster_start, cluster_end",
+                "SELECT * FROM cluster('left_t') ORDER BY contig, pos_start, pos_end, cluster, cluster_start, cluster_end",
             )
             .await?
             .collect()
@@ -3566,6 +3628,7 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
                 "contig",
                 "pos_start",
                 "pos_end",
+                "cluster",
                 "cluster_start",
                 "cluster_end",
             ],


### PR DESCRIPTION
## Summary
- fix `cluster` partition invariance by expressing the required input distribution on `ClusterExec`
- remove the scan-time repartition injection and let the planner enforce hash partitioning by contig
- add regressions covering `cluster` target partition invariance, partitioned parquet plans, and the exon rows from the reported failure

## Details
This fixes the engine-side issue behind `biodatageeks/polars-bio#373`.

`ClusterExec` now requires `HashPartitioned` input by contig, matching the distribution contract already used by `merge`, `complement`, and `subtract`. That ensures clustered ranges stay contig-local even when upstream lazy inputs arrive fragmented across partitions.

The test coverage added here includes:
- target partition invariance for `cluster`
- partitioned parquet invariance including `cluster`
- `EXPLAIN` assertions showing planner-inserted hash repartition for `cluster`
- a regression on the exon rows from the reported issue, checked under `target_partitions=1` and `4`

Fixes biodatageeks/polars-bio#373

## Verification
- `cargo fmt --all`
- `cargo test -p datafusion-bio-function-ranges --test integration_test test_cluster_exons_issue_373_target_partitions_preserve_boundaries -- --nocapture`
- `cargo test -p datafusion-bio-function-ranges --test integration_test test_range_udtfs_target_partitions_invariant -- --nocapture`
- `cargo test -p datafusion-bio-function-ranges --test integration_test test_range_udtfs_partitioned_parquet_target_partitions_invariant -- --nocapture`
- `cargo test -p datafusion-bio-function-ranges --test integration_test test_partitioned_parquet_explain_preserves_hash_repartition -- --nocapture`
- `cargo test -p datafusion-bio-function-ranges --test integration_test test_cluster_udtf_basic -- --nocapture`