### PR TITLE
fix: reduce CI runner disk pressure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
           toolchain: '1.91.0'
           components: 'clippy, rustfmt'
 
-      - name: Cache Cargo registry and build
+      # Avoid caching target: restored build artifacts can exhaust runner disk.
+      - name: Cache Cargo registry and git deps
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-


### PR DESCRIPTION
## Summary
- remove `target` from the CI cache to avoid restoring large build artifacts onto the runner
- keep Git LFS enabled so the golden VEP fixture tests still run in CI
- document the reason inline in the workflow

## Context
The failing Actions job ran out of disk during the cache step with `System.IO.IOException: No space left on device`.

Failed run:
- https://github.com/biodatageeks/datafusion-bio-functions/actions/runs/24850343665/job/72748757976

## Validation
- workflow YAML parses successfully
- pre-commit hooks passed during commit
- GitHub Actions were not rerun from this environment