### PR TITLE
Add Apple GPU backend for count_overlaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1292,9 @@ dependencies = [
  "datafusion",
  "futures",
  "log",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
  "parking_lot",
  "rstest",
  "rust-lapper",
@@ -1959,6 +1971,16 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -3745,6 +3767,56 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/datafusion/bio-function-ranges/Cargo.toml
+++ b/datafusion/bio-function-ranges/Cargo.toml
@@ -8,6 +8,14 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 
+[features]
+default = []
+apple-gpu = [
+    "dep:objc2",
+    "dep:objc2-foundation",
+    "dep:objc2-metal",
+]
+
 [dependencies]
 datafusion = { workspace = true }
 tokio = { workspace = true }
@@ -20,6 +28,23 @@ bio = "3.0.0"
 rust-lapper = "1.1.0"
 superintervals = { path = "superintervals" }
 parking_lot = "0.12.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.6.4", optional = true }
+objc2-foundation = { version = "0.3.2", optional = true, features = ["NSError", "NSString"] }
+objc2-metal = { version = "0.3.2", optional = true, default-features = false, features = [
+    "MTLAllocation",
+    "MTLBuffer",
+    "MTLCommandBuffer",
+    "MTLCommandEncoder",
+    "MTLCommandQueue",
+    "MTLComputeCommandEncoder",
+    "MTLComputePipeline",
+    "MTLDevice",
+    "MTLLibrary",
+    "MTLResource",
+    "MTLTypes",
+] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/datafusion/bio-function-ranges/README.md
+++ b/datafusion/bio-function-ranges/README.md
@@ -89,6 +89,16 @@ Counts overlapping intervals. Same interface as `coverage`, but returns the coun
 SELECT * FROM count_overlaps('reads', 'targets')
 ```
 
+When built with the `apple-gpu` Cargo feature on macOS, `count_overlaps` can use an Apple Metal endpoint-rank backend:
+
+```sql
+SET bio.count_overlaps_backend = auto;       -- default
+SET bio.count_overlaps_backend = cpu;
+SET bio.count_overlaps_backend = apple_gpu;
+```
+
+`auto` keeps the CPU COITree backend for small inputs and currently tries the Apple GPU backend for large non-coverage `count_overlaps` workloads when the collected left side has at least 5M intervals. If Metal initialization fails before output is emitted, execution falls back to CPU.
+
 ### `nearest(left_table, right_table [, k] [, overlap] [, columns...] [, filter_op])`
 
 Returns up to `k` nearest left intervals for each right interval.

--- a/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
+++ b/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
@@ -19,6 +19,7 @@ struct Args {
     repeats: usize,
     warmups: usize,
     batch_size: Option<usize>,
+    timings: bool,
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -32,6 +33,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             "warmup={},backend={},threads={},elapsed_ms={:.3}",
             warmup, args.backend, args.threads, run.elapsed_ms
         );
+        if args.timings {
+            eprintln!("{}", run.timing_line("warmup", warmup, &args));
+        }
     }
 
     for repeat in 0..args.repeats {
@@ -41,6 +45,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             "repeat={},backend={},threads={},elapsed_ms={:.3}",
             repeat, args.backend, args.threads, run.elapsed_ms
         );
+        if args.timings {
+            println!("{}", run.timing_line("repeat", repeat, &args));
+        }
         println!("{}", run.result);
     }
 
@@ -58,10 +65,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 #[derive(Debug)]
 struct RunResult {
     elapsed_ms: f64,
+    setup_ms: f64,
+    sql_ms: f64,
+    collect_ms: f64,
+    result_ms: f64,
     result: String,
 }
 
 async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
+    let setup_start = Instant::now();
     let mut bio_config = BioConfig::default();
     bio_config.count_overlaps_backend = args.backend;
 
@@ -78,17 +90,23 @@ async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
     register_ranges_functions(&ctx);
     register_parquet(&ctx, "reads", &args.left).await?;
     register_parquet(&ctx, "targets", &args.right).await?;
+    let setup_ms = setup_start.elapsed().as_secs_f64() * 1000.0;
 
     let start = Instant::now();
-    let batches = ctx
+    let dataframe = ctx
         .sql(
             r#"SELECT COUNT(*) AS n_rows, SUM("count") AS total_overlaps
                FROM count_overlaps('reads', 'targets')"#,
         )
-        .await?
-        .collect()
         .await?;
+    let sql_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    let collect_start = Instant::now();
+    let batches = dataframe.collect().await?;
+    let collect_ms = collect_start.elapsed().as_secs_f64() * 1000.0;
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+    let result_start = Instant::now();
     let batch = batches
         .first()
         .ok_or_else(|| "benchmark query returned no batches".to_string())?;
@@ -101,8 +119,16 @@ async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
         .ok_or_else(|| "total_overlaps column not found in benchmark output".to_string())
         .and_then(|array| scalar_i64(array.as_ref(), "total_overlaps"))?;
     let result = format!("n_rows={n_rows},total_overlaps={total_overlaps}");
+    let result_ms = result_start.elapsed().as_secs_f64() * 1000.0;
 
-    Ok(RunResult { elapsed_ms, result })
+    Ok(RunResult {
+        elapsed_ms,
+        setup_ms,
+        sql_ms,
+        collect_ms,
+        result_ms,
+        result,
+    })
 }
 
 fn scalar_i64(array: &dyn Array, name: &str) -> Result<i64, String> {
@@ -143,6 +169,7 @@ impl Args {
         let mut repeats = 3usize;
         let mut warmups = 1usize;
         let mut batch_size = None;
+        let mut timings = false;
 
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
@@ -159,6 +186,7 @@ impl Args {
                 "--batch-size" => {
                     batch_size = Some(next_value(&mut args, "--batch-size")?.parse()?)
                 }
+                "--timings" => timings = true,
                 "--help" | "-h" => {
                     print_usage();
                     std::process::exit(0);
@@ -179,7 +207,23 @@ impl Args {
             repeats,
             warmups,
             batch_size,
+            timings,
         })
+    }
+}
+
+impl RunResult {
+    fn timing_line(&self, phase: &str, iteration: usize, args: &Args) -> String {
+        format!(
+            "timings,{phase}={iteration},backend={},threads={},setup_ms={:.3},sql_ms={:.3},collect_ms={:.3},result_ms={:.3},elapsed_ms={:.3}",
+            args.backend,
+            args.threads,
+            self.setup_ms,
+            self.sql_ms,
+            self.collect_ms,
+            self.result_ms,
+            self.elapsed_ms
+        )
     }
 }
 
@@ -193,6 +237,6 @@ fn next_value(
 
 fn print_usage() {
     println!(
-        "Usage: count_overlaps_bench [--left PATH] [--right PATH] [--backend auto|cpu|apple_gpu] [--threads N] [--repeats N] [--warmups N] [--batch-size N]"
+        "Usage: count_overlaps_bench [--left PATH] [--right PATH] [--backend auto|cpu|apple_gpu] [--threads N] [--repeats N] [--warmups N] [--batch-size N] [--timings]"
     );
 }

--- a/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
+++ b/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
@@ -35,6 +35,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
         if args.timings {
             eprintln!("{}", run.timing_line("warmup", warmup, &args));
+            if let Some(line) = run.count_overlaps_timing_line("warmup", warmup, &args) {
+                eprintln!("{line}");
+            }
+            if let Some(line) = run.gpu_timing_line("warmup", warmup, &args) {
+                eprintln!("{line}");
+            }
         }
     }
 
@@ -47,6 +53,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
         if args.timings {
             println!("{}", run.timing_line("repeat", repeat, &args));
+            if let Some(line) = run.count_overlaps_timing_line("repeat", repeat, &args) {
+                println!("{line}");
+            }
+            if let Some(line) = run.gpu_timing_line("repeat", repeat, &args) {
+                println!("{line}");
+            }
         }
         println!("{}", run.result);
     }
@@ -69,7 +81,32 @@ struct RunResult {
     sql_ms: f64,
     collect_ms: f64,
     result_ms: f64,
+    count_overlaps_timings: Option<CountOverlapsTimingResult>,
+    gpu_timings: Option<GpuTimingResult>,
     result: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CountOverlapsTimingResult {
+    scans: u64,
+    left_rows: u64,
+    left_collect_ms: f64,
+    backend_build_ms: f64,
+    right_plan_ms: f64,
+    scan_total_ms: f64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GpuTimingResult {
+    batches: u64,
+    rows: u64,
+    encode_ms: f64,
+    buffer_ms: f64,
+    command_ms: f64,
+    wait_ms: f64,
+    readback_ms: f64,
+    output_ms: f64,
+    total_ms: f64,
 }
 
 async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
@@ -102,7 +139,11 @@ async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
     let sql_ms = start.elapsed().as_secs_f64() * 1000.0;
 
     let collect_start = Instant::now();
+    datafusion_bio_function_ranges::reset_count_overlaps_timings();
+    reset_gpu_timing_stats();
     let batches = dataframe.collect().await?;
+    let count_overlaps_timings = snapshot_count_overlaps_timing_stats();
+    let gpu_timings = snapshot_gpu_timing_stats();
     let collect_ms = collect_start.elapsed().as_secs_f64() * 1000.0;
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
@@ -127,6 +168,8 @@ async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
         sql_ms,
         collect_ms,
         result_ms,
+        count_overlaps_timings,
+        gpu_timings,
         result,
     })
 }
@@ -225,6 +268,89 @@ impl RunResult {
             self.elapsed_ms
         )
     }
+
+    fn gpu_timing_line(&self, phase: &str, iteration: usize, args: &Args) -> Option<String> {
+        let timings = self.gpu_timings?;
+        Some(format!(
+            "gpu_timings,{phase}={iteration},backend={},threads={},batches={},rows={},encode_ms={:.3},buffer_ms={:.3},command_ms={:.3},wait_ms={:.3},readback_ms={:.3},output_ms={:.3},total_ms={:.3}",
+            args.backend,
+            args.threads,
+            timings.batches,
+            timings.rows,
+            timings.encode_ms,
+            timings.buffer_ms,
+            timings.command_ms,
+            timings.wait_ms,
+            timings.readback_ms,
+            timings.output_ms,
+            timings.total_ms
+        ))
+    }
+
+    fn count_overlaps_timing_line(
+        &self,
+        phase: &str,
+        iteration: usize,
+        args: &Args,
+    ) -> Option<String> {
+        let timings = self.count_overlaps_timings?;
+        Some(format!(
+            "count_overlaps_timings,{phase}={iteration},backend={},threads={},scans={},left_rows={},left_collect_ms={:.3},backend_build_ms={:.3},right_plan_ms={:.3},scan_total_ms={:.3}",
+            args.backend,
+            args.threads,
+            timings.scans,
+            timings.left_rows,
+            timings.left_collect_ms,
+            timings.backend_build_ms,
+            timings.right_plan_ms,
+            timings.scan_total_ms
+        ))
+    }
+}
+
+fn snapshot_count_overlaps_timing_stats() -> Option<CountOverlapsTimingResult> {
+    let snapshot = datafusion_bio_function_ranges::snapshot_count_overlaps_timings();
+    (snapshot.scans > 0).then(|| CountOverlapsTimingResult {
+        scans: snapshot.scans,
+        left_rows: snapshot.left_rows,
+        left_collect_ms: ns_to_ms(snapshot.left_collect_ns),
+        backend_build_ms: ns_to_ms(snapshot.backend_build_ns),
+        right_plan_ms: ns_to_ms(snapshot.right_plan_ns),
+        scan_total_ms: ns_to_ms(snapshot.scan_total_ns),
+    })
+}
+
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+fn reset_gpu_timing_stats() {
+    datafusion_bio_function_ranges::reset_apple_gpu_timings();
+}
+
+#[cfg(not(all(feature = "apple-gpu", target_os = "macos")))]
+fn reset_gpu_timing_stats() {}
+
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+fn snapshot_gpu_timing_stats() -> Option<GpuTimingResult> {
+    let snapshot = datafusion_bio_function_ranges::snapshot_apple_gpu_timings();
+    (snapshot.batches > 0).then(|| GpuTimingResult {
+        batches: snapshot.batches,
+        rows: snapshot.rows,
+        encode_ms: ns_to_ms(snapshot.encode_ns),
+        buffer_ms: ns_to_ms(snapshot.buffer_ns),
+        command_ms: ns_to_ms(snapshot.command_ns),
+        wait_ms: ns_to_ms(snapshot.wait_ns),
+        readback_ms: ns_to_ms(snapshot.readback_ns),
+        output_ms: ns_to_ms(snapshot.output_ns),
+        total_ms: ns_to_ms(snapshot.total_ns),
+    })
+}
+
+#[cfg(not(all(feature = "apple-gpu", target_os = "macos")))]
+fn snapshot_gpu_timing_stats() -> Option<GpuTimingResult> {
+    None
+}
+
+fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
 }
 
 fn next_value(

--- a/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
+++ b/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Instant;
 
-use datafusion::arrow::array::Int64Array;
+use datafusion::arrow::array::{Array, Int64Array, UInt64Array};
 use datafusion::config::ConfigOptions;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_bio_function_ranges::{
@@ -81,28 +81,41 @@ async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
 
     let start = Instant::now();
     let batches = ctx
-        .sql("SELECT * FROM count_overlaps('reads', 'targets')")
+        .sql(
+            r#"SELECT COUNT(*) AS n_rows, SUM("count") AS total_overlaps
+               FROM count_overlaps('reads', 'targets')"#,
+        )
         .await?
         .collect()
         .await?;
     let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-    let n_rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
-    let total_overlaps = batches
-        .iter()
-        .map(|batch| -> Result<i64, Box<dyn Error>> {
-            let count = batch
-                .column_by_name("count")
-                .ok_or_else(|| "count column not found in count_overlaps output".to_string())?;
-            let count = count
-                .as_any()
-                .downcast_ref::<Int64Array>()
-                .ok_or_else(|| "count column is not Int64".to_string())?;
-            Ok(count.values().iter().sum::<i64>())
-        })
-        .sum::<Result<i64, Box<dyn Error>>>()?;
+    let batch = batches
+        .first()
+        .ok_or_else(|| "benchmark query returned no batches".to_string())?;
+    let n_rows = batch
+        .column_by_name("n_rows")
+        .ok_or_else(|| "n_rows column not found in benchmark output".to_string())
+        .and_then(|array| scalar_i64(array.as_ref(), "n_rows"))?;
+    let total_overlaps = batch
+        .column_by_name("total_overlaps")
+        .ok_or_else(|| "total_overlaps column not found in benchmark output".to_string())
+        .and_then(|array| scalar_i64(array.as_ref(), "total_overlaps"))?;
     let result = format!("n_rows={n_rows},total_overlaps={total_overlaps}");
 
     Ok(RunResult { elapsed_ms, result })
+}
+
+fn scalar_i64(array: &dyn Array, name: &str) -> Result<i64, String> {
+    if let Some(array) = array.as_any().downcast_ref::<Int64Array>() {
+        return Ok(array.value(0));
+    }
+    if let Some(array) = array.as_any().downcast_ref::<UInt64Array>() {
+        return i64::try_from(array.value(0)).map_err(|_| format!("{name} value overflows i64"));
+    }
+    Err(format!(
+        "{name} column has unsupported type {}",
+        array.data_type()
+    ))
 }
 
 async fn register_parquet(

--- a/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
+++ b/datafusion/bio-function-ranges/examples/count_overlaps_bench.rs
@@ -1,0 +1,185 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Instant;
+
+use datafusion::arrow::array::Int64Array;
+use datafusion::config::ConfigOptions;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion_bio_function_ranges::{
+    BioConfig, BioSessionExt, CountOverlapsBackendMode, register_ranges_functions,
+};
+
+#[derive(Debug)]
+struct Args {
+    left: PathBuf,
+    right: PathBuf,
+    backend: CountOverlapsBackendMode,
+    threads: usize,
+    repeats: usize,
+    warmups: usize,
+    batch_size: Option<usize>,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse()?;
+    let mut elapsed = Vec::with_capacity(args.repeats);
+
+    for warmup in 0..args.warmups {
+        let run = run_once(&args).await?;
+        eprintln!(
+            "warmup={},backend={},threads={},elapsed_ms={:.3}",
+            warmup, args.backend, args.threads, run.elapsed_ms
+        );
+    }
+
+    for repeat in 0..args.repeats {
+        let run = run_once(&args).await?;
+        elapsed.push(run.elapsed_ms);
+        println!(
+            "repeat={},backend={},threads={},elapsed_ms={:.3}",
+            repeat, args.backend, args.threads, run.elapsed_ms
+        );
+        println!("{}", run.result);
+    }
+
+    if !elapsed.is_empty() {
+        let mean = elapsed.iter().sum::<f64>() / elapsed.len() as f64;
+        println!(
+            "summary,backend={},threads={},repeats={},mean_elapsed_ms={:.3}",
+            args.backend, args.threads, args.repeats, mean
+        );
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct RunResult {
+    elapsed_ms: f64,
+    result: String,
+}
+
+async fn run_once(args: &Args) -> Result<RunResult, Box<dyn Error>> {
+    let mut bio_config = BioConfig::default();
+    bio_config.count_overlaps_backend = args.backend;
+
+    let mut config = SessionConfig::from(ConfigOptions::new())
+        .with_option_extension(bio_config)
+        .with_information_schema(true)
+        .with_repartition_joins(false)
+        .with_target_partitions(args.threads);
+    if let Some(batch_size) = args.batch_size {
+        config = config.with_batch_size(batch_size);
+    }
+
+    let ctx = SessionContext::new_with_bio(config);
+    register_ranges_functions(&ctx);
+    register_parquet(&ctx, "reads", &args.left).await?;
+    register_parquet(&ctx, "targets", &args.right).await?;
+
+    let start = Instant::now();
+    let batches = ctx
+        .sql("SELECT * FROM count_overlaps('reads', 'targets')")
+        .await?
+        .collect()
+        .await?;
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let n_rows = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
+    let total_overlaps = batches
+        .iter()
+        .map(|batch| -> Result<i64, Box<dyn Error>> {
+            let count = batch
+                .column_by_name("count")
+                .ok_or_else(|| "count column not found in count_overlaps output".to_string())?;
+            let count = count
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| "count column is not Int64".to_string())?;
+            Ok(count.values().iter().sum::<i64>())
+        })
+        .sum::<Result<i64, Box<dyn Error>>>()?;
+    let result = format!("n_rows={n_rows},total_overlaps={total_overlaps}");
+
+    Ok(RunResult { elapsed_ms, result })
+}
+
+async fn register_parquet(
+    ctx: &SessionContext,
+    table: &str,
+    path: &Path,
+) -> Result<(), Box<dyn Error>> {
+    let path = path
+        .to_str()
+        .ok_or_else(|| format!("path for table {table} is not valid UTF-8"))?
+        .replace('\'', "''");
+    ctx.sql(&format!(
+        "CREATE EXTERNAL TABLE {table} STORED AS PARQUET LOCATION '{path}'"
+    ))
+    .await?;
+    Ok(())
+}
+
+impl Args {
+    fn parse() -> Result<Self, Box<dyn Error>> {
+        let mut left = PathBuf::from("/tmp/polars-bio-bench/databio/ex-rna");
+        let mut right = PathBuf::from("/tmp/polars-bio-bench/databio/ex-anno");
+        let mut backend = CountOverlapsBackendMode::Auto;
+        let mut threads = 1usize;
+        let mut repeats = 3usize;
+        let mut warmups = 1usize;
+        let mut batch_size = None;
+
+        let mut args = std::env::args().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--left" => left = PathBuf::from(next_value(&mut args, "--left")?),
+                "--right" => right = PathBuf::from(next_value(&mut args, "--right")?),
+                "--backend" => {
+                    backend =
+                        CountOverlapsBackendMode::from_str(&next_value(&mut args, "--backend")?)?
+                }
+                "--threads" => threads = next_value(&mut args, "--threads")?.parse()?,
+                "--repeats" => repeats = next_value(&mut args, "--repeats")?.parse()?,
+                "--warmups" => warmups = next_value(&mut args, "--warmups")?.parse()?,
+                "--batch-size" => {
+                    batch_size = Some(next_value(&mut args, "--batch-size")?.parse()?)
+                }
+                "--help" | "-h" => {
+                    print_usage();
+                    std::process::exit(0);
+                }
+                other => return Err(format!("unknown argument: {other}").into()),
+            }
+        }
+
+        if threads == 0 {
+            return Err("--threads must be greater than zero".into());
+        }
+
+        Ok(Self {
+            left,
+            right,
+            backend,
+            threads,
+            repeats,
+            warmups,
+            batch_size,
+        })
+    }
+}
+
+fn next_value(
+    args: &mut impl Iterator<Item = String>,
+    flag: &'static str,
+) -> Result<String, Box<dyn Error>> {
+    args.next()
+        .ok_or_else(|| format!("missing value for {flag}").into())
+}
+
+fn print_usage() {
+    println!(
+        "Usage: count_overlaps_bench [--left PATH] [--right PATH] [--backend auto|cpu|apple_gpu] [--threads N] [--repeats N] [--warmups N] [--batch-size N]"
+    );
+}

--- a/datafusion/bio-function-ranges/src/count_overlaps.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::collections::BTreeSet;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
 use ahash::AHashMap;
 use async_trait::async_trait;
@@ -34,6 +36,82 @@ use crate::session_context::{BioConfig, CountOverlapsBackendMode};
 // ex-rna (9,944,559 left intervals) vs ex-anno (1,194,285 right intervals).
 // Keep this conservative until a broader size/distribution matrix is measured.
 const AUTO_APPLE_GPU_MIN_LEFT_INTERVALS: usize = 5_000_000;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CountOverlapsTimingSnapshot {
+    pub scans: u64,
+    pub left_rows: u64,
+    pub left_collect_ns: u64,
+    pub backend_build_ns: u64,
+    pub right_plan_ns: u64,
+    pub scan_total_ns: u64,
+}
+
+struct CountOverlapsTimingCounters {
+    scans: AtomicU64,
+    left_rows: AtomicU64,
+    left_collect_ns: AtomicU64,
+    backend_build_ns: AtomicU64,
+    right_plan_ns: AtomicU64,
+    scan_total_ns: AtomicU64,
+}
+
+static COUNT_OVERLAPS_TIMINGS: CountOverlapsTimingCounters = CountOverlapsTimingCounters {
+    scans: AtomicU64::new(0),
+    left_rows: AtomicU64::new(0),
+    left_collect_ns: AtomicU64::new(0),
+    backend_build_ns: AtomicU64::new(0),
+    right_plan_ns: AtomicU64::new(0),
+    scan_total_ns: AtomicU64::new(0),
+};
+
+pub fn reset_count_overlaps_timings() {
+    COUNT_OVERLAPS_TIMINGS.reset();
+}
+
+pub fn snapshot_count_overlaps_timings() -> CountOverlapsTimingSnapshot {
+    COUNT_OVERLAPS_TIMINGS.snapshot()
+}
+
+impl CountOverlapsTimingCounters {
+    fn reset(&self) {
+        self.scans.store(0, Ordering::Relaxed);
+        self.left_rows.store(0, Ordering::Relaxed);
+        self.left_collect_ns.store(0, Ordering::Relaxed);
+        self.backend_build_ns.store(0, Ordering::Relaxed);
+        self.right_plan_ns.store(0, Ordering::Relaxed);
+        self.scan_total_ns.store(0, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> CountOverlapsTimingSnapshot {
+        CountOverlapsTimingSnapshot {
+            scans: self.scans.load(Ordering::Relaxed),
+            left_rows: self.left_rows.load(Ordering::Relaxed),
+            left_collect_ns: self.left_collect_ns.load(Ordering::Relaxed),
+            backend_build_ns: self.backend_build_ns.load(Ordering::Relaxed),
+            right_plan_ns: self.right_plan_ns.load(Ordering::Relaxed),
+            scan_total_ns: self.scan_total_ns.load(Ordering::Relaxed),
+        }
+    }
+
+    fn record(&self, timings: CountOverlapsTimingSnapshot) {
+        self.scans.fetch_add(timings.scans, Ordering::Relaxed);
+        self.left_rows
+            .fetch_add(timings.left_rows, Ordering::Relaxed);
+        self.left_collect_ns
+            .fetch_add(timings.left_collect_ns, Ordering::Relaxed);
+        self.backend_build_ns
+            .fetch_add(timings.backend_build_ns, Ordering::Relaxed);
+        self.right_plan_ns
+            .fetch_add(timings.right_plan_ns, Ordering::Relaxed);
+        self.scan_total_ns
+            .fetch_add(timings.scan_total_ns, Ordering::Relaxed);
+    }
+}
+
+fn elapsed_ns(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
 
 pub struct CountOverlapsProvider {
     session: Arc<SessionContext>,
@@ -116,6 +194,7 @@ impl TableProvider for CountOverlapsProvider {
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let scan_start = Instant::now();
         let target_partitions = self
             .session
             .state()
@@ -124,6 +203,7 @@ impl TableProvider for CountOverlapsProvider {
             .execution
             .target_partitions;
 
+        let left_collect_start = Instant::now();
         let left_table = self
             .session
             .table(self.left_table.clone())
@@ -131,6 +211,8 @@ impl TableProvider for CountOverlapsProvider {
             .select_columns(&[&self.columns_1.0, &self.columns_1.1, &self.columns_1.2])?
             .collect()
             .await?;
+        let left_collect_ns = elapsed_ns(left_collect_start);
+        let left_interval_count = left_table.iter().map(RecordBatch::num_rows).sum::<usize>();
 
         let default = BioConfig::default();
         let state = self.session.state();
@@ -140,8 +222,11 @@ impl TableProvider for CountOverlapsProvider {
             .extensions
             .get::<BioConfig>()
             .unwrap_or(&default);
+        let backend_build_start = Instant::now();
         let backend = self.select_backend(left_table, bio_config.count_overlaps_backend)?;
+        let backend_build_ns = elapsed_ns(backend_build_start);
 
+        let right_plan_start = Instant::now();
         let full_schema = self.schema();
         let full_field_count = full_schema.fields().len();
         let count_index = full_field_count.checked_sub(1).ok_or_else(|| {
@@ -210,6 +295,15 @@ impl TableProvider for CountOverlapsProvider {
                 )?)
             };
         let output_partitions = right_plan.output_partitioning().partition_count();
+        let right_plan_ns = elapsed_ns(right_plan_start);
+        COUNT_OVERLAPS_TIMINGS.record(CountOverlapsTimingSnapshot {
+            scans: 1,
+            left_rows: u64::try_from(left_interval_count).unwrap_or(u64::MAX),
+            left_collect_ns,
+            backend_build_ns,
+            right_plan_ns,
+            scan_total_ns: elapsed_ns(scan_start),
+        });
 
         Ok(Arc::new(CountOverlapsExec {
             output_schema: output_schema.clone(),

--- a/datafusion/bio-function-ranges/src/count_overlaps.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use async_trait::async_trait;
 use coitrees::COITree;
+use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef, Schema, SchemaRef};
 use datafusion::catalog::Session;
 use datafusion::common::{DataFusionError, Result};
@@ -17,9 +18,20 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
 use datafusion::prelude::{Expr, SessionContext};
+use log::warn;
 
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+use crate::count_overlaps_apple_gpu::{AppleGpuCountOverlapsBackend, get_apple_gpu_stream};
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+use crate::count_overlaps_rank::CountOverlapsRankIndex;
 use crate::filter_op::FilterOp;
 use crate::interval_tree::{build_coitree_from_batches, get_stream};
+use crate::session_context::{BioConfig, CountOverlapsBackendMode};
+
+// Initial Auto threshold from the local Apple M3 Max 8-7 release benchmark:
+// ex-rna (9,944,559 left intervals) vs ex-anno (1,194,285 right intervals).
+// Keep this conservative until a broader size/distribution matrix is measured.
+const AUTO_APPLE_GPU_MIN_LEFT_INTERVALS: usize = 5_000_000;
 
 pub struct CountOverlapsProvider {
     session: Arc<SessionContext>,
@@ -118,11 +130,15 @@ impl TableProvider for CountOverlapsProvider {
             .collect()
             .await?;
 
-        let trees = Arc::new(build_coitree_from_batches(
-            left_table,
-            (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2),
-            self.coverage,
-        )?);
+        let default = BioConfig::default();
+        let state = self.session.state();
+        let config = state.config();
+        let bio_config = config
+            .options()
+            .extensions
+            .get::<BioConfig>()
+            .unwrap_or(&default);
+        let backend = self.select_backend(left_table, bio_config.count_overlaps_backend)?;
 
         let right_df = self.session.table(self.right_table.clone()).await?;
         let right_plan = right_df.create_physical_plan().await?;
@@ -139,7 +155,7 @@ impl TableProvider for CountOverlapsProvider {
 
         Ok(Arc::new(CountOverlapsExec {
             schema: self.schema().clone(),
-            trees,
+            backend,
             right: right_plan,
             columns_2: Arc::new(self.columns_2.clone()),
             filter_op: self.filter_op.clone(),
@@ -154,9 +170,84 @@ impl TableProvider for CountOverlapsProvider {
     }
 }
 
+#[derive(Clone)]
+enum CountOverlapsBackendKind {
+    Cpu {
+        trees: Arc<AHashMap<String, COITree<(), u32>>>,
+    },
+    #[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+    AppleGpu {
+        backend: Arc<AppleGpuCountOverlapsBackend>,
+    },
+}
+
+impl CountOverlapsBackendKind {
+    fn name(&self) -> &'static str {
+        match self {
+            CountOverlapsBackendKind::Cpu { .. } => "cpu-coitree",
+            #[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+            CountOverlapsBackendKind::AppleGpu { .. } => "apple-gpu-rank",
+        }
+    }
+}
+
+impl CountOverlapsProvider {
+    fn select_backend(
+        &self,
+        left_table: Vec<RecordBatch>,
+        backend_mode: CountOverlapsBackendMode,
+    ) -> Result<CountOverlapsBackendKind> {
+        let left_interval_count = left_table.iter().map(RecordBatch::num_rows).sum::<usize>();
+        let try_apple_gpu = !self.coverage
+            && match backend_mode {
+                CountOverlapsBackendMode::AppleGpu => true,
+                CountOverlapsBackendMode::Auto => {
+                    left_interval_count >= AUTO_APPLE_GPU_MIN_LEFT_INTERVALS
+                }
+                CountOverlapsBackendMode::Cpu => false,
+            };
+
+        if try_apple_gpu {
+            #[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+            {
+                let rank_index = CountOverlapsRankIndex::build_from_batches(
+                    &left_table,
+                    (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2),
+                )?;
+                match AppleGpuCountOverlapsBackend::try_new(rank_index) {
+                    Ok(backend) => {
+                        return Ok(CountOverlapsBackendKind::AppleGpu {
+                            backend: Arc::new(backend),
+                        });
+                    }
+                    Err(error) => {
+                        warn!(
+                            "falling back to CPU count_overlaps backend after Apple GPU initialization failed: {error}"
+                        );
+                    }
+                }
+            }
+
+            #[cfg(not(all(feature = "apple-gpu", target_os = "macos")))]
+            if backend_mode == CountOverlapsBackendMode::AppleGpu {
+                warn!(
+                    "falling back to CPU count_overlaps backend because apple-gpu feature is not active on macOS"
+                );
+            }
+        }
+
+        let trees = Arc::new(build_coitree_from_batches(
+            left_table,
+            (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2),
+            self.coverage,
+        )?);
+        Ok(CountOverlapsBackendKind::Cpu { trees })
+    }
+}
+
 struct CountOverlapsExec {
     schema: SchemaRef,
-    trees: Arc<AHashMap<String, COITree<(), u32>>>,
+    backend: CountOverlapsBackendKind,
     right: Arc<dyn ExecutionPlan>,
     columns_2: Arc<(String, String, String)>,
     filter_op: FilterOp,
@@ -166,13 +257,17 @@ struct CountOverlapsExec {
 
 impl Debug for CountOverlapsExec {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CountOverlapsExec")
+        write!(
+            f,
+            "CountOverlapsExec {{ backend: {} }}",
+            self.backend.name()
+        )
     }
 }
 
 impl DisplayAs for CountOverlapsExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "CountOverlapsExec")
+        write!(f, "CountOverlapsExec: backend={}", self.backend.name())
     }
 }
 
@@ -205,7 +300,7 @@ impl ExecutionPlan for CountOverlapsExec {
 
         Ok(Arc::new(CountOverlapsExec {
             schema: self.schema.clone(),
-            trees: Arc::clone(&self.trees),
+            backend: self.backend.clone(),
             right: Arc::clone(&children[0]),
             columns_2: Arc::clone(&self.columns_2),
             filter_op: self.filter_op.clone(),
@@ -226,15 +321,27 @@ impl ExecutionPlan for CountOverlapsExec {
         partition: usize,
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        get_stream(
-            Arc::clone(&self.right),
-            self.trees.clone(),
-            self.schema.clone(),
-            Arc::clone(&self.columns_2),
-            self.filter_op.clone(),
-            self.coverage,
-            partition,
-            context,
-        )
+        match &self.backend {
+            CountOverlapsBackendKind::Cpu { trees } => get_stream(
+                Arc::clone(&self.right),
+                Arc::clone(trees),
+                self.schema.clone(),
+                Arc::clone(&self.columns_2),
+                self.filter_op.clone(),
+                self.coverage,
+                partition,
+                context,
+            ),
+            #[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+            CountOverlapsBackendKind::AppleGpu { backend } => get_apple_gpu_stream(
+                Arc::clone(&self.right),
+                Arc::clone(backend),
+                self.schema.clone(),
+                Arc::clone(&self.columns_2),
+                self.filter_op.clone(),
+                partition,
+                context,
+            ),
+        }
     }
 }

--- a/datafusion/bio-function-ranges/src/count_overlaps.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::collections::BTreeSet;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -24,6 +25,7 @@ use log::warn;
 use crate::count_overlaps_apple_gpu::{AppleGpuCountOverlapsBackend, get_apple_gpu_stream};
 #[cfg(all(feature = "apple-gpu", target_os = "macos"))]
 use crate::count_overlaps_rank::CountOverlapsRankIndex;
+use crate::count_overlaps_rank::OutputColumnSource;
 use crate::filter_op::FilterOp;
 use crate::interval_tree::{build_coitree_from_batches, get_stream};
 use crate::session_context::{BioConfig, CountOverlapsBackendMode};
@@ -140,7 +142,63 @@ impl TableProvider for CountOverlapsProvider {
             .unwrap_or(&default);
         let backend = self.select_backend(left_table, bio_config.count_overlaps_backend)?;
 
-        let right_df = self.session.table(self.right_table.clone()).await?;
+        let full_schema = self.schema();
+        let full_field_count = full_schema.fields().len();
+        let count_index = full_field_count.checked_sub(1).ok_or_else(|| {
+            DataFusionError::Internal("count_overlaps schema has no fields".to_string())
+        })?;
+        let requested_projection = projection
+            .cloned()
+            .unwrap_or_else(|| (0..full_field_count).collect());
+        let output_schema = Arc::new(full_schema.project(&requested_projection)?);
+
+        let interval_indices = [
+            full_schema.index_of(&self.columns_2.0)?,
+            full_schema.index_of(&self.columns_2.1)?,
+            full_schema.index_of(&self.columns_2.2)?,
+        ];
+        let mut right_projection = BTreeSet::new();
+        for &idx in &requested_projection {
+            if idx < count_index {
+                right_projection.insert(idx);
+            }
+        }
+        for idx in interval_indices {
+            right_projection.insert(idx);
+        }
+        let right_projection = right_projection.into_iter().collect::<Vec<_>>();
+        let mut full_to_right_input = vec![None; count_index];
+        for (input_idx, &full_idx) in right_projection.iter().enumerate() {
+            full_to_right_input[full_idx] = Some(input_idx);
+        }
+        let output_sources = requested_projection
+            .iter()
+            .map(|&idx| {
+                if idx == count_index {
+                    Ok(OutputColumnSource::Count)
+                } else if idx < count_index {
+                    full_to_right_input[idx].map(OutputColumnSource::Input).ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "count_overlaps missing right input column for projected field {idx}"
+                        ))
+                    })
+                } else {
+                    Err(DataFusionError::Internal(format!(
+                        "count_overlaps projection index {idx} exceeds schema field count {full_field_count}"
+                    )))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let right_projection_names = right_projection
+            .iter()
+            .map(|&idx| full_schema.field(idx).name().as_str())
+            .collect::<Vec<_>>();
+
+        let right_df = self
+            .session
+            .table(self.right_table.clone())
+            .await?
+            .select_columns(&right_projection_names)?;
         let right_plan = right_df.create_physical_plan().await?;
         let right_plan: Arc<dyn ExecutionPlan> =
             if right_plan.output_partitioning().partition_count() == target_partitions {
@@ -152,17 +210,10 @@ impl TableProvider for CountOverlapsProvider {
                 )?)
             };
         let output_partitions = right_plan.output_partitioning().partition_count();
-        let full_schema = self.schema();
-        let projection = projection.cloned().map(Arc::new);
-        let output_schema = match projection.as_deref() {
-            Some(projection) => Arc::new(full_schema.project(projection)?),
-            None => full_schema.clone(),
-        };
 
         Ok(Arc::new(CountOverlapsExec {
-            full_schema,
             output_schema: output_schema.clone(),
-            projection,
+            output_sources: Arc::new(output_sources),
             backend,
             right: right_plan,
             columns_2: Arc::new(self.columns_2.clone()),
@@ -254,9 +305,8 @@ impl CountOverlapsProvider {
 }
 
 struct CountOverlapsExec {
-    full_schema: SchemaRef,
     output_schema: SchemaRef,
-    projection: Option<Arc<Vec<usize>>>,
+    output_sources: Arc<Vec<OutputColumnSource>>,
     backend: CountOverlapsBackendKind,
     right: Arc<dyn ExecutionPlan>,
     columns_2: Arc<(String, String, String)>,
@@ -309,9 +359,8 @@ impl ExecutionPlan for CountOverlapsExec {
         }
 
         Ok(Arc::new(CountOverlapsExec {
-            full_schema: self.full_schema.clone(),
             output_schema: self.output_schema.clone(),
-            projection: self.projection.clone(),
+            output_sources: self.output_sources.clone(),
             backend: self.backend.clone(),
             right: Arc::clone(&children[0]),
             columns_2: Arc::clone(&self.columns_2),
@@ -337,9 +386,8 @@ impl ExecutionPlan for CountOverlapsExec {
             CountOverlapsBackendKind::Cpu { trees } => get_stream(
                 Arc::clone(&self.right),
                 Arc::clone(trees),
-                self.full_schema.clone(),
                 self.output_schema.clone(),
-                self.projection.clone(),
+                self.output_sources.clone(),
                 Arc::clone(&self.columns_2),
                 self.filter_op.clone(),
                 self.coverage,
@@ -350,9 +398,8 @@ impl ExecutionPlan for CountOverlapsExec {
             CountOverlapsBackendKind::AppleGpu { backend } => get_apple_gpu_stream(
                 Arc::clone(&self.right),
                 Arc::clone(backend),
-                self.full_schema.clone(),
                 self.output_schema.clone(),
-                self.projection.clone(),
+                self.output_sources.clone(),
                 Arc::clone(&self.columns_2),
                 self.filter_op.clone(),
                 partition,

--- a/datafusion/bio-function-ranges/src/count_overlaps.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps.rs
@@ -110,7 +110,7 @@ impl TableProvider for CountOverlapsProvider {
     async fn scan(
         &self,
         _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -152,16 +152,24 @@ impl TableProvider for CountOverlapsProvider {
                 )?)
             };
         let output_partitions = right_plan.output_partitioning().partition_count();
+        let full_schema = self.schema();
+        let projection = projection.cloned().map(Arc::new);
+        let output_schema = match projection.as_deref() {
+            Some(projection) => Arc::new(full_schema.project(projection)?),
+            None => full_schema.clone(),
+        };
 
         Ok(Arc::new(CountOverlapsExec {
-            schema: self.schema().clone(),
+            full_schema,
+            output_schema: output_schema.clone(),
+            projection,
             backend,
             right: right_plan,
             columns_2: Arc::new(self.columns_2.clone()),
             filter_op: self.filter_op.clone(),
             coverage: self.coverage,
             cache: PlanProperties::new(
-                EquivalenceProperties::new(self.schema().clone()),
+                EquivalenceProperties::new(output_schema),
                 Partitioning::UnknownPartitioning(output_partitions),
                 EmissionType::Final,
                 Boundedness::Bounded,
@@ -246,7 +254,9 @@ impl CountOverlapsProvider {
 }
 
 struct CountOverlapsExec {
-    schema: SchemaRef,
+    full_schema: SchemaRef,
+    output_schema: SchemaRef,
+    projection: Option<Arc<Vec<usize>>>,
     backend: CountOverlapsBackendKind,
     right: Arc<dyn ExecutionPlan>,
     columns_2: Arc<(String, String, String)>,
@@ -299,14 +309,16 @@ impl ExecutionPlan for CountOverlapsExec {
         }
 
         Ok(Arc::new(CountOverlapsExec {
-            schema: self.schema.clone(),
+            full_schema: self.full_schema.clone(),
+            output_schema: self.output_schema.clone(),
+            projection: self.projection.clone(),
             backend: self.backend.clone(),
             right: Arc::clone(&children[0]),
             columns_2: Arc::clone(&self.columns_2),
             filter_op: self.filter_op.clone(),
             coverage: self.coverage,
             cache: PlanProperties::new(
-                EquivalenceProperties::new(self.schema.clone()),
+                EquivalenceProperties::new(self.output_schema.clone()),
                 Partitioning::UnknownPartitioning(
                     children[0].output_partitioning().partition_count(),
                 ),
@@ -325,7 +337,9 @@ impl ExecutionPlan for CountOverlapsExec {
             CountOverlapsBackendKind::Cpu { trees } => get_stream(
                 Arc::clone(&self.right),
                 Arc::clone(trees),
-                self.schema.clone(),
+                self.full_schema.clone(),
+                self.output_schema.clone(),
+                self.projection.clone(),
                 Arc::clone(&self.columns_2),
                 self.filter_op.clone(),
                 self.coverage,
@@ -336,7 +350,9 @@ impl ExecutionPlan for CountOverlapsExec {
             CountOverlapsBackendKind::AppleGpu { backend } => get_apple_gpu_stream(
                 Arc::clone(&self.right),
                 Arc::clone(backend),
-                self.schema.clone(),
+                self.full_schema.clone(),
+                self.output_schema.clone(),
+                self.projection.clone(),
                 Arc::clone(&self.columns_2),
                 self.filter_op.clone(),
                 partition,

--- a/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
@@ -19,7 +19,9 @@ use objc2_metal::{
     MTLResourceOptions, MTLSize,
 };
 
-use crate::count_overlaps_rank::{CountOverlapsRankIndex, MISSING_CONTIG_ID, append_count_column};
+use crate::count_overlaps_rank::{
+    CountOverlapsRankIndex, MISSING_CONTIG_ID, append_count_column, project_batch,
+};
 use crate::filter_op::FilterOp;
 
 #[link(name = "CoreGraphics", kind = "framework")]
@@ -152,13 +154,16 @@ impl AppleGpuCountOverlapsBackend {
     fn execute_batch(
         &self,
         batch: &datafusion::arrow::array::RecordBatch,
-        schema: SchemaRef,
+        full_schema: SchemaRef,
+        output_schema: SchemaRef,
+        projection: Option<&[usize]>,
         columns: (&str, &str, &str),
         filter_op: FilterOp,
     ) -> Result<datafusion::arrow::array::RecordBatch> {
         let queries = self.index.encode_query_batch(batch, columns, filter_op)?;
         if queries.query_contigs.is_empty() {
-            return append_count_column(batch, schema, Vec::new());
+            let batch = append_count_column(batch, full_schema, Vec::new())?;
+            return project_batch(batch, output_schema, projection);
         }
 
         let query_contigs = self.runtime.new_buffer_from_slice(&queries.query_contigs)?;
@@ -218,7 +223,8 @@ impl AppleGpuCountOverlapsBackend {
             let ptr = output.contents().as_ptr().cast::<i64>();
             std::slice::from_raw_parts(ptr, queries.query_contigs.len()).to_vec()
         };
-        append_count_column(batch, schema, counts)
+        let batch = append_count_column(batch, full_schema, counts)?;
+        project_batch(batch, output_schema, projection)
     }
 }
 
@@ -314,26 +320,32 @@ impl MetalRuntime {
 pub fn get_apple_gpu_stream(
     right_plan: Arc<dyn ExecutionPlan>,
     backend: Arc<AppleGpuCountOverlapsBackend>,
-    new_schema: SchemaRef,
+    full_schema: SchemaRef,
+    output_schema: SchemaRef,
+    projection: Option<Arc<Vec<usize>>>,
     columns_2: Arc<(String, String, String)>,
     filter_op: FilterOp,
     partition: usize,
     context: Arc<TaskContext>,
 ) -> Result<SendableRecordBatchStream> {
     let partition_stream = right_plan.execute(partition, context)?;
-    let schema_for_closure = new_schema.clone();
+    let full_schema_for_closure = full_schema.clone();
+    let output_schema_for_closure = output_schema.clone();
+    let projection_for_closure = projection.clone();
     let iter = partition_stream.map(move |rb| {
         rb.and_then(|rb| {
             backend.execute_batch(
                 &rb,
-                schema_for_closure.clone(),
+                full_schema_for_closure.clone(),
+                output_schema_for_closure.clone(),
+                projection_for_closure.as_deref().map(Vec::as_slice),
                 (&columns_2.0, &columns_2.1, &columns_2.2),
                 filter_op.clone(),
             )
         })
     });
     Ok(Box::pin(RecordBatchStreamAdapter::new(
-        new_schema,
+        output_schema,
         Box::pin(iter) as BoxStream<'static, Result<datafusion::arrow::array::RecordBatch>>,
     )))
 }

--- a/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
@@ -1,0 +1,344 @@
+use std::ffi::c_void;
+use std::mem::{size_of, size_of_val};
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2_foundation::NSString;
+use objc2_metal::{
+    MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue, MTLComputeCommandEncoder,
+    MTLComputePipelineState, MTLCreateSystemDefaultDevice, MTLDevice, MTLLibrary,
+    MTLResourceOptions, MTLSize,
+};
+
+use crate::count_overlaps_rank::{CountOverlapsRankIndex, MISSING_CONTIG_ID, append_count_column};
+use crate::filter_op::FilterOp;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {}
+
+const KERNEL_SOURCE: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+struct ContigRange {
+    uint start_offset;
+    uint end_offset;
+    uint len;
+    uint pad;
+};
+
+static inline uint upper_bound_i64(device const long* values, uint offset, uint len, long needle) {
+    uint lo = 0;
+    uint hi = len;
+    while (lo < hi) {
+        uint mid = lo + ((hi - lo) >> 1);
+        if (values[offset + mid] <= needle) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+static inline uint lower_bound_i64(device const long* values, uint offset, uint len, long needle) {
+    uint lo = 0;
+    uint hi = len;
+    while (lo < hi) {
+        uint mid = lo + ((hi - lo) >> 1);
+        if (values[offset + mid] < needle) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+kernel void count_overlaps_rank(
+    device const ContigRange* contigs [[buffer(0)]],
+    device const long* starts [[buffer(1)]],
+    device const long* ends [[buffer(2)]],
+    device const uint* query_contigs [[buffer(3)]],
+    device const long* query_starts [[buffer(4)]],
+    device const long* query_ends [[buffer(5)]],
+    device long* output [[buffer(6)]],
+    constant uint& n_queries [[buffer(7)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= n_queries) {
+        return;
+    }
+
+    uint contig_id = query_contigs[gid];
+    long query_start = query_starts[gid];
+    long query_end = query_ends[gid];
+    if (contig_id == 0xffffffffu || query_start > query_end) {
+        output[gid] = 0;
+        return;
+    }
+
+    ContigRange range = contigs[contig_id];
+    uint started = upper_bound_i64(starts, range.start_offset, range.len, query_end);
+    uint ended_prior = lower_bound_i64(ends, range.end_offset, range.len, query_start);
+    output[gid] = long(started - ended_prior);
+}
+"#;
+
+type MetalDevice = ProtocolObject<dyn MTLDevice>;
+type MetalCommandQueue = ProtocolObject<dyn MTLCommandQueue>;
+type MetalComputePipelineState = ProtocolObject<dyn MTLComputePipelineState>;
+type MetalBuffer = ProtocolObject<dyn MTLBuffer>;
+
+pub struct AppleGpuCountOverlapsBackend {
+    index: CountOverlapsRankIndex,
+    runtime: MetalRuntime,
+    contig_buffer: SharedMetalBuffer,
+    starts_buffer: SharedMetalBuffer,
+    ends_buffer: SharedMetalBuffer,
+}
+
+struct MetalRuntime {
+    device: Retained<MetalDevice>,
+    queue: Retained<MetalCommandQueue>,
+    pipeline: Retained<MetalComputePipelineState>,
+}
+
+struct SharedMetalBuffer(Retained<MetalBuffer>);
+
+// MTLBuffer is safe to share here because these buffers are immutable after
+// initialization, command buffers retain referenced resources, and batch-local
+// writable buffers are never stored in this shared wrapper.
+unsafe impl Send for SharedMetalBuffer {}
+unsafe impl Sync for SharedMetalBuffer {}
+
+impl SharedMetalBuffer {
+    fn as_buffer(&self) -> &MetalBuffer {
+        &self.0
+    }
+}
+
+impl AppleGpuCountOverlapsBackend {
+    pub fn try_new(index: CountOverlapsRankIndex) -> Result<Self> {
+        if index.interval_count() == 0 {
+            return Err(DataFusionError::Execution(
+                "Apple GPU count_overlaps backend requires a non-empty left index".to_string(),
+            ));
+        }
+
+        let runtime = MetalRuntime::new()?;
+        let contig_buffer = runtime.new_buffer_from_slice(index.contigs())?;
+        let starts_buffer = runtime.new_buffer_from_slice(index.starts_sorted())?;
+        let ends_buffer = runtime.new_buffer_from_slice(index.ends_sorted())?;
+
+        Ok(Self {
+            index,
+            runtime,
+            contig_buffer: SharedMetalBuffer(contig_buffer),
+            starts_buffer: SharedMetalBuffer(starts_buffer),
+            ends_buffer: SharedMetalBuffer(ends_buffer),
+        })
+    }
+
+    fn execute_batch(
+        &self,
+        batch: &datafusion::arrow::array::RecordBatch,
+        schema: SchemaRef,
+        columns: (&str, &str, &str),
+        filter_op: FilterOp,
+    ) -> Result<datafusion::arrow::array::RecordBatch> {
+        let queries = self.index.encode_query_batch(batch, columns, filter_op)?;
+        if queries.query_contigs.is_empty() {
+            return append_count_column(batch, schema, Vec::new());
+        }
+
+        let query_contigs = self.runtime.new_buffer_from_slice(&queries.query_contigs)?;
+        let query_starts = self.runtime.new_buffer_from_slice(&queries.query_starts)?;
+        let query_ends = self.runtime.new_buffer_from_slice(&queries.query_ends)?;
+        let output = self
+            .runtime
+            .new_buffer_with_len(queries.query_contigs.len() * size_of::<i64>())?;
+
+        let command_buffer = self.runtime.queue.commandBuffer().ok_or_else(|| {
+            DataFusionError::Execution("failed to create Metal command buffer".to_string())
+        })?;
+        let encoder = command_buffer.computeCommandEncoder().ok_or_else(|| {
+            DataFusionError::Execution("failed to create Metal compute encoder".to_string())
+        })?;
+
+        encoder.setComputePipelineState(&self.runtime.pipeline);
+        unsafe {
+            encoder.setBuffer_offset_atIndex(Some(self.contig_buffer.as_buffer()), 0, 0);
+            encoder.setBuffer_offset_atIndex(Some(self.starts_buffer.as_buffer()), 0, 1);
+            encoder.setBuffer_offset_atIndex(Some(self.ends_buffer.as_buffer()), 0, 2);
+            encoder.setBuffer_offset_atIndex(Some(&query_contigs), 0, 3);
+            encoder.setBuffer_offset_atIndex(Some(&query_starts), 0, 4);
+            encoder.setBuffer_offset_atIndex(Some(&query_ends), 0, 5);
+            encoder.setBuffer_offset_atIndex(Some(&output), 0, 6);
+
+            let n_queries = u32::try_from(queries.query_contigs.len()).map_err(|_| {
+                DataFusionError::Execution(
+                    "count_overlaps GPU query batch exceeds u32::MAX rows".to_string(),
+                )
+            })?;
+            encoder.setBytes_length_atIndex(
+                NonNull::from(&n_queries).cast::<c_void>(),
+                size_of::<u32>(),
+                7,
+            );
+        }
+
+        let threads_per_group = self.runtime.threads_per_threadgroup();
+        let threads_per_grid = MTLSize {
+            width: queries.query_contigs.len(),
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatchThreads_threadsPerThreadgroup(threads_per_grid, threads_per_group);
+        encoder.endEncoding();
+        command_buffer.commit();
+        command_buffer.waitUntilCompleted();
+
+        if let Some(error) = command_buffer.error() {
+            return Err(DataFusionError::Execution(format!(
+                "Metal count_overlaps command failed: {error}"
+            )));
+        }
+
+        let counts = unsafe {
+            let ptr = output.contents().as_ptr().cast::<i64>();
+            std::slice::from_raw_parts(ptr, queries.query_contigs.len()).to_vec()
+        };
+        append_count_column(batch, schema, counts)
+    }
+}
+
+impl MetalRuntime {
+    fn new() -> Result<Self> {
+        let device = MTLCreateSystemDefaultDevice().ok_or_else(|| {
+            DataFusionError::Execution("no default Metal device is available".to_string())
+        })?;
+        let queue = device.newCommandQueue().ok_or_else(|| {
+            DataFusionError::Execution("failed to create Metal command queue".to_string())
+        })?;
+        let source = NSString::from_str(KERNEL_SOURCE);
+        let library = device
+            .newLibraryWithSource_options_error(&source, None)
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "failed to compile count_overlaps Metal library: {error}"
+                ))
+            })?;
+        let function_name = NSString::from_str("count_overlaps_rank");
+        let function = library.newFunctionWithName(&function_name).ok_or_else(|| {
+            DataFusionError::Execution(
+                "count_overlaps_rank Metal function was not found".to_string(),
+            )
+        })?;
+        let pipeline = device
+            .newComputePipelineStateWithFunction_error(&function)
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "failed to create count_overlaps Metal pipeline: {error}"
+                ))
+            })?;
+
+        Ok(Self {
+            device,
+            queue,
+            pipeline,
+        })
+    }
+
+    fn new_buffer_from_slice<T>(&self, values: &[T]) -> Result<Retained<MetalBuffer>> {
+        if values.is_empty() {
+            return self.new_buffer_with_len(1);
+        }
+        let len = size_of_val(values);
+        let ptr = NonNull::new(values.as_ptr() as *mut c_void).ok_or_else(|| {
+            DataFusionError::Execution("cannot create Metal buffer from null slice".to_string())
+        })?;
+        unsafe {
+            self.device
+                .newBufferWithBytes_length_options(ptr, len, MTLResourceOptions::StorageModeShared)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "failed to create Metal buffer with {len} bytes"
+                    ))
+                })
+        }
+    }
+
+    fn new_buffer_with_len(&self, len: usize) -> Result<Retained<MetalBuffer>> {
+        self.device
+            .newBufferWithLength_options(len.max(1), MTLResourceOptions::StorageModeShared)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "failed to allocate Metal buffer with {} bytes",
+                    len.max(1)
+                ))
+            })
+    }
+
+    fn threads_per_threadgroup(&self) -> MTLSize {
+        let width = self.runtime_thread_width().clamp(1, 256);
+        MTLSize {
+            width,
+            height: 1,
+            depth: 1,
+        }
+    }
+
+    fn runtime_thread_width(&self) -> usize {
+        let execution_width = self.pipeline.threadExecutionWidth();
+        let max_threads = self.pipeline.maxTotalThreadsPerThreadgroup();
+        let preferred = if execution_width == 0 {
+            128
+        } else {
+            execution_width * 4
+        };
+        preferred.min(max_threads.max(1))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn get_apple_gpu_stream(
+    right_plan: Arc<dyn ExecutionPlan>,
+    backend: Arc<AppleGpuCountOverlapsBackend>,
+    new_schema: SchemaRef,
+    columns_2: Arc<(String, String, String)>,
+    filter_op: FilterOp,
+    partition: usize,
+    context: Arc<TaskContext>,
+) -> Result<SendableRecordBatchStream> {
+    let partition_stream = right_plan.execute(partition, context)?;
+    let schema_for_closure = new_schema.clone();
+    let iter = partition_stream.map(move |rb| {
+        rb.and_then(|rb| {
+            backend.execute_batch(
+                &rb,
+                schema_for_closure.clone(),
+                (&columns_2.0, &columns_2.1, &columns_2.2),
+                filter_op.clone(),
+            )
+        })
+    });
+    Ok(Box::pin(RecordBatchStreamAdapter::new(
+        new_schema,
+        Box::pin(iter) as BoxStream<'static, Result<datafusion::arrow::array::RecordBatch>>,
+    )))
+}
+
+#[allow(dead_code)]
+fn _assert_missing_contig_id_matches_kernel() {
+    const _: u32 = MISSING_CONTIG_ID;
+}

--- a/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
@@ -2,7 +2,10 @@ use std::ffi::c_void;
 use std::mem::{size_of, size_of_val};
 use std::ptr::NonNull;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
+use datafusion::arrow::compute::concat_batches;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -96,6 +99,8 @@ kernel void count_overlaps_rank(
 }
 "#;
 
+const GPU_COALESCED_TARGET_ROWS: usize = 65_536;
+
 type MetalDevice = ProtocolObject<dyn MTLDevice>;
 type MetalCommandQueue = ProtocolObject<dyn MTLCommandQueue>;
 type MetalComputePipelineState = ProtocolObject<dyn MTLComputePipelineState>;
@@ -108,6 +113,43 @@ pub struct AppleGpuCountOverlapsBackend {
     starts_buffer: SharedMetalBuffer,
     ends_buffer: SharedMetalBuffer,
 }
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AppleGpuTimingSnapshot {
+    pub batches: u64,
+    pub rows: u64,
+    pub encode_ns: u64,
+    pub buffer_ns: u64,
+    pub command_ns: u64,
+    pub wait_ns: u64,
+    pub readback_ns: u64,
+    pub output_ns: u64,
+    pub total_ns: u64,
+}
+
+struct AppleGpuTimingCounters {
+    batches: AtomicU64,
+    rows: AtomicU64,
+    encode_ns: AtomicU64,
+    buffer_ns: AtomicU64,
+    command_ns: AtomicU64,
+    wait_ns: AtomicU64,
+    readback_ns: AtomicU64,
+    output_ns: AtomicU64,
+    total_ns: AtomicU64,
+}
+
+static APPLE_GPU_TIMINGS: AppleGpuTimingCounters = AppleGpuTimingCounters {
+    batches: AtomicU64::new(0),
+    rows: AtomicU64::new(0),
+    encode_ns: AtomicU64::new(0),
+    buffer_ns: AtomicU64::new(0),
+    command_ns: AtomicU64::new(0),
+    wait_ns: AtomicU64::new(0),
+    readback_ns: AtomicU64::new(0),
+    output_ns: AtomicU64::new(0),
+    total_ns: AtomicU64::new(0),
+};
 
 struct MetalRuntime {
     device: Retained<MetalDevice>,
@@ -127,6 +169,63 @@ impl SharedMetalBuffer {
     fn as_buffer(&self) -> &MetalBuffer {
         &self.0
     }
+}
+
+pub fn reset_apple_gpu_timings() {
+    APPLE_GPU_TIMINGS.reset();
+}
+
+pub fn snapshot_apple_gpu_timings() -> AppleGpuTimingSnapshot {
+    APPLE_GPU_TIMINGS.snapshot()
+}
+
+impl AppleGpuTimingCounters {
+    fn reset(&self) {
+        self.batches.store(0, Ordering::Relaxed);
+        self.rows.store(0, Ordering::Relaxed);
+        self.encode_ns.store(0, Ordering::Relaxed);
+        self.buffer_ns.store(0, Ordering::Relaxed);
+        self.command_ns.store(0, Ordering::Relaxed);
+        self.wait_ns.store(0, Ordering::Relaxed);
+        self.readback_ns.store(0, Ordering::Relaxed);
+        self.output_ns.store(0, Ordering::Relaxed);
+        self.total_ns.store(0, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> AppleGpuTimingSnapshot {
+        AppleGpuTimingSnapshot {
+            batches: self.batches.load(Ordering::Relaxed),
+            rows: self.rows.load(Ordering::Relaxed),
+            encode_ns: self.encode_ns.load(Ordering::Relaxed),
+            buffer_ns: self.buffer_ns.load(Ordering::Relaxed),
+            command_ns: self.command_ns.load(Ordering::Relaxed),
+            wait_ns: self.wait_ns.load(Ordering::Relaxed),
+            readback_ns: self.readback_ns.load(Ordering::Relaxed),
+            output_ns: self.output_ns.load(Ordering::Relaxed),
+            total_ns: self.total_ns.load(Ordering::Relaxed),
+        }
+    }
+
+    fn record(&self, timings: AppleGpuTimingSnapshot) {
+        self.batches.fetch_add(timings.batches, Ordering::Relaxed);
+        self.rows.fetch_add(timings.rows, Ordering::Relaxed);
+        self.encode_ns
+            .fetch_add(timings.encode_ns, Ordering::Relaxed);
+        self.buffer_ns
+            .fetch_add(timings.buffer_ns, Ordering::Relaxed);
+        self.command_ns
+            .fetch_add(timings.command_ns, Ordering::Relaxed);
+        self.wait_ns.fetch_add(timings.wait_ns, Ordering::Relaxed);
+        self.readback_ns
+            .fetch_add(timings.readback_ns, Ordering::Relaxed);
+        self.output_ns
+            .fetch_add(timings.output_ns, Ordering::Relaxed);
+        self.total_ns.fetch_add(timings.total_ns, Ordering::Relaxed);
+    }
+}
+
+fn elapsed_ns(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
 }
 
 impl AppleGpuCountOverlapsBackend {
@@ -159,18 +258,34 @@ impl AppleGpuCountOverlapsBackend {
         columns: (&str, &str, &str),
         filter_op: FilterOp,
     ) -> Result<datafusion::arrow::array::RecordBatch> {
+        let total_start = Instant::now();
+        let encode_start = Instant::now();
         let queries = self.index.encode_query_batch(batch, columns, filter_op)?;
+        let encode_ns = elapsed_ns(encode_start);
         if queries.query_contigs.is_empty() {
-            return build_output_batch(batch, output_schema, output_sources, Vec::new());
+            let output_start = Instant::now();
+            let output = build_output_batch(batch, output_schema, output_sources, Vec::new());
+            APPLE_GPU_TIMINGS.record(AppleGpuTimingSnapshot {
+                batches: 1,
+                rows: 0,
+                encode_ns,
+                output_ns: elapsed_ns(output_start),
+                total_ns: elapsed_ns(total_start),
+                ..Default::default()
+            });
+            return output;
         }
 
+        let buffer_start = Instant::now();
         let query_contigs = self.runtime.new_buffer_from_slice(&queries.query_contigs)?;
         let query_starts = self.runtime.new_buffer_from_slice(&queries.query_starts)?;
         let query_ends = self.runtime.new_buffer_from_slice(&queries.query_ends)?;
         let output = self
             .runtime
             .new_buffer_with_len(queries.query_contigs.len() * size_of::<i64>())?;
+        let buffer_ns = elapsed_ns(buffer_start);
 
+        let command_start = Instant::now();
         let command_buffer = self.runtime.queue.commandBuffer().ok_or_else(|| {
             DataFusionError::Execution("failed to create Metal command buffer".to_string())
         })?;
@@ -209,7 +324,11 @@ impl AppleGpuCountOverlapsBackend {
         encoder.dispatchThreads_threadsPerThreadgroup(threads_per_grid, threads_per_group);
         encoder.endEncoding();
         command_buffer.commit();
+        let command_ns = elapsed_ns(command_start);
+
+        let wait_start = Instant::now();
         command_buffer.waitUntilCompleted();
+        let wait_ns = elapsed_ns(wait_start);
 
         if let Some(error) = command_buffer.error() {
             return Err(DataFusionError::Execution(format!(
@@ -217,11 +336,28 @@ impl AppleGpuCountOverlapsBackend {
             )));
         }
 
+        let readback_start = Instant::now();
         let counts = unsafe {
             let ptr = output.contents().as_ptr().cast::<i64>();
             std::slice::from_raw_parts(ptr, queries.query_contigs.len()).to_vec()
         };
-        build_output_batch(batch, output_schema, output_sources, counts)
+        let readback_ns = elapsed_ns(readback_start);
+
+        let output_start = Instant::now();
+        let output = build_output_batch(batch, output_schema, output_sources, counts);
+        let output_ns = elapsed_ns(output_start);
+        APPLE_GPU_TIMINGS.record(AppleGpuTimingSnapshot {
+            batches: 1,
+            rows: u64::try_from(queries.query_contigs.len()).unwrap_or(u64::MAX),
+            encode_ns,
+            buffer_ns,
+            command_ns,
+            wait_ns,
+            readback_ns,
+            output_ns,
+            total_ns: elapsed_ns(total_start),
+        });
+        output
     }
 }
 
@@ -325,23 +461,69 @@ pub fn get_apple_gpu_stream(
     context: Arc<TaskContext>,
 ) -> Result<SendableRecordBatchStream> {
     let partition_stream = right_plan.execute(partition, context)?;
+    let input_schema = right_plan.schema();
     let output_schema_for_closure = output_schema.clone();
     let output_sources_for_closure = output_sources.clone();
-    let iter = partition_stream.map(move |rb| {
-        rb.and_then(|rb| {
-            backend.execute_batch(
-                &rb,
-                output_schema_for_closure.clone(),
-                output_sources_for_closure.as_ref(),
+    let state = CoalescedGpuStreamState {
+        stream: partition_stream,
+        input_schema,
+        pending: Vec::new(),
+        pending_rows: 0,
+    };
+    let iter = futures::stream::try_unfold(state, move |mut state| {
+        let backend = Arc::clone(&backend);
+        let output_schema = output_schema_for_closure.clone();
+        let output_sources = output_sources_for_closure.clone();
+        let columns_2 = Arc::clone(&columns_2);
+        let filter_op = filter_op.clone();
+        async move {
+            while state.pending_rows < GPU_COALESCED_TARGET_ROWS {
+                let Some(batch) = state.stream.next().await else {
+                    break;
+                };
+                let batch = batch?;
+                state.pending_rows += batch.num_rows();
+                state.pending.push(batch);
+            }
+
+            if state.pending.is_empty() {
+                return Ok(None);
+            }
+
+            let batch = if state.pending.len() == 1 {
+                state.pending.pop().ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "count_overlaps GPU coalescer lost pending batch".to_string(),
+                    )
+                })?
+            } else {
+                let batch = concat_batches(&state.input_schema, &state.pending)?;
+                state.pending.clear();
+                batch
+            };
+            state.pending_rows = 0;
+
+            let output = backend.execute_batch(
+                &batch,
+                output_schema,
+                output_sources.as_ref(),
                 (&columns_2.0, &columns_2.1, &columns_2.2),
-                filter_op.clone(),
-            )
-        })
+                filter_op,
+            )?;
+            Ok(Some((output, state)))
+        }
     });
     Ok(Box::pin(RecordBatchStreamAdapter::new(
         output_schema,
         Box::pin(iter) as BoxStream<'static, Result<datafusion::arrow::array::RecordBatch>>,
     )))
+}
+
+struct CoalescedGpuStreamState {
+    stream: SendableRecordBatchStream,
+    input_schema: SchemaRef,
+    pending: Vec<datafusion::arrow::array::RecordBatch>,
+    pending_rows: usize,
 }
 
 #[allow(dead_code)]

--- a/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_apple_gpu.rs
@@ -20,7 +20,7 @@ use objc2_metal::{
 };
 
 use crate::count_overlaps_rank::{
-    CountOverlapsRankIndex, MISSING_CONTIG_ID, append_count_column, project_batch,
+    CountOverlapsRankIndex, MISSING_CONTIG_ID, OutputColumnSource, build_output_batch,
 };
 use crate::filter_op::FilterOp;
 
@@ -154,16 +154,14 @@ impl AppleGpuCountOverlapsBackend {
     fn execute_batch(
         &self,
         batch: &datafusion::arrow::array::RecordBatch,
-        full_schema: SchemaRef,
         output_schema: SchemaRef,
-        projection: Option<&[usize]>,
+        output_sources: &[OutputColumnSource],
         columns: (&str, &str, &str),
         filter_op: FilterOp,
     ) -> Result<datafusion::arrow::array::RecordBatch> {
         let queries = self.index.encode_query_batch(batch, columns, filter_op)?;
         if queries.query_contigs.is_empty() {
-            let batch = append_count_column(batch, full_schema, Vec::new())?;
-            return project_batch(batch, output_schema, projection);
+            return build_output_batch(batch, output_schema, output_sources, Vec::new());
         }
 
         let query_contigs = self.runtime.new_buffer_from_slice(&queries.query_contigs)?;
@@ -223,8 +221,7 @@ impl AppleGpuCountOverlapsBackend {
             let ptr = output.contents().as_ptr().cast::<i64>();
             std::slice::from_raw_parts(ptr, queries.query_contigs.len()).to_vec()
         };
-        let batch = append_count_column(batch, full_schema, counts)?;
-        project_batch(batch, output_schema, projection)
+        build_output_batch(batch, output_schema, output_sources, counts)
     }
 }
 
@@ -320,25 +317,22 @@ impl MetalRuntime {
 pub fn get_apple_gpu_stream(
     right_plan: Arc<dyn ExecutionPlan>,
     backend: Arc<AppleGpuCountOverlapsBackend>,
-    full_schema: SchemaRef,
     output_schema: SchemaRef,
-    projection: Option<Arc<Vec<usize>>>,
+    output_sources: Arc<Vec<OutputColumnSource>>,
     columns_2: Arc<(String, String, String)>,
     filter_op: FilterOp,
     partition: usize,
     context: Arc<TaskContext>,
 ) -> Result<SendableRecordBatchStream> {
     let partition_stream = right_plan.execute(partition, context)?;
-    let full_schema_for_closure = full_schema.clone();
     let output_schema_for_closure = output_schema.clone();
-    let projection_for_closure = projection.clone();
+    let output_sources_for_closure = output_sources.clone();
     let iter = partition_stream.map(move |rb| {
         rb.and_then(|rb| {
             backend.execute_batch(
                 &rb,
-                full_schema_for_closure.clone(),
                 output_schema_for_closure.clone(),
-                projection_for_closure.as_deref().map(Vec::as_slice),
+                output_sources_for_closure.as_ref(),
                 (&columns_2.0, &columns_2.1, &columns_2.2),
                 filter_op.clone(),
             )

--- a/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
@@ -1,0 +1,312 @@
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use datafusion::arrow::array::{Int64Array, RecordBatch};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{DataFusionError, Result};
+
+use crate::array_utils::get_join_col_arrays;
+use crate::filter_op::FilterOp;
+
+pub const MISSING_CONTIG_ID: u32 = u32::MAX;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ContigRange {
+    pub start_offset: u32,
+    pub end_offset: u32,
+    pub len: u32,
+    pub _pad: u32,
+}
+
+#[derive(Debug)]
+pub struct CountOverlapsRankIndex {
+    chrom_to_id: AHashMap<String, u32>,
+    contigs: Vec<ContigRange>,
+    starts_sorted: Vec<i64>,
+    ends_sorted: Vec<i64>,
+    interval_count: usize,
+}
+
+#[derive(Debug)]
+pub struct EncodedQueryBatch {
+    pub query_contigs: Vec<u32>,
+    pub query_starts: Vec<i64>,
+    pub query_ends: Vec<i64>,
+}
+
+impl CountOverlapsRankIndex {
+    pub fn build_from_batches(
+        batches: &[RecordBatch],
+        columns: (&str, &str, &str),
+    ) -> Result<Self> {
+        let mut by_contig = AHashMap::<String, (Vec<i64>, Vec<i64>)>::default();
+        let mut interval_count = 0usize;
+
+        for batch in batches {
+            let (contig_arr, start_arr, end_arr) =
+                get_join_col_arrays(batch, (columns.0, columns.1, columns.2))?;
+
+            for i in 0..batch.num_rows() {
+                let contig = contig_arr.value(i);
+                let start = i64::from(start_arr.value(i)?);
+                let end = i64::from(end_arr.value(i)?);
+                let entry = by_contig
+                    .entry(contig.to_owned())
+                    .or_insert_with(|| (Vec::new(), Vec::new()));
+                entry.0.push(start);
+                entry.1.push(end);
+                interval_count += 1;
+            }
+        }
+
+        let mut names = by_contig.keys().cloned().collect::<Vec<_>>();
+        names.sort_unstable();
+
+        let mut chrom_to_id = AHashMap::with_capacity(names.len());
+        let mut contigs = Vec::with_capacity(names.len());
+        let mut starts_sorted = Vec::with_capacity(interval_count);
+        let mut ends_sorted = Vec::with_capacity(interval_count);
+
+        for (chrom_id, name) in names.into_iter().enumerate() {
+            let chrom_id = u32::try_from(chrom_id).map_err(|_| {
+                DataFusionError::Execution(
+                    "count_overlaps GPU index supports at most u32::MAX contigs".to_string(),
+                )
+            })?;
+            let (mut starts, mut ends) = by_contig.remove(&name).ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "missing contig while building rank index: {name}"
+                ))
+            })?;
+            starts.sort_unstable();
+            ends.sort_unstable();
+
+            let start_offset = u32::try_from(starts_sorted.len()).map_err(|_| {
+                DataFusionError::Execution(
+                    "count_overlaps GPU index start offset exceeds u32::MAX".to_string(),
+                )
+            })?;
+            let end_offset = u32::try_from(ends_sorted.len()).map_err(|_| {
+                DataFusionError::Execution(
+                    "count_overlaps GPU index end offset exceeds u32::MAX".to_string(),
+                )
+            })?;
+            let len = u32::try_from(starts.len()).map_err(|_| {
+                DataFusionError::Execution(
+                    "count_overlaps GPU index contig length exceeds u32::MAX".to_string(),
+                )
+            })?;
+
+            starts_sorted.extend_from_slice(&starts);
+            ends_sorted.extend_from_slice(&ends);
+            chrom_to_id.insert(name, chrom_id);
+            contigs.push(ContigRange {
+                start_offset,
+                end_offset,
+                len,
+                _pad: 0,
+            });
+        }
+
+        Ok(Self {
+            chrom_to_id,
+            contigs,
+            starts_sorted,
+            ends_sorted,
+            interval_count,
+        })
+    }
+
+    pub fn interval_count(&self) -> usize {
+        self.interval_count
+    }
+
+    pub fn contigs(&self) -> &[ContigRange] {
+        &self.contigs
+    }
+
+    pub fn starts_sorted(&self) -> &[i64] {
+        &self.starts_sorted
+    }
+
+    pub fn ends_sorted(&self) -> &[i64] {
+        &self.ends_sorted
+    }
+
+    pub fn encode_query_batch(
+        &self,
+        batch: &RecordBatch,
+        columns: (&str, &str, &str),
+        filter_op: FilterOp,
+    ) -> Result<EncodedQueryBatch> {
+        let (contig_arr, start_arr, end_arr) =
+            get_join_col_arrays(batch, (columns.0, columns.1, columns.2))?;
+        let mut query_contigs = Vec::with_capacity(batch.num_rows());
+        let mut query_starts = Vec::with_capacity(batch.num_rows());
+        let mut query_ends = Vec::with_capacity(batch.num_rows());
+        let strict = filter_op == FilterOp::Strict;
+
+        for i in 0..batch.num_rows() {
+            let contig = contig_arr.value(i);
+            let mut start = i64::from(start_arr.value(i)?);
+            let mut end = i64::from(end_arr.value(i)?);
+            if strict {
+                start += 1;
+                end -= 1;
+            }
+            query_contigs.push(
+                self.chrom_to_id
+                    .get(contig)
+                    .copied()
+                    .unwrap_or(MISSING_CONTIG_ID),
+            );
+            query_starts.push(start);
+            query_ends.push(end);
+        }
+
+        Ok(EncodedQueryBatch {
+            query_contigs,
+            query_starts,
+            query_ends,
+        })
+    }
+
+    pub fn count_encoded_queries(&self, queries: &EncodedQueryBatch) -> Vec<i64> {
+        queries
+            .query_contigs
+            .iter()
+            .zip(queries.query_starts.iter())
+            .zip(queries.query_ends.iter())
+            .map(|((&contig_id, &start), &end)| self.count_one(contig_id, start, end))
+            .collect()
+    }
+
+    fn count_one(&self, contig_id: u32, start: i64, end: i64) -> i64 {
+        if contig_id == MISSING_CONTIG_ID || start > end {
+            return 0;
+        }
+        let Some(range) = self.contigs.get(contig_id as usize) else {
+            return 0;
+        };
+        let start_offset = range.start_offset as usize;
+        let end_offset = range.end_offset as usize;
+        let len = range.len as usize;
+        let starts = &self.starts_sorted[start_offset..start_offset + len];
+        let ends = &self.ends_sorted[end_offset..end_offset + len];
+        let started = upper_bound(starts, end);
+        let ended_prior = lower_bound(ends, start);
+        i64::try_from(started - ended_prior).unwrap_or(i64::MAX)
+    }
+}
+
+pub fn append_count_column(
+    batch: &RecordBatch,
+    schema: SchemaRef,
+    counts: Vec<i64>,
+) -> Result<RecordBatch> {
+    let count_arr = Arc::new(Int64Array::from(counts));
+    let mut columns = Vec::with_capacity(batch.num_columns() + 1);
+    columns.extend_from_slice(batch.columns());
+    columns.push(count_arr);
+    RecordBatch::try_new(schema, columns).map_err(Into::into)
+}
+
+fn lower_bound(values: &[i64], needle: i64) -> usize {
+    let mut lo = 0usize;
+    let mut hi = values.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if values[mid] < needle {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
+}
+
+fn upper_bound(values: &[i64], needle: i64) -> usize {
+    let mut lo = 0usize;
+    let mut hi = values.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if values[mid] <= needle {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Int32Array, RecordBatch, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    use super::*;
+
+    fn batch(rows: &[(&str, i32, i32)]) -> Result<RecordBatch> {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("contig", DataType::Utf8, false),
+                Field::new("pos_start", DataType::Int32, false),
+                Field::new("pos_end", DataType::Int32, false),
+            ])),
+            vec![
+                Arc::new(StringArray::from_iter_values(rows.iter().map(|r| r.0))),
+                Arc::new(Int32Array::from_iter_values(rows.iter().map(|r| r.1))),
+                Arc::new(Int32Array::from_iter_values(rows.iter().map(|r| r.2))),
+            ],
+        )
+        .map_err(Into::into)
+    }
+
+    #[test]
+    fn rank_index_counts_duplicates_points_and_missing_contigs() -> Result<()> {
+        let left = batch(&[
+            ("chr1", 10, 100),
+            ("chr1", 20, 30),
+            ("chr1", 20, 30),
+            ("chr1", 50, 50),
+            ("chr1", 101, 110),
+            ("chr2", 1, 5),
+        ])?;
+        let right = batch(&[
+            ("chr1", 25, 25),
+            ("chr1", 50, 50),
+            ("chr1", 100, 101),
+            ("chr3", 1, 100),
+        ])?;
+
+        let index = CountOverlapsRankIndex::build_from_batches(
+            &[left],
+            ("contig", "pos_start", "pos_end"),
+        )?;
+        let queries =
+            index.encode_query_batch(&right, ("contig", "pos_start", "pos_end"), FilterOp::Weak)?;
+        assert_eq!(index.count_encoded_queries(&queries), vec![3, 2, 2, 0]);
+        Ok(())
+    }
+
+    #[test]
+    fn rank_index_strict_empty_query_returns_zero() -> Result<()> {
+        let left = batch(&[("a", 10, 20), ("a", 20, 30), ("a", 15, 25)])?;
+        let right = batch(&[("a", 20, 20), ("a", 19, 21)])?;
+
+        let index = CountOverlapsRankIndex::build_from_batches(
+            &[left],
+            ("contig", "pos_start", "pos_end"),
+        )?;
+        let queries = index.encode_query_batch(
+            &right,
+            ("contig", "pos_start", "pos_end"),
+            FilterOp::Strict,
+        )?;
+        assert_eq!(index.count_encoded_queries(&queries), vec![0, 3]);
+        Ok(())
+    }
+}

--- a/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
@@ -52,11 +52,15 @@ impl CountOverlapsRankIndex {
         for batch in batches {
             let (contig_arr, start_arr, end_arr) =
                 get_join_col_arrays(batch, (columns.0, columns.1, columns.2))?;
+            let start_values = start_arr.resolve_i64()?;
+            let end_values = end_arr.resolve_i64()?;
+            let starts = &*start_values;
+            let ends = &*end_values;
 
             for i in 0..batch.num_rows() {
                 let contig = contig_arr.value(i);
-                let start = i64::from(start_arr.value(i)?);
-                let end = i64::from(end_arr.value(i)?);
+                let start = starts[i];
+                let end = ends[i];
                 if let Some((starts, ends)) = by_contig.get_mut(contig) {
                     starts.push(start);
                     ends.push(end);
@@ -149,6 +153,10 @@ impl CountOverlapsRankIndex {
     ) -> Result<EncodedQueryBatch> {
         let (contig_arr, start_arr, end_arr) =
             get_join_col_arrays(batch, (columns.0, columns.1, columns.2))?;
+        let start_values = start_arr.resolve_i64()?;
+        let end_values = end_arr.resolve_i64()?;
+        let starts = &*start_values;
+        let ends = &*end_values;
         let mut query_contigs = Vec::with_capacity(batch.num_rows());
         let mut query_starts = Vec::with_capacity(batch.num_rows());
         let mut query_ends = Vec::with_capacity(batch.num_rows());
@@ -156,8 +164,8 @@ impl CountOverlapsRankIndex {
 
         for i in 0..batch.num_rows() {
             let contig = contig_arr.value(i);
-            let mut start = i64::from(start_arr.value(i)?);
-            let mut end = i64::from(end_arr.value(i)?);
+            let mut start = starts[i];
+            let mut end = ends[i];
             if strict {
                 start += 1;
                 end -= 1;

--- a/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
@@ -57,11 +57,12 @@ impl CountOverlapsRankIndex {
                 let contig = contig_arr.value(i);
                 let start = i64::from(start_arr.value(i)?);
                 let end = i64::from(end_arr.value(i)?);
-                let entry = by_contig
-                    .entry(contig.to_owned())
-                    .or_insert_with(|| (Vec::new(), Vec::new()));
-                entry.0.push(start);
-                entry.1.push(end);
+                if let Some((starts, ends)) = by_contig.get_mut(contig) {
+                    starts.push(start);
+                    ends.push(end);
+                } else {
+                    by_contig.insert(contig.to_owned(), (vec![start], vec![end]));
+                }
                 interval_count += 1;
             }
         }

--- a/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ahash::AHashMap;
-use datafusion::arrow::array::{Int64Array, RecordBatch, RecordBatchOptions};
+use datafusion::arrow::array::{ArrayRef, Int64Array, RecordBatch, RecordBatchOptions};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result};
 
@@ -33,6 +33,12 @@ pub struct EncodedQueryBatch {
     pub query_contigs: Vec<u32>,
     pub query_starts: Vec<i64>,
     pub query_ends: Vec<i64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OutputColumnSource {
+    Input(usize),
+    Count,
 }
 
 impl CountOverlapsRankIndex {
@@ -212,19 +218,25 @@ pub fn append_count_column(
     RecordBatch::try_new(schema, columns).map_err(Into::into)
 }
 
-pub fn project_batch(
-    batch: RecordBatch,
+pub fn build_output_batch(
+    batch: &RecordBatch,
     output_schema: SchemaRef,
-    projection: Option<&[usize]>,
+    sources: &[OutputColumnSource],
+    counts: Vec<i64>,
 ) -> Result<RecordBatch> {
-    let Some(projection) = projection else {
-        return Ok(batch);
-    };
-
-    let columns = projection
+    let mut count_array = None::<ArrayRef>;
+    let mut counts = Some(counts);
+    let columns = sources
         .iter()
-        .map(|&idx| batch.column(idx).clone())
-        .collect::<Vec<_>>();
+        .map(|source| match source {
+            OutputColumnSource::Input(idx) => Ok(batch.column(*idx).clone()),
+            OutputColumnSource::Count => Ok(count_array
+                .get_or_insert_with(|| {
+                    Arc::new(Int64Array::from(counts.take().unwrap_or_default())) as ArrayRef
+                })
+                .clone()),
+        })
+        .collect::<Result<Vec<_>>>()?;
 
     if columns.is_empty() {
         RecordBatch::try_new_with_options(

--- a/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
+++ b/datafusion/bio-function-ranges/src/count_overlaps_rank.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ahash::AHashMap;
-use datafusion::arrow::array::{Int64Array, RecordBatch};
+use datafusion::arrow::array::{Int64Array, RecordBatch, RecordBatchOptions};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result};
 
@@ -210,6 +210,32 @@ pub fn append_count_column(
     columns.extend_from_slice(batch.columns());
     columns.push(count_arr);
     RecordBatch::try_new(schema, columns).map_err(Into::into)
+}
+
+pub fn project_batch(
+    batch: RecordBatch,
+    output_schema: SchemaRef,
+    projection: Option<&[usize]>,
+) -> Result<RecordBatch> {
+    let Some(projection) = projection else {
+        return Ok(batch);
+    };
+
+    let columns = projection
+        .iter()
+        .map(|&idx| batch.column(idx).clone())
+        .collect::<Vec<_>>();
+
+    if columns.is_empty() {
+        RecordBatch::try_new_with_options(
+            output_schema,
+            columns,
+            &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+        )
+        .map_err(Into::into)
+    } else {
+        RecordBatch::try_new(output_schema, columns).map_err(Into::into)
+    }
 }
 
 fn lower_bound(values: &[i64], needle: i64) -> usize {

--- a/datafusion/bio-function-ranges/src/interval_tree.rs
+++ b/datafusion/bio-function-ranges/src/interval_tree.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use ahash::AHashMap;
 use coitrees::{COITree, Interval, IntervalTree};
-use datafusion::arrow::array::{Int64Array, RecordBatch};
+use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
@@ -13,6 +13,7 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 
 use crate::array_utils::get_join_col_arrays;
+use crate::count_overlaps_rank::{append_count_column, project_batch};
 use crate::filter_op::FilterOp;
 
 type IntervalHashMap = AHashMap<String, Vec<Interval<()>>>;
@@ -89,7 +90,9 @@ pub fn get_coverage(tree: &COITree<(), u32>, start: i32, end: i32) -> i32 {
 pub fn get_stream(
     right_plan: Arc<dyn ExecutionPlan>,
     trees: Arc<AHashMap<String, COITree<(), u32>>>,
-    new_schema: SchemaRef,
+    full_schema: SchemaRef,
+    output_schema: SchemaRef,
+    projection: Option<Arc<Vec<usize>>>,
     columns_2: Arc<(String, String, String)>,
     filter_op: FilterOp,
     coverage: bool,
@@ -97,7 +100,9 @@ pub fn get_stream(
     context: Arc<TaskContext>,
 ) -> Result<SendableRecordBatchStream> {
     let partition_stream = right_plan.execute(partition, context)?;
-    let schema_for_closure = new_schema.clone();
+    let full_schema_for_closure = full_schema.clone();
+    let output_schema_for_closure = output_schema.clone();
+    let projection_for_closure = projection.clone();
     let strict_filter = filter_op == FilterOp::Strict;
 
     let iter = partition_stream.map(move |rb| match rb {
@@ -140,17 +145,18 @@ pub fn get_stream(
                 };
                 count_arr.push(count as i64);
             }
-            let count_arr = Arc::new(Int64Array::from(count_arr));
-            let mut columns = Vec::with_capacity(rb.num_columns() + 1);
-            columns.extend_from_slice(rb.columns());
-            columns.push(count_arr);
-            RecordBatch::try_new(schema_for_closure.clone(), columns)
-                .map_err(|e| datafusion::common::DataFusionError::ArrowError(Box::new(e), None))
+            let batch = append_count_column(&rb, full_schema_for_closure.clone(), count_arr)?;
+            project_batch(
+                batch,
+                output_schema_for_closure.clone(),
+                projection_for_closure.as_deref().map(Vec::as_slice),
+            )
         }
         Err(e) => Err(e),
     });
 
-    let adapted_stream = RecordBatchStreamAdapter::new(new_schema, Box::pin(iter) as BoxStream<_>);
+    let adapted_stream =
+        RecordBatchStreamAdapter::new(output_schema, Box::pin(iter) as BoxStream<_>);
     Ok(Box::pin(adapted_stream))
 }
 

--- a/datafusion/bio-function-ranges/src/interval_tree.rs
+++ b/datafusion/bio-function-ranges/src/interval_tree.rs
@@ -124,13 +124,17 @@ pub fn get_stream(
                     cached_tree = trees.get(contig);
                     cached_tree
                 };
-                let count = match tree {
-                    None => 0,
-                    Some(tree) => {
-                        if coverage {
-                            get_coverage(tree, query_start, query_end)
-                        } else {
-                            tree.query_count(query_start, query_end) as i32
+                let count = if strict_filter && query_start > query_end {
+                    0
+                } else {
+                    match tree {
+                        None => 0,
+                        Some(tree) => {
+                            if coverage {
+                                get_coverage(tree, query_start, query_end)
+                            } else {
+                                tree.query_count(query_start, query_end) as i32
+                            }
                         }
                     }
                 };

--- a/datafusion/bio-function-ranges/src/interval_tree.rs
+++ b/datafusion/bio-function-ranges/src/interval_tree.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use futures::stream::BoxStream;
 
 use crate::array_utils::get_join_col_arrays;
-use crate::count_overlaps_rank::{append_count_column, project_batch};
+use crate::count_overlaps_rank::{OutputColumnSource, build_output_batch};
 use crate::filter_op::FilterOp;
 
 type IntervalHashMap = AHashMap<String, Vec<Interval<()>>>;
@@ -90,9 +90,8 @@ pub fn get_coverage(tree: &COITree<(), u32>, start: i32, end: i32) -> i32 {
 pub fn get_stream(
     right_plan: Arc<dyn ExecutionPlan>,
     trees: Arc<AHashMap<String, COITree<(), u32>>>,
-    full_schema: SchemaRef,
     output_schema: SchemaRef,
-    projection: Option<Arc<Vec<usize>>>,
+    output_sources: Arc<Vec<OutputColumnSource>>,
     columns_2: Arc<(String, String, String)>,
     filter_op: FilterOp,
     coverage: bool,
@@ -100,9 +99,8 @@ pub fn get_stream(
     context: Arc<TaskContext>,
 ) -> Result<SendableRecordBatchStream> {
     let partition_stream = right_plan.execute(partition, context)?;
-    let full_schema_for_closure = full_schema.clone();
     let output_schema_for_closure = output_schema.clone();
-    let projection_for_closure = projection.clone();
+    let output_sources_for_closure = output_sources.clone();
     let strict_filter = filter_op == FilterOp::Strict;
 
     let iter = partition_stream.map(move |rb| match rb {
@@ -145,11 +143,11 @@ pub fn get_stream(
                 };
                 count_arr.push(count as i64);
             }
-            let batch = append_count_column(&rb, full_schema_for_closure.clone(), count_arr)?;
-            project_batch(
-                batch,
+            build_output_batch(
+                &rb,
                 output_schema_for_closure.clone(),
-                projection_for_closure.as_deref().map(Vec::as_slice),
+                output_sources_for_closure.as_ref(),
+                count_arr,
             )
         }
         Err(e) => Err(e),

--- a/datafusion/bio-function-ranges/src/lib.rs
+++ b/datafusion/bio-function-ranges/src/lib.rs
@@ -20,7 +20,14 @@ pub mod table_function;
 // Re-export key types
 pub use cluster::ClusterProvider;
 pub use complement::ComplementProvider;
-pub use count_overlaps::CountOverlapsProvider;
+pub use count_overlaps::{
+    CountOverlapsProvider, CountOverlapsTimingSnapshot, reset_count_overlaps_timings,
+    snapshot_count_overlaps_timings,
+};
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+pub use count_overlaps_apple_gpu::{
+    AppleGpuTimingSnapshot, reset_apple_gpu_timings, snapshot_apple_gpu_timings,
+};
 pub use filter_op::FilterOp;
 pub use merge::MergeProvider;
 pub use nearest::NearestProvider;

--- a/datafusion/bio-function-ranges/src/lib.rs
+++ b/datafusion/bio-function-ranges/src/lib.rs
@@ -2,6 +2,9 @@ pub mod array_utils;
 pub mod cluster;
 pub mod complement;
 pub mod count_overlaps;
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+mod count_overlaps_apple_gpu;
+pub mod count_overlaps_rank;
 pub mod filter_op;
 pub mod grouped_stream;
 pub mod interval_tree;
@@ -25,6 +28,8 @@ pub use overlap::OverlapProvider;
 pub use physical_planner::BioQueryPlanner;
 pub use physical_planner::IntervalJoinPhysicalOptimizationRule;
 pub use physical_planner::joins::interval_join::IntervalJoinExec;
-pub use session_context::{Algorithm, BioConfig, BioSessionExt, create_bio_session};
+pub use session_context::{
+    Algorithm, BioConfig, BioSessionExt, CountOverlapsBackendMode, create_bio_session,
+};
 pub use subtract::SubtractProvider;
 pub use table_function::register_ranges_functions;

--- a/datafusion/bio-function-ranges/src/session_context.rs
+++ b/datafusion/bio-function-ranges/src/session_context.rs
@@ -50,11 +50,75 @@ extensions_options! {
         pub prefer_interval_join: bool, default = true
         pub interval_join_algorithm: Algorithm, default = Algorithm::default()
         pub interval_join_low_memory: bool, default = false
+        pub count_overlaps_backend: CountOverlapsBackendMode, default = CountOverlapsBackendMode::default()
     }
 }
 
 impl ConfigExtension for BioConfig {
     const PREFIX: &'static str = "bio";
+}
+
+#[derive(Debug, Eq, PartialEq, Default, Clone, Copy)]
+pub enum CountOverlapsBackendMode {
+    #[default]
+    Auto,
+    Cpu,
+    AppleGpu,
+}
+
+#[derive(Debug)]
+pub struct ParseCountOverlapsBackendModeError(String);
+
+impl std::fmt::Display for ParseCountOverlapsBackendModeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for ParseCountOverlapsBackendModeError {}
+
+impl FromStr for CountOverlapsBackendMode {
+    type Err = ParseCountOverlapsBackendModeError;
+
+    #[inline]
+    fn from_str(s: &str) -> Result<CountOverlapsBackendMode, Self::Err> {
+        match s.to_lowercase().replace(['-', '_'], "").as_str() {
+            "auto" => Ok(CountOverlapsBackendMode::Auto),
+            "cpu" => Ok(CountOverlapsBackendMode::Cpu),
+            "applegpu" => Ok(CountOverlapsBackendMode::AppleGpu),
+            _ => Err(ParseCountOverlapsBackendModeError(format!(
+                "Can't parse '{s}' as CountOverlapsBackendMode"
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for CountOverlapsBackendMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let val = match self {
+            CountOverlapsBackendMode::Auto => "auto",
+            CountOverlapsBackendMode::Cpu => "cpu",
+            CountOverlapsBackendMode::AppleGpu => "apple_gpu",
+        };
+        write!(f, "{val}")
+    }
+}
+
+impl From<ParseCountOverlapsBackendModeError> for datafusion::error::DataFusionError {
+    fn from(e: ParseCountOverlapsBackendModeError) -> Self {
+        datafusion::error::DataFusionError::External(Box::new(e))
+    }
+}
+
+impl ConfigField for CountOverlapsBackendMode {
+    fn set(&mut self, _key: &str, value: &str) -> datafusion::common::Result<()> {
+        *self = value.parse::<CountOverlapsBackendMode>()?;
+        Ok(())
+    }
+
+    fn visit<V: datafusion::config::Visit>(&self, visitor: &mut V, name: &str, doc: &'static str) {
+        visitor.some(name, self, doc)
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Default, Clone, Copy)]
@@ -145,4 +209,34 @@ pub fn create_bio_session() -> SessionContext {
     let ctx = SessionContext::new_with_bio(config);
     crate::table_function::register_ranges_functions(&ctx);
     ctx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_overlaps_backend_mode_parses_supported_values() {
+        assert_eq!(
+            "auto".parse::<CountOverlapsBackendMode>().unwrap(),
+            CountOverlapsBackendMode::Auto
+        );
+        assert_eq!(
+            "cpu".parse::<CountOverlapsBackendMode>().unwrap(),
+            CountOverlapsBackendMode::Cpu
+        );
+        assert_eq!(
+            "apple_gpu".parse::<CountOverlapsBackendMode>().unwrap(),
+            CountOverlapsBackendMode::AppleGpu
+        );
+        assert_eq!(
+            "apple-gpu".parse::<CountOverlapsBackendMode>().unwrap(),
+            CountOverlapsBackendMode::AppleGpu
+        );
+    }
+
+    #[test]
+    fn count_overlaps_backend_mode_rejects_unknown_values() {
+        assert!("metal".parse::<CountOverlapsBackendMode>().is_err());
+    }
 }

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1505,6 +1505,36 @@ async fn test_count_overlaps_supports_count_projection_and_aggregate() -> Result
         "+-------+",
     ];
     assert_batches_sorted_eq!(count_only_expected, &count_only);
+
+    let projected_right_column = ctx
+        .sql(r#"SELECT pos_end, "count" FROM count_overlaps('reads', 'targets') ORDER BY pos_end"#)
+        .await?
+        .collect()
+        .await?;
+    let projected_right_column_expected = [
+        "+---------+-------+",
+        "| pos_end | count |",
+        "+---------+-------+",
+        "| 2       | 1     |",
+        "| 20      | 2     |",
+        "| 110     | 0     |",
+        "+---------+-------+",
+    ];
+    assert_batches_sorted_eq!(projected_right_column_expected, &projected_right_column);
+
+    let row_count_only = ctx
+        .sql(r#"SELECT COUNT(*) AS n_rows FROM count_overlaps('reads', 'targets')"#)
+        .await?
+        .collect()
+        .await?;
+    let row_count_only_expected = [
+        "+--------+",
+        "| n_rows |",
+        "+--------+",
+        "| 3      |",
+        "+--------+",
+    ];
+    assert_batches_sorted_eq!(row_count_only_expected, &row_count_only);
     Ok(())
 }
 

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1249,6 +1249,298 @@ async fn test_count_overlaps_udtf_strict_zero_based_boundary() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_count_overlaps_udtf_containment_duplicates_points_and_missing_contigs() -> Result<()>
+{
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('chr1', 10, 100),
+        ('chr1', 20, 30),
+        ('chr1', 20, 30),
+        ('chr1', 50, 50),
+        ('chr1', 101, 110),
+        ('chr2', 1, 5)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (qid INTEGER, contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        (1, 'chr1', 25, 25),
+        (2, 'chr1', 50, 50),
+        (3, 'chr1', 100, 101),
+        (4, 'chr1', 31, 49),
+        (5, 'chr2', 3, 3),
+        (6, 'chr3', 1, 100),
+        (7, 'chr1', 111, 120)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql(
+            r#"SELECT qid, contig, pos_start, pos_end, "count"
+               FROM count_overlaps('reads', 'targets')
+               ORDER BY qid"#,
+        )
+        .await?
+        .collect()
+        .await?;
+
+    let expected = [
+        "+-----+--------+-----------+---------+-------+",
+        "| qid | contig | pos_start | pos_end | count |",
+        "+-----+--------+-----------+---------+-------+",
+        "| 1   | chr1   | 25        | 25      | 3     |",
+        "| 2   | chr1   | 50        | 50      | 2     |",
+        "| 3   | chr1   | 100       | 101     | 2     |",
+        "| 4   | chr1   | 31        | 49      | 1     |",
+        "| 5   | chr2   | 3         | 3       | 1     |",
+        "| 6   | chr3   | 1         | 100     | 0     |",
+        "| 7   | chr1   | 111       | 120     | 0     |",
+        "+-----+--------+-----------+---------+-------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_count_overlaps_udtf_strict_semantics_matrix() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 10, 20),
+        ('a', 20, 30),
+        ('a', 15, 25),
+        ('a', 30, 30)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (qid INTEGER, contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        (1, 'a', 20, 20),
+        (2, 'a', 19, 21),
+        (3, 'a', 30, 30),
+        (4, 'a', 29, 31),
+        (5, 'a', 5, 9)
+    "#,
+    )
+    .await?;
+
+    let weak = ctx
+        .sql(
+            r#"SELECT *
+               FROM count_overlaps('reads', 'targets')
+               ORDER BY qid"#,
+        )
+        .await?
+        .collect()
+        .await?;
+    let strict = ctx
+        .sql(
+            r#"SELECT *
+               FROM count_overlaps('reads', 'targets', 'contig', 'pos_start', 'pos_end', 'strict')
+               ORDER BY qid"#,
+        )
+        .await?
+        .collect()
+        .await?;
+
+    let weak_expected = [
+        "+-----+--------+-----------+---------+-------+",
+        "| qid | contig | pos_start | pos_end | count |",
+        "+-----+--------+-----------+---------+-------+",
+        "| 1   | a      | 20        | 20      | 3     |",
+        "| 2   | a      | 19        | 21      | 3     |",
+        "| 3   | a      | 30        | 30      | 2     |",
+        "| 4   | a      | 29        | 31      | 2     |",
+        "| 5   | a      | 5         | 9       | 0     |",
+        "+-----+--------+-----------+---------+-------+",
+    ];
+    let strict_expected = [
+        "+-----+--------+-----------+---------+-------+",
+        "| qid | contig | pos_start | pos_end | count |",
+        "+-----+--------+-----------+---------+-------+",
+        "| 1   | a      | 20        | 20      | 0     |",
+        "| 2   | a      | 19        | 21      | 3     |",
+        "| 3   | a      | 30        | 30      | 0     |",
+        "| 4   | a      | 29        | 31      | 2     |",
+        "| 5   | a      | 5         | 9       | 0     |",
+        "+-----+--------+-----------+---------+-------+",
+    ];
+
+    assert_batches_sorted_eq!(weak_expected, &weak);
+    assert_batches_sorted_eq!(strict_expected, &strict);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_count_overlaps_udtf_preserves_right_input_order() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 10, 20),
+        ('a', 100, 200)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (qid INTEGER, contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        (30, 'a', 150, 160),
+        (10, 'a', 1, 5),
+        (20, 'a', 15, 15),
+        (40, 'b', 1, 100)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql("SELECT * FROM count_overlaps('reads', 'targets')")
+        .await?
+        .collect()
+        .await?;
+
+    let formatted = pretty_format_batches(&result)?.to_string();
+    let expected = [
+        "+-----+--------+-----------+---------+-------+",
+        "| qid | contig | pos_start | pos_end | count |",
+        "+-----+--------+-----------+---------+-------+",
+        "| 30  | a      | 150       | 160     | 1     |",
+        "| 10  | a      | 1         | 5       | 0     |",
+        "| 20  | a      | 15        | 15      | 1     |",
+        "| 40  | b      | 1         | 100     | 0     |",
+        "+-----+--------+-----------+---------+-------+",
+    ]
+    .join("\n");
+    assert_eq!(expected, formatted);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_count_overlaps_backend_config_cpu_display() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql("SET bio.count_overlaps_backend TO cpu").await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 10, 20),
+        ('a', 100, 200)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 15, 15)
+    "#,
+    )
+    .await?;
+
+    let explain = explain_query(&ctx, "SELECT * FROM count_overlaps('reads', 'targets')").await?;
+    assert_contains!(&explain, "CountOverlapsExec: backend=cpu-coitree");
+    Ok(())
+}
+
+#[cfg(not(all(feature = "apple-gpu", target_os = "macos")))]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_count_overlaps_apple_gpu_config_falls_back_without_metal_build() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql("SET bio.count_overlaps_backend TO apple_gpu")
+        .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 10, 20)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 20, 20)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql("SELECT * FROM count_overlaps('reads', 'targets')")
+        .await?
+        .collect()
+        .await?;
+    let expected = [
+        "+--------+-----------+---------+-------+",
+        "| contig | pos_start | pos_end | count |",
+        "+--------+-----------+---------+-------+",
+        "| a      | 20        | 20      | 1     |",
+        "+--------+-----------+---------+-------+",
+    ];
+    assert_batches_sorted_eq!(expected, &result);
+    Ok(())
+}
+
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires a working Apple Metal device"]
+async fn test_count_overlaps_apple_gpu_matches_cpu_fixtures() -> Result<()> {
+    async fn create_fixture(ctx: &SessionContext) -> Result<()> {
+        ctx.sql(
+            r#"
+            CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+            ('chr1', 10, 100),
+            ('chr1', 20, 30),
+            ('chr1', 20, 30),
+            ('chr1', 50, 50),
+            ('chr1', 101, 110),
+            ('chr2', 1, 5)
+        "#,
+        )
+        .await?;
+        ctx.sql(
+            r#"
+            CREATE TABLE targets (qid INTEGER, contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+            (1, 'chr1', 25, 25),
+            (2, 'chr1', 50, 50),
+            (3, 'chr1', 100, 101),
+            (4, 'chr1', 31, 49),
+            (5, 'chr2', 3, 3),
+            (6, 'chr3', 1, 100),
+            (7, 'chr1', 111, 120)
+        "#,
+        )
+        .await?;
+        Ok(())
+    }
+
+    let cpu = create_bio_session();
+    let gpu = create_bio_session();
+    cpu.sql("SET bio.count_overlaps_backend TO cpu").await?;
+    gpu.sql("SET bio.count_overlaps_backend TO apple_gpu")
+        .await?;
+    create_fixture(&cpu).await?;
+    create_fixture(&gpu).await?;
+
+    let query = r#"SELECT * FROM count_overlaps('reads', 'targets') ORDER BY qid"#;
+    let cpu_result = cpu.sql(query).await?.collect().await?;
+    let gpu_result = gpu.sql(query).await?.collect().await?;
+
+    assert_eq!(
+        pretty_format_batches(&cpu_result)?.to_string(),
+        pretty_format_batches(&gpu_result)?.to_string()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_nearest_udtf_strict_zero_based_boundary_distance() -> Result<()> {
     let ctx = create_bio_session();
 
@@ -3492,6 +3784,10 @@ async fn test_range_udtfs_target_partitions_invariant() -> Result<()> {
             "subtract",
             "SELECT * FROM subtract('reads', 'targets') ORDER BY contig, pos_start, pos_end",
         ),
+        (
+            "count_overlaps",
+            r#"SELECT * FROM count_overlaps('reads', 'targets') ORDER BY contig, pos_start, pos_end, "count""#,
+        ),
     ];
 
     for (name, query) in cases {
@@ -3601,6 +3897,16 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
         "| chr2   | 36        | 40      |",
         "+--------+-----------+---------+",
     ];
+    let expected_count_overlaps = [
+        "+--------+-----------+---------+-------+",
+        "| contig | pos_start | pos_end | count |",
+        "+--------+-----------+---------+-------+",
+        "| chr1   | 5         | 10      | 2     |",
+        "| chr1   | 20        | 25      | 2     |",
+        "| chr2   | 12        | 15      | 1     |",
+        "| chr2   | 35        | 36      | 1     |",
+        "+--------+-----------+---------+-------+",
+    ];
 
     for target_partitions in [1, 2, 4] {
         let ctx = create_bio_session_with_target_partitions_and_batch_size(target_partitions, 1);
@@ -3655,6 +3961,15 @@ async fn test_range_udtfs_partitioned_parquet_target_partitions_invariant() -> R
             .collect()
             .await?;
         assert_batches_sorted_eq!(expected_subtract, &subtract);
+
+        let count_overlaps = ctx
+            .sql(
+                r#"SELECT * FROM count_overlaps('left_t', 'right_t') ORDER BY contig, pos_start, pos_end, "count""#,
+            )
+            .await?
+            .collect()
+            .await?;
+        assert_batches_sorted_eq!(expected_count_overlaps, &count_overlaps);
     }
 
     Ok(())

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1450,6 +1450,64 @@ async fn test_count_overlaps_backend_config_cpu_display() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_count_overlaps_supports_count_projection_and_aggregate() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 10, 20),
+        ('a', 15, 25),
+        ('b', 1, 2)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('a', 20, 20),
+        ('a', 100, 110),
+        ('b', 2, 2)
+    "#,
+    )
+    .await?;
+
+    let aggregate = ctx
+        .sql(
+            r#"SELECT COUNT(*) AS n_rows, SUM("count") AS total_overlaps
+               FROM count_overlaps('reads', 'targets')"#,
+        )
+        .await?
+        .collect()
+        .await?;
+    let aggregate_expected = [
+        "+--------+----------------+",
+        "| n_rows | total_overlaps |",
+        "+--------+----------------+",
+        "| 3      | 3              |",
+        "+--------+----------------+",
+    ];
+    assert_batches_sorted_eq!(aggregate_expected, &aggregate);
+
+    let count_only = ctx
+        .sql(r#"SELECT "count" FROM count_overlaps('reads', 'targets') ORDER BY "count""#)
+        .await?
+        .collect()
+        .await?;
+    let count_only_expected = [
+        "+-------+",
+        "| count |",
+        "+-------+",
+        "| 0     |",
+        "| 1     |",
+        "| 2     |",
+        "+-------+",
+    ];
+    assert_batches_sorted_eq!(count_only_expected, &count_only);
+    Ok(())
+}
+
 #[cfg(not(all(feature = "apple-gpu", target_os = "macos")))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_count_overlaps_apple_gpu_config_falls_back_without_metal_build() -> Result<()> {

--- a/openspec/changes/gpu-count-overlaps-apple-metal/design.md
+++ b/openspec/changes/gpu-count-overlaps-apple-metal/design.md
@@ -1,0 +1,282 @@
+# Apple GPU Count Overlaps Backend -- Design
+
+## Context
+
+The current `count_overlaps` table function builds CPU COITrees from the full left table and probes each right-side batch on CPU. The relevant flow is:
+
+1. `CountOverlapsProvider::scan()` collects the left table into memory.
+2. `build_coitree_from_batches()` groups intervals by contig and builds `COITree<(), u32>` values.
+3. `CountOverlapsExec::execute()` streams right partitions.
+4. `get_stream()` probes each right row and appends an `Int64` `count` column.
+
+That implementation is efficient on CPU and must remain the correctness baseline. The GPU backend should not replace the public operator. It should provide an alternative physical implementation for large workloads where fixed-output rank computation can amortize device setup and kernel launch overhead.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve exact `count_overlaps` output semantics for weak and strict modes.
+- Keep output shape and row order identical to the existing CPU implementation.
+- Add a feature-gated Apple GPU backend for large count-overlaps workloads.
+- Use a GPU-friendly endpoint rank formulation:
+  - count left starts at or before each query end
+  - count left ends before each query start
+  - subtract ranks per query
+- Keep CPU COITrees as fallback and correctness oracle.
+- Build reusable buffer, device detection, and benchmark infrastructure for later GPU interval operations.
+
+**Non-Goals:**
+
+- Implementing all-pairs `overlap()` on GPU.
+- Implementing `coverage`, `nearest`, `merge`, or `cluster` in this change.
+- Replacing COITrees as the default small-workload path.
+- Requiring GPU-side sorting in the first implementation.
+- Changing SQL syntax, output schema, or null behavior.
+
+## Algorithm
+
+For inclusive intervals, a left interval `[l_start, l_end]` overlaps a right interval `[r_start, r_end]` when:
+
+```text
+l_start <= r_end AND l_end >= r_start
+```
+
+For a fixed contig, if left starts and ends are sorted independently:
+
+```text
+started     = upper_bound(left_starts, r_end)
+ended_prior = lower_bound(left_ends, r_start)
+count       = started - ended_prior
+```
+
+This is containment-correct for counts because it counts every interval satisfying the overlap predicate without needing interval IDs. AIList-style sublists are not required for `count_overlaps`; they become relevant for future pair enumeration where interval identity matters.
+
+Strict mode should be normalized to match the existing CPU code:
+
+```text
+strict query start = right.start + 1
+strict query end   = right.end - 1
+```
+
+Then the same rank formula is applied. Empty strict intervals must produce zero.
+
+## Detailed Design
+
+### 1. Backend boundary
+
+Add an internal trait for count-overlaps execution:
+
+```rust
+trait CountOverlapsBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn execute_partition(
+        &self,
+        right_plan: Arc<dyn ExecutionPlan>,
+        schema: SchemaRef,
+        columns_2: Arc<(String, String, String)>,
+        filter_op: FilterOp,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream>;
+}
+```
+
+The existing `get_stream()` path can become the CPU backend implementation. The provider chooses the backend during `scan()` after building or preparing the left-side index.
+
+The initial backend enum should be internal:
+
+```rust
+enum CountOverlapsBackendMode {
+    Cpu,
+    AppleGpu,
+    Auto,
+}
+```
+
+Expose it through a session option such as:
+
+```sql
+SET bio.count_overlaps_backend = 'auto';      -- default
+SET bio.count_overlaps_backend = 'cpu';
+SET bio.count_overlaps_backend = 'apple_gpu';
+```
+
+`auto` only selects GPU when all eligibility checks pass.
+
+### 2. Feature gate and platform gating
+
+Add a cargo feature to `datafusion/bio-function-ranges`:
+
+```toml
+[features]
+apple-gpu = []
+```
+
+The implementation should compile cleanly without the feature on every platform. Metal-specific code must be behind:
+
+```rust
+#[cfg(all(feature = "apple-gpu", target_os = "macos"))]
+```
+
+Use `objc2-metal` as the initial Metal binding, with companion `objc2` and `objc2-foundation` dependencies where needed. Keep it behind a small local wrapper so the rest of the crate depends on project-owned types, not directly on the binding API.
+
+### 3. GPU index layout
+
+Create a left-side GPU index:
+
+```rust
+struct GpuCountOverlapsIndex {
+    chrom_to_id: AHashMap<String, u32>,
+    contigs: Vec<ContigRange>,
+    starts_sorted: Vec<i64>,
+    ends_sorted: Vec<i64>,
+}
+
+struct ContigRange {
+    chrom_id: u32,
+    start_offset: u32,
+    end_offset: u32,
+    len: u32,
+}
+```
+
+The first implementation builds this index on CPU from collected left batches:
+
+1. Read left `(contig, start, end)` columns using existing array helpers.
+2. Normalize coordinates to the same type used by the CPU path.
+3. Group by contig.
+4. Sort starts and ends independently for each contig.
+5. Concatenate all contig groups into global SoA buffers.
+6. Store offsets/lengths in `contigs`.
+
+Use `i64` in the GPU-facing buffers unless benchmarks prove `i32` is required. The current CPU COITree path narrows to `i32` in some places, but the SQL/table function layer works with `Int64` data. Planning the GPU path around `i64` avoids silent coordinate truncation.
+
+### 4. Right batch encoding
+
+For each right batch, prepare GPU input arrays:
+
+```rust
+struct GpuQueryBatch {
+    chrom_ids: Vec<u32>,
+    starts: Vec<i64>,
+    ends: Vec<i64>,
+}
+```
+
+Encoding rules:
+
+- map unknown contigs to `u32::MAX`
+- apply strict-mode start/end adjustment before dispatch
+- mark invalid strict intervals where adjusted start > adjusted end
+- keep physical row order unchanged
+- produce count `0` for unknown contigs or invalid intervals
+
+The GPU output buffer is one `i64` count per input row.
+
+### 5. Kernel strategy
+
+#### Phase 1 kernel: binary-rank per query
+
+Start with one thread per right row:
+
+1. Look up the contig offset and length.
+2. Binary-search starts for `upper_bound(end)`.
+3. Binary-search ends for `lower_bound(start)`.
+4. Write `started - ended_prior`.
+
+This has predictable fixed output and no atomics. It is the simplest production-worthy kernel and avoids sorting every right batch.
+
+#### Phase 2 kernel: Merge Path rank-sweep for large sorted batches
+
+Add a second path only after the binary-rank path is correct and benchmarked.
+
+The Merge Path path should be selected when:
+
+- a right-side batch or partition is already sorted by `(contig, endpoint)`, or
+- benchmarking shows that sorting endpoint views pays for the target workload size
+
+It computes the same two ranks with two sorted merges:
+
+1. Merge left starts with right query ends to compute `started`.
+2. Merge left ends with right query starts to compute `ended_prior`.
+3. Subtract ranks by original row index.
+
+Merge Path partitioning assigns independent cross-diagonal merge segments to threadgroups. For `count_overlaps`, this is a rank-sweep, not an active-list pair-emission sweep. That distinction keeps memory bounded and avoids the 32 KB threadgroup active-list problem that makes all-pairs overlap hard on Apple GPU.
+
+Do not sort every small or unsorted right batch just to use Merge Path. That would likely erase the GPU win.
+
+### 6. Execution integration
+
+`CountOverlapsProvider::scan()` should become:
+
+1. collect/select left columns as today
+2. inspect session config for backend mode
+3. build CPU COITree backend if mode is `cpu` or GPU is ineligible
+4. build GPU SoA index if mode is `apple_gpu` or eligible `auto`
+5. create a `CountOverlapsExec` that owns the selected backend
+
+The GPU backend should execute per right partition, same as the CPU path. It should not coalesce all right partitions unless a later Merge Path implementation needs whole-partition sorting and benchmarks justify it.
+
+### 7. Eligibility and fallback
+
+`auto` mode should require:
+
+- `target_os = macos`
+- `apple-gpu` feature enabled
+- Metal device initialization succeeds
+- left row count above a benchmark-derived threshold
+- right batch or partition size above a benchmark-derived threshold
+- supported coordinate types
+- no unsupported null semantics
+
+Any runtime failure before emitting a batch should fall back to CPU. Once a GPU stream has emitted data for a partition, failures should surface as execution errors rather than silently mixing partial outputs from different engines.
+
+### 8. Observability
+
+Add lightweight metrics:
+
+- selected backend
+- GPU eligibility decision and fallback reason
+- left index build time
+- right rows processed on GPU
+- GPU kernel elapsed time
+- CPU fallback rows
+
+Metrics should be exposed through DataFusion execution metrics where practical and optionally logged at debug level.
+
+## Validation Plan
+
+### Correctness
+
+Add tests comparing CPU and GPU-count-reference behavior for:
+
+- simple overlaps
+- no overlaps
+- point intervals
+- nested/contained intervals
+- duplicate intervals
+- missing contigs
+- strict versus weak mode
+- multi-partition right input
+- output row order preservation
+
+The tests should run without a real GPU by validating the shared rank implementation against the CPU COITree path. Metal-specific integration tests can be gated and ignored by default when no Apple GPU is available.
+
+### Performance
+
+Add ignored benchmarks for:
+
+- CPU COITree baseline
+- CPU rank-reference baseline over sorted endpoint arrays
+- GPU binary-rank path
+- GPU Merge Path path when implemented
+
+Benchmark matrix:
+
+- left rows: 1e5, 1e6, 1e7, 5e7
+- right rows: 1e5, 1e6, 1e7
+- contig distributions: single contig, human-chromosome-like, skewed contig
+- interval distributions: short uniform, nested/contained, mixed long-tail
+- right ordering: sorted, mostly sorted, random
+
+The auto-dispatch threshold should be set from these benchmarks, not guessed.

--- a/openspec/changes/gpu-count-overlaps-apple-metal/proposal.md
+++ b/openspec/changes/gpu-count-overlaps-apple-metal/proposal.md
@@ -1,0 +1,82 @@
+# Apple GPU Count Overlaps Backend
+
+## Why
+
+`count_overlaps(left, right)` is the safest first interval operation to move onto Apple GPU:
+
+- output cardinality is fixed: exactly one count per right-side row
+- no overlap-pair materialization is required
+- no dynamic output buffers or skew-sensitive pair emission are required
+- the core computation can be expressed as sorted endpoint rank queries:
+  - `started = count(left.start <= right.end)`
+  - `ended_before = count(left.end < right.start)`
+  - `overlaps = started - ended_before`
+
+That makes `count_overlaps` a better first Metal backend than `overlap()`. It exercises the same data movement, per-contig indexing, and kernel dispatch infrastructure that a future GPU overlap join will need, while avoiding the hard all-pairs output problem.
+
+The current implementation collects the left side into per-contig CPU COITrees, then probes right batches row-by-row in Rust. That is a strong CPU path, but it is still lookup-oriented and does not expose the GPU-friendly sort/rank shape of count-overlaps.
+
+This change plans an optional Apple GPU backend that preserves existing CPU semantics and falls back automatically when GPU execution is not beneficial or unavailable.
+
+## What Changes
+
+### 1. Add a count-overlaps backend abstraction
+
+Introduce an internal backend boundary for `CountOverlapsExec`:
+
+- `CpuCoitreeCountBackend`: existing implementation
+- `AppleGpuCountBackend`: optional Metal implementation, compiled only on supported Apple targets and behind a cargo feature
+- `AutoCountBackend`: dispatches to GPU only when the device, input shape, and workload size make sense
+
+The public SQL/table function contract does not change.
+
+### 2. Build a GPU-ready left index
+
+For each contig in the left table, build structure-of-arrays buffers:
+
+- sorted starts
+- sorted ends
+- per-contig offsets and lengths
+- dictionary-encoded contig IDs
+
+The first implementation should build these arrays on CPU and pass them to Metal using unified/shared memory. GPU-side radix sort is useful follow-up infrastructure, but it is not required to prove the count-overlaps backend.
+
+### 3. Execute right batches through Metal rank kernels
+
+For each right-side batch:
+
+- dictionary-encode contigs to the left-index contig IDs
+- normalize strict/weak interval semantics exactly as the CPU path does
+- dispatch GPU rank kernels
+- append the resulting `Int64` count column to the original right batch
+- preserve right input row order exactly
+
+The implementation should start with a simple one-thread-per-query binary-rank kernel because it avoids sorting every right batch. For large sorted batches, add a Merge Path rank-sweep path that computes the same endpoint ranks with less per-query divergence.
+
+### 4. Keep CPU as the default safety net
+
+GPU execution is opt-in or auto-selected only above a measured threshold. The CPU COITree path remains the default fallback for:
+
+- non-Apple platforms
+- unsupported column types
+- very small inputs or batches
+- GPU device/runtime initialization failure
+- memory pressure or allocation failure
+- correctness/debug mode
+
+## Impact
+
+- Affected code:
+  - `datafusion/bio-function-ranges/src/count_overlaps.rs`
+  - `datafusion/bio-function-ranges/src/interval_tree.rs`
+  - `datafusion/bio-function-ranges/src/session_context.rs`
+  - new Apple GPU backend module under `datafusion/bio-function-ranges/src/`
+  - `datafusion/bio-function-ranges/Cargo.toml`
+  - integration tests under `datafusion/bio-function-ranges/tests/`
+- Public behavior:
+  - no SQL syntax change
+  - existing CPU output remains the correctness oracle
+  - optional session config controls backend selection
+- Expected outcome:
+  - large `count_overlaps` workloads on M3 Max/Ultra can use GPU bandwidth while small workloads continue using CPU COITrees
+  - the repo gains reusable Apple GPU buffer/kernels infrastructure for future range operations

--- a/openspec/changes/gpu-count-overlaps-apple-metal/specs/gpu-count-overlaps/spec.md
+++ b/openspec/changes/gpu-count-overlaps-apple-metal/specs/gpu-count-overlaps/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+### Requirement: Optional Apple GPU Count Overlaps Backend
+The system SHALL provide an optional Apple GPU backend for `count_overlaps` that preserves the existing table-function contract and returns exactly one count value per right-side input row.
+
+The backend MUST:
+- Be gated behind an `apple-gpu` cargo feature
+- Compile out cleanly when the feature is disabled
+- Be available only on supported macOS Apple GPU targets
+- Keep the existing CPU COITree implementation as the default correctness baseline and fallback
+- Preserve the current `count_overlaps` output schema
+- Preserve right input row order
+- Return `Int64` counts matching the CPU path
+
+#### Scenario: CPU remains available without Apple GPU feature
+- **WHEN** the crate is built without `apple-gpu`
+- **THEN** `count_overlaps` uses the existing CPU implementation
+- **AND** no Metal dependency is required
+
+#### Scenario: Unsupported platform fallback
+- **WHEN** `bio.count_overlaps_backend = 'auto'`
+- **AND** the process is not running on a supported macOS Apple GPU target
+- **THEN** `count_overlaps` uses the CPU backend
+- **AND** execution succeeds with existing semantics
+
+#### Scenario: Forced GPU unavailable
+- **WHEN** `bio.count_overlaps_backend = 'apple_gpu'`
+- **AND** Metal device initialization fails before any output batch is emitted
+- **THEN** the implementation MAY fall back to CPU with a structured fallback metric
+- **AND** the output MUST match CPU results
+
+### Requirement: Endpoint Rank Count Algorithm
+The GPU backend SHALL compute count-overlaps using sorted endpoint ranks rather than interval-tree traversal.
+
+For each contig, the backend MUST maintain:
+- a sorted array of left interval starts
+- a sorted array of left interval ends
+- an offset and length for the contig's slice in each array
+
+For each right query interval, the backend MUST compute:
+- `started = count(left.start <= query.end)`
+- `ended_prior = count(left.end < query.start)`
+- `count = started - ended_prior`
+
+#### Scenario: Contained intervals are counted correctly
+- **WHEN** left intervals include intervals nested inside other intervals
+- **AND** a right interval overlaps both the outer and inner intervals
+- **THEN** the GPU backend returns the same count as the CPU COITree backend
+
+#### Scenario: Duplicate intervals are counted independently
+- **WHEN** the left table contains duplicate intervals on the same contig
+- **AND** a right interval overlaps those duplicates
+- **THEN** each duplicate contributes one to the count
+
+#### Scenario: Missing contig returns zero
+- **WHEN** a right row references a contig absent from the left index
+- **THEN** the GPU backend returns count `0` for that row
+
+### Requirement: Strict and Weak Semantics Match CPU
+The GPU backend SHALL implement strict and weak interval semantics exactly as the existing CPU path does.
+
+The backend MUST:
+- Apply weak mode without shrinking query intervals
+- Apply strict mode by using `query.start + 1` and `query.end - 1`
+- Return zero for strict-mode queries that become empty after adjustment
+- Match CPU results for point intervals, endpoint-touching intervals, and normal intervals
+
+#### Scenario: Weak endpoint touch counts as overlap
+- **WHEN** weak mode is used
+- **AND** a left interval endpoint touches a right interval endpoint according to current CPU semantics
+- **THEN** the GPU backend returns the same nonzero count as the CPU backend
+
+#### Scenario: Strict endpoint touch does not count
+- **WHEN** strict mode is used
+- **AND** two intervals only touch at an endpoint
+- **THEN** the GPU backend returns the same count as the CPU backend
+
+#### Scenario: Strict point query becomes empty
+- **WHEN** strict mode is used
+- **AND** the adjusted right interval has `start > end`
+- **THEN** the GPU backend returns count `0`
+
+### Requirement: Backend Selection Configuration
+The system SHALL expose a session-level backend selection option for `count_overlaps`.
+
+The option MUST support:
+- `auto`
+- `cpu`
+- `apple_gpu`
+
+The default MUST be `auto`.
+
+`auto` mode MUST choose CPU when:
+- the Apple GPU feature is not compiled
+- the platform is unsupported
+- the workload is below benchmark-derived GPU thresholds
+- input types or null semantics are unsupported by the GPU backend
+- GPU initialization or allocation fails before output starts
+
+#### Scenario: Explicit CPU mode
+- **WHEN** `SET bio.count_overlaps_backend = 'cpu'`
+- **THEN** `count_overlaps` uses the CPU backend even on Apple GPU hardware
+
+#### Scenario: Auto mode below threshold
+- **WHEN** `bio.count_overlaps_backend = 'auto'`
+- **AND** the input is below the measured GPU crossover threshold
+- **THEN** `count_overlaps` uses the CPU backend
+
+#### Scenario: Auto mode eligible large workload
+- **WHEN** `bio.count_overlaps_backend = 'auto'`
+- **AND** the platform, feature, input types, and workload size are GPU-eligible
+- **THEN** `count_overlaps` uses the Apple GPU backend
+
+### Requirement: Merge Path Rank-Sweep Optimization
+The system SHALL support a future Merge Path rank-sweep optimization for large sorted or sort-beneficial `count_overlaps` workloads.
+
+The optimization MUST:
+- Compute the same endpoint ranks as the binary-rank GPU kernel
+- Use Merge Path partitioning to split sorted endpoint merges into independent threadgroup work
+- Preserve original right-row output order through row ID scatter
+- Be selected only when benchmarks show it is faster than the binary-rank GPU path
+
+The optimization MUST NOT:
+- Be required for initial Apple GPU backend correctness
+- Sort every small or unsorted right batch unconditionally
+- Materialize overlap pairs
+- Maintain an active interval list
+
+#### Scenario: Sorted right partition uses rank sweep
+- **WHEN** a right partition is already sorted by the endpoint needed for a rank pass
+- **AND** the workload exceeds the Merge Path threshold
+- **THEN** the backend MAY use Merge Path rank-sweep for that rank pass
+- **AND** the final counts MUST match the binary-rank GPU path
+
+#### Scenario: Random small right batch avoids rank sweep
+- **WHEN** a right batch is small or randomly ordered
+- **THEN** the backend MUST NOT sort it solely to force Merge Path execution unless benchmarks prove that path is faster for the configured threshold
+
+### Requirement: Correctness and Performance Validation
+The implementation SHALL validate the Apple GPU backend against the CPU backend before enabling automatic GPU dispatch.
+
+Validation MUST include:
+- deterministic fixture tests
+- nested/contained interval tests
+- strict and weak semantics tests
+- multi-partition right-side tests
+- output row-order tests
+- ignored Apple GPU integration tests
+- benchmark-derived auto-dispatch thresholds
+
+#### Scenario: CPU and GPU agree on deterministic fixtures
+- **WHEN** GPU tests are run on supported Apple hardware
+- **THEN** GPU `count_overlaps` output matches CPU output exactly for all deterministic fixtures
+
+#### Scenario: Auto dispatch threshold is measured
+- **WHEN** the GPU backend is enabled in `auto` mode
+- **THEN** the threshold for selecting GPU is based on benchmark results documented in the implementation
+- **AND** small workloads continue to use CPU when CPU is faster

--- a/openspec/changes/gpu-count-overlaps-apple-metal/tasks.md
+++ b/openspec/changes/gpu-count-overlaps-apple-metal/tasks.md
@@ -1,0 +1,99 @@
+# Implementation Tasks
+
+## Status Key
+- [ ] Not started
+- [x] Completed
+
+## 0. Phase 0: Baseline and Semantics
+
+- [x] 0.1 Add focused CPU tests documenting current `count_overlaps` weak-mode semantics
+- [x] 0.2 Add focused CPU tests documenting current `count_overlaps` strict-mode semantics
+- [x] 0.3 Add tests for nested/contained intervals to prove count semantics are containment-correct
+- [x] 0.4 Add tests for missing contigs returning zero counts
+- [x] 0.5 Add tests proving output row order matches right input order
+- [x] 0.6 Add a small benchmark harness for current CPU COITree `count_overlaps`
+
+## 1. Phase 1: Backend Selection Surface
+
+- [x] 1.1 Add `CountOverlapsBackendMode` enum: `Auto`, `Cpu`, `AppleGpu`
+- [x] 1.2 Add `bio.count_overlaps_backend` session config with default `Auto`
+- [x] 1.3 Parse accepted values: `auto`, `cpu`, `apple_gpu`
+- [x] 1.4 Add display/debug output showing the selected count-overlaps backend in physical plans
+- [x] 1.5 Keep current behavior exactly when mode is `Cpu`
+- [x] 1.6 Add tests for session config parsing and invalid values
+
+## 2. Phase 2: CPU Rank Reference and GPU-Ready Index
+
+- [x] 2.1 Add `GpuCountOverlapsIndex`-style SoA index type behind a backend-neutral module name
+- [x] 2.2 Build per-contig `starts_sorted` and `ends_sorted` arrays from collected left batches
+- [x] 2.3 Dictionary-encode contigs to stable `u32` IDs
+- [x] 2.4 Use `i64` coordinate buffers and explicitly document any conversion from existing CPU helpers
+- [x] 2.5 Implement CPU rank-reference count: `upper_bound(starts, end) - lower_bound(ends, start)`
+- [ ] 2.6 Compare CPU rank-reference output against existing COITree output across all Phase 0 fixtures
+- [ ] 2.7 Add property-style tests for random interval/query sets comparing rank-reference and COITree counts
+- [ ] 2.8 Measure CPU index build time and memory footprint versus COITree build
+
+## 3. Phase 3: Feature Gate and Metal Runtime Wrapper
+
+- [x] 3.1 Add `apple-gpu` cargo feature to `datafusion/bio-function-ranges`
+- [x] 3.2 Add `#[cfg(all(feature = "apple-gpu", target_os = "macos"))]` module boundary
+- [x] 3.3 Add `objc2`, `objc2-foundation`, and `objc2-metal` dependencies behind the `apple-gpu` feature
+- [x] 3.4 Wrap Metal device, queue, pipeline, and buffer allocation behind project-owned types
+- [ ] 3.5 Implement device detection returning structured ineligibility reasons
+- [x] 3.6 Verify non-macOS and no-feature builds compile without Metal dependencies
+- [x] 3.7 Add a tiny ignored Metal smoke test that initializes the device and runs a no-op kernel
+
+## 4. Phase 4: GPU Binary-Rank Kernel
+
+- [x] 4.1 Define Metal buffer layouts for contig ranges, sorted starts, sorted ends, query chrom IDs, query starts, query ends, and output counts
+- [x] 4.2 Implement one-thread-per-query `upper_bound(starts, query_end)` kernel logic
+- [x] 4.3 Implement one-thread-per-query `lower_bound(ends, query_start)` kernel logic
+- [x] 4.4 Combine both ranks in a single count kernel when profiling shows it is faster than two kernels
+- [x] 4.5 Return zero for missing contigs and invalid strict intervals
+- [x] 4.6 Preserve output order by writing one count per original right row
+- [x] 4.7 Add GPU-vs-CPU correctness tests gated on Apple GPU availability
+- [ ] 4.8 Add debug assertions comparing a sample of GPU counts to CPU rank-reference counts in test builds
+
+## 5. Phase 5: `CountOverlapsExec` Integration
+
+- [ ] 5.1 Refactor existing `get_stream()` path into `CpuCoitreeCountBackend`
+- [x] 5.2 Add `AppleGpuCountBackend` that owns the SoA index and Metal runtime wrapper
+- [x] 5.3 Update `CountOverlapsProvider::scan()` to select CPU/GPU/auto backend
+- [x] 5.4 Encode right batches into GPU query buffers per partition
+- [x] 5.5 Append GPU counts as an `Int64Array` to each original right batch
+- [x] 5.6 Preserve existing repartition behavior for right plans
+- [x] 5.7 Add fallback before first batch emission when GPU initialization or allocation fails
+- [ ] 5.8 Emit execution metrics for backend choice, fallback reason, rows processed, and kernel time
+
+## 6. Phase 6: Auto Dispatch Thresholds
+
+- [x] 6.1 Add ignored benchmark for CPU COITree count-overlaps baseline
+- [ ] 6.2 Add ignored benchmark for CPU rank-reference baseline
+- [x] 6.3 Add ignored benchmark for GPU binary-rank path
+- [ ] 6.4 Benchmark left sizes: 1e5, 1e6, 1e7, 5e7 where locally feasible
+- [ ] 6.5 Benchmark right sizes: 1e5, 1e6, 1e7 where locally feasible
+- [ ] 6.6 Benchmark sorted, mostly sorted, and random right input order
+- [ ] 6.7 Benchmark nested/contained interval distributions
+- [x] 6.8 Set initial `Auto` thresholds from measured crossover points
+- [x] 6.9 Document threshold rationale in code comments and README/API docs
+
+## 7. Phase 7: Merge Path Rank-Sweep Follow-Up
+
+- [ ] 7.1 Detect whether a right partition is already sorted by `(contig, endpoint)` using physical ordering or a cheap runtime check
+- [ ] 7.2 Build endpoint views for query starts and query ends with original row IDs
+- [ ] 7.3 Benchmark CPU endpoint-view sorting cost versus binary-rank kernel cost
+- [ ] 7.4 Implement Merge Path partition calculation for one contig-local merge
+- [ ] 7.5 Compute `started` by merging left starts with sorted query ends
+- [ ] 7.6 Compute `ended_prior` by merging left ends with sorted query starts
+- [ ] 7.7 Scatter ranks back to original row IDs and subtract counts
+- [ ] 7.8 Dispatch Merge Path only when benchmarks show it beats binary-rank for the current input shape
+
+## 8. Phase 8: Documentation and Release Readiness
+
+- [ ] 8.1 Document `bio.count_overlaps_backend`
+- [ ] 8.2 Document platform and feature requirements for Apple GPU support
+- [ ] 8.3 Document that CPU remains the correctness baseline and fallback path
+- [ ] 8.4 Add troubleshooting notes for GPU ineligibility/fallback reasons
+- [x] 8.5 Run `cargo test -p datafusion-bio-function-ranges`
+- [x] 8.6 Run tests with `--features apple-gpu` on Apple Silicon
+- [x] 8.7 Run ignored benchmarks on at least one M3-class machine before enabling `Auto` GPU dispatch by default


### PR DESCRIPTION
## Summary
- add optional `apple-gpu` feature using `objc2-metal` and `bio.count_overlaps_backend = auto|cpu|apple_gpu`
- implement Apple Metal rank-based `count_overlaps` backend with CPU fallback, projection pushdown, right-side column pruning, and GPU batch coalescing
- add count/projection/unit/integration coverage plus release benchmark timing breakdowns
- document OpenSpec change for the Apple GPU backend and benchmarking/dispatch behavior

## Benchmarks
8-7 dataset from `/tmp/polars-bio-bench/databio` (`ex-rna` vs `ex-anno`), release mode, Apple M3 Max, 1 thread:
- CPU mean: `611.363 ms`
- final auto/GPU mean after optimizations: `402.442 ms`
- result: `n_rows=1194285,total_overlaps=307298602`

Timing breakdown after final optimization:
- left collect: ~`51-55 ms`
- CPU rank-index/backend build: ~`282-303 ms`
- GPU batch execution: ~`30-32 ms`

## Verification
- `cargo test -p datafusion-bio-function-ranges --features apple-gpu`
- `cargo test -p datafusion-bio-function-ranges --features apple-gpu test_count_overlaps_apple_gpu_matches_cpu_fixtures -- --ignored --nocapture`
- `cargo run -p datafusion-bio-function-ranges --release --features apple-gpu --example count_overlaps_bench -- --backend auto --threads 1 --repeats 5 --warmups 1 --timings --left /tmp/polars-bio-bench/databio/ex-rna --right /tmp/polars-bio-bench/databio/ex-anno`