### PR TITLE
feat: Add left overlap output mode

### DIFF
--- a/datafusion/bio-function-ranges/src/lib.rs
+++ b/datafusion/bio-function-ranges/src/lib.rs
@@ -21,7 +21,7 @@ pub use count_overlaps::CountOverlapsProvider;
 pub use filter_op::FilterOp;
 pub use merge::MergeProvider;
 pub use nearest::NearestProvider;
-pub use overlap::OverlapProvider;
+pub use overlap::{OverlapOutputMode, OverlapProvider};
 pub use physical_planner::BioQueryPlanner;
 pub use physical_planner::IntervalJoinPhysicalOptimizationRule;
 pub use physical_planner::joins::interval_join::IntervalJoinExec;

--- a/datafusion/bio-function-ranges/src/overlap.rs
+++ b/datafusion/bio-function-ranges/src/overlap.rs
@@ -7,10 +7,49 @@ use datafusion::arrow::datatypes::{Field, Schema, SchemaRef};
 use datafusion::catalog::Session;
 use datafusion::common::Result;
 use datafusion::datasource::{TableProvider, TableType};
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::{ExecutionPlan, PhysicalExpr};
 use datafusion::prelude::{Expr, SessionContext};
 
 use crate::filter_op::FilterOp;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OverlapOutputMode {
+    Join,
+    Left,
+}
+
+fn wrap_with_projection(
+    plan: Arc<dyn ExecutionPlan>,
+    projection: Option<&Vec<usize>>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let Some(indices) = projection else {
+        return Ok(plan);
+    };
+
+    let schema = plan.schema();
+    let is_identity = indices.len() == schema.fields().len()
+        && indices
+            .iter()
+            .copied()
+            .enumerate()
+            .all(|(expected, actual)| expected == actual);
+    if is_identity {
+        return Ok(plan);
+    }
+
+    let exprs = indices
+        .iter()
+        .map(|&idx| {
+            let field = schema.field(idx);
+            let expr = Arc::new(Column::new(field.name(), idx)) as Arc<dyn PhysicalExpr>;
+            (expr, field.name().clone())
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Arc::new(ProjectionExec::try_new(exprs, plan)?))
+}
 
 pub struct OverlapProvider {
     session: Arc<SessionContext>,
@@ -21,6 +60,7 @@ pub struct OverlapProvider {
     columns_1: (String, String, String),
     columns_2: (String, String, String),
     filter_op: FilterOp,
+    output_mode: OverlapOutputMode,
     schema: SchemaRef,
 }
 
@@ -36,25 +76,55 @@ impl OverlapProvider {
         columns_2: Vec<String>,
         filter_op: FilterOp,
     ) -> Self {
-        let mut fields = left_schema
-            .fields()
-            .iter()
-            .map(|f| {
-                Arc::new(Field::new(
-                    format!("left_{}", f.name()),
-                    f.data_type().clone(),
-                    f.is_nullable(),
-                ))
-            })
-            .collect::<Vec<_>>();
-        fields.extend(right_schema.fields().iter().map(|f| {
-            Arc::new(Field::new(
-                format!("right_{}", f.name()),
-                f.data_type().clone(),
-                f.is_nullable(),
-            ))
-        }));
-        let schema = Arc::new(Schema::new(fields));
+        Self::new_with_output_mode(
+            session,
+            left_table,
+            right_table,
+            left_schema,
+            right_schema,
+            columns_1,
+            columns_2,
+            filter_op,
+            OverlapOutputMode::Join,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_output_mode(
+        session: Arc<SessionContext>,
+        left_table: String,
+        right_table: String,
+        left_schema: Schema,
+        right_schema: Schema,
+        columns_1: Vec<String>,
+        columns_2: Vec<String>,
+        filter_op: FilterOp,
+        output_mode: OverlapOutputMode,
+    ) -> Self {
+        let schema = match output_mode {
+            OverlapOutputMode::Join => {
+                let mut fields = left_schema
+                    .fields()
+                    .iter()
+                    .map(|f| {
+                        Arc::new(Field::new(
+                            format!("left_{}", f.name()),
+                            f.data_type().clone(),
+                            f.is_nullable(),
+                        ))
+                    })
+                    .collect::<Vec<_>>();
+                fields.extend(right_schema.fields().iter().map(|f| {
+                    Arc::new(Field::new(
+                        format!("right_{}", f.name()),
+                        f.data_type().clone(),
+                        f.is_nullable(),
+                    ))
+                }));
+                Arc::new(Schema::new(fields))
+            }
+            OverlapOutputMode::Left => Arc::new(left_schema.clone()),
+        };
 
         Self {
             session,
@@ -73,8 +143,61 @@ impl OverlapProvider {
                 columns_2[2].clone(),
             ),
             filter_op,
+            output_mode,
             schema,
         }
+    }
+
+    fn join_query(&self, sign: &str) -> String {
+        let select_left = self
+            .left_schema
+            .fields()
+            .iter()
+            .map(|f| format!("a.`{}` AS `left_{}`", f.name(), f.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let select_right = self
+            .right_schema
+            .fields()
+            .iter()
+            .map(|f| format!("b.`{}` AS `right_{}`", f.name(), f.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let (c1, s1, e1) = (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2);
+        let (c2, s2, e2) = (&self.columns_2.0, &self.columns_2.1, &self.columns_2.2);
+
+        format!(
+            "SELECT {select_left}, {select_right} \
+             FROM `{}` AS b, `{}` AS a \
+             WHERE a.`{c1}` = b.`{c2}` \
+             AND CAST(a.`{e1}` AS INTEGER) >{sign} CAST(b.`{s2}` AS INTEGER) \
+             AND CAST(a.`{s1}` AS INTEGER) <{sign} CAST(b.`{e2}` AS INTEGER)",
+            self.right_table, self.left_table,
+        )
+    }
+
+    fn left_query(&self, sign: &str) -> String {
+        let select_left = self
+            .left_schema
+            .fields()
+            .iter()
+            .map(|f| format!("a.`{}`", f.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let (c1, s1, e1) = (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2);
+        let (c2, s2, e2) = (&self.columns_2.0, &self.columns_2.1, &self.columns_2.2);
+
+        format!(
+            "SELECT {select_left} \
+             FROM `{}` AS b \
+             RIGHT SEMI JOIN `{}` AS a \
+             ON a.`{c1}` = b.`{c2}` \
+             AND CAST(a.`{e1}` AS INTEGER) >{sign} CAST(b.`{s2}` AS INTEGER) \
+             AND CAST(a.`{s1}` AS INTEGER) <{sign} CAST(b.`{e2}` AS INTEGER)",
+            self.right_table, self.left_table,
+        )
     }
 }
 
@@ -105,44 +228,23 @@ impl TableProvider for OverlapProvider {
     async fn scan(
         &self,
         _state: &dyn Session,
-        _projection: Option<&Vec<usize>>,
+        projection: Option<&Vec<usize>>,
         _filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let select_left = self
-            .left_schema
-            .fields()
-            .iter()
-            .map(|f| format!("a.`{}` AS `left_{}`", f.name(), f.name()))
-            .collect::<Vec<_>>()
-            .join(", ");
-        let select_right = self
-            .right_schema
-            .fields()
-            .iter()
-            .map(|f| format!("b.`{}` AS `right_{}`", f.name(), f.name()))
-            .collect::<Vec<_>>()
-            .join(", ");
-
         let sign = if self.filter_op == FilterOp::Strict {
             ""
         } else {
             "="
         };
 
-        let (c1, s1, e1) = (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2);
-        let (c2, s2, e2) = (&self.columns_2.0, &self.columns_2.1, &self.columns_2.2);
-
-        let query = format!(
-            "SELECT {select_left}, {select_right} \
-             FROM `{}` AS b, `{}` AS a \
-             WHERE a.`{c1}` = b.`{c2}` \
-             AND CAST(a.`{e1}` AS INTEGER) >{sign} CAST(b.`{s2}` AS INTEGER) \
-             AND CAST(a.`{s1}` AS INTEGER) <{sign} CAST(b.`{e2}` AS INTEGER)",
-            self.right_table, self.left_table,
-        );
+        let query = match self.output_mode {
+            OverlapOutputMode::Join => self.join_query(sign),
+            OverlapOutputMode::Left => self.left_query(sign),
+        };
 
         let df = self.session.sql(&query).await?;
-        df.create_physical_plan().await
+        let plan = df.create_physical_plan().await?;
+        wrap_with_projection(plan, projection)
     }
 }

--- a/datafusion/bio-function-ranges/src/overlap.rs
+++ b/datafusion/bio-function-ranges/src/overlap.rs
@@ -18,6 +18,7 @@ use crate::filter_op::FilterOp;
 pub enum OverlapOutputMode {
     Join,
     Left,
+    LeftDistinct,
 }
 
 fn wrap_with_projection(
@@ -123,7 +124,9 @@ impl OverlapProvider {
                 }));
                 Arc::new(Schema::new(fields))
             }
-            OverlapOutputMode::Left => Arc::new(left_schema.clone()),
+            OverlapOutputMode::Left | OverlapOutputMode::LeftDistinct => {
+                Arc::new(left_schema.clone())
+            }
         };
 
         Self {
@@ -191,6 +194,28 @@ impl OverlapProvider {
 
         format!(
             "SELECT {select_left} \
+             FROM `{}` AS b, `{}` AS a \
+             WHERE a.`{c1}` = b.`{c2}` \
+             AND CAST(a.`{e1}` AS INTEGER) >{sign} CAST(b.`{s2}` AS INTEGER) \
+             AND CAST(a.`{s1}` AS INTEGER) <{sign} CAST(b.`{e2}` AS INTEGER)",
+            self.right_table, self.left_table,
+        )
+    }
+
+    fn left_distinct_query(&self, sign: &str) -> String {
+        let select_left = self
+            .left_schema
+            .fields()
+            .iter()
+            .map(|f| format!("a.`{}`", f.name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let (c1, s1, e1) = (&self.columns_1.0, &self.columns_1.1, &self.columns_1.2);
+        let (c2, s2, e2) = (&self.columns_2.0, &self.columns_2.1, &self.columns_2.2);
+
+        format!(
+            "SELECT {select_left} \
              FROM `{}` AS b \
              RIGHT SEMI JOIN `{}` AS a \
              ON a.`{c1}` = b.`{c2}` \
@@ -241,6 +266,7 @@ impl TableProvider for OverlapProvider {
         let query = match self.output_mode {
             OverlapOutputMode::Join => self.join_query(sign),
             OverlapOutputMode::Left => self.left_query(sign),
+            OverlapOutputMode::LeftDistinct => self.left_distinct_query(sign),
         };
 
         let df = self.session.sql(&query).await?;

--- a/datafusion/bio-function-ranges/src/physical_planner/joins/interval_join.rs
+++ b/datafusion/bio-function-ranges/src/physical_planner/joins/interval_join.rs
@@ -1011,6 +1011,42 @@ impl IntervalJoinStreamState {
 }
 
 impl IntervalJoinStream {
+    fn is_probe_existence_join(join_type: JoinType) -> bool {
+        matches!(join_type, JoinType::RightSemi | JoinType::RightAnti)
+    }
+
+    fn should_emit_probe_row(join_type: JoinType, has_match: bool) -> bool {
+        match join_type {
+            JoinType::RightSemi => has_match,
+            JoinType::RightAnti => !has_match,
+            _ => false,
+        }
+    }
+
+    fn build_probe_only_batch(
+        schema: SchemaRef,
+        column_indices: &[ColumnIndex],
+        batch: &RecordBatch,
+        right_indices: Vec<u32>,
+    ) -> Result<RecordBatch> {
+        let right_indexes = PrimitiveArray::<UInt32Type>::from(right_indices);
+        let mut columns: Vec<Arc<dyn Array>> = Vec::with_capacity(schema.fields().len());
+
+        for column_index in column_indices {
+            if column_index.side != JoinSide::Right {
+                return internal_err!(
+                    "Expected probe-only join output column to come from right side, got {:?}",
+                    column_index.side
+                );
+            }
+
+            let array = batch.column(column_index.index);
+            columns.push(compute::take(array, &right_indexes, None)?);
+        }
+
+        Ok(RecordBatch::try_new(schema, columns)?)
+    }
+
     fn poll_next_impl(
         &mut self,
         cx: &mut std::task::Context<'_>,
@@ -1117,6 +1153,8 @@ impl IntervalJoinStream {
     fn process_probe_batch_streaming(
         &mut self,
     ) -> Result<StatefulStreamResult<Option<RecordBatch>>> {
+        let join_type = self.join_type;
+        let probe_existence_join = Self::is_probe_existence_join(join_type);
         let state = self.state.try_as_process_probe_batch_mut()?;
         let build_side = match self.build_side.as_ref() {
             Some(build_side) => Ok(build_side),
@@ -1135,9 +1173,47 @@ impl IntervalJoinStream {
         let chunk_end = std::cmp::min(start_row_idx + self.max_output_batch_size / 100, batch_size);
 
         let mut temp_matches = Vec::with_capacity(64);
-        let mut total_output_rows = state.accumulated_left_matches.len();
+        let mut total_output_rows = if probe_existence_join {
+            state.accumulated_right_indices.len()
+        } else {
+            state.accumulated_left_matches.len()
+        };
 
         for i in start_row_idx..chunk_end {
+            if probe_existence_join {
+                let mut has_match = false;
+                build_side.hash_map.get(
+                    self.hashes_buffer[i],
+                    start.value(i),
+                    end.value(i),
+                    |_| {
+                        has_match = true;
+                    },
+                );
+
+                if Self::should_emit_probe_row(join_type, has_match) {
+                    state.accumulated_right_indices.push(i as u32);
+                    total_output_rows += 1;
+                }
+
+                if total_output_rows >= self.max_output_batch_size {
+                    state.probe_row_idx = i + 1;
+                    self.state =
+                        IntervalJoinStreamState::EmitAccumulatedMatches(ProcessProbeBatchState {
+                            batch: state.batch.clone(),
+                            probe_row_idx: state.probe_row_idx,
+                            accumulated_left_matches: Vec::new(),
+                            accumulated_right_indices: std::mem::take(
+                                &mut state.accumulated_right_indices,
+                            ),
+                        });
+                    timer.done();
+                    return self.emit_accumulated_matches();
+                }
+
+                continue;
+            }
+
             temp_matches.clear();
 
             build_side
@@ -1191,7 +1267,13 @@ impl IntervalJoinStream {
         state.probe_row_idx = chunk_end;
 
         if chunk_end >= batch_size {
-            if !state.accumulated_left_matches.is_empty() {
+            let has_accumulated_output = if probe_existence_join {
+                !state.accumulated_right_indices.is_empty()
+            } else {
+                !state.accumulated_left_matches.is_empty()
+            };
+
+            if has_accumulated_output {
                 self.state =
                     IntervalJoinStreamState::EmitAccumulatedMatches(ProcessProbeBatchState {
                         batch: state.batch.clone(),
@@ -1217,6 +1299,9 @@ impl IntervalJoinStream {
     }
 
     fn emit_accumulated_matches(&mut self) -> Result<StatefulStreamResult<Option<RecordBatch>>> {
+        let probe_existence_join = Self::is_probe_existence_join(self.join_type);
+        let schema = self.schema.clone();
+        let column_indices = self.column_indices.clone();
         let state = match &mut self.state {
             IntervalJoinStreamState::EmitAccumulatedMatches(state) => state,
             _ => return internal_err!("Expected EmitAccumulatedMatches state"),
@@ -1227,7 +1312,13 @@ impl IntervalJoinStream {
             None => internal_err!("Expected build side in ready state"),
         }?;
 
-        if state.accumulated_left_matches.is_empty() {
+        let has_pending_output = if probe_existence_join {
+            !state.accumulated_right_indices.is_empty()
+        } else {
+            !state.accumulated_left_matches.is_empty()
+        };
+
+        if !has_pending_output {
             if state.probe_row_idx >= state.batch.num_rows() {
                 self.state = IntervalJoinStreamState::FetchProbeBatch;
             } else {
@@ -1239,6 +1330,31 @@ impl IntervalJoinStream {
                 });
             }
             return Ok(StatefulStreamResult::Continue);
+        }
+
+        if probe_existence_join {
+            let result = Self::build_probe_only_batch(
+                schema,
+                &column_indices,
+                &state.batch,
+                std::mem::take(&mut state.accumulated_right_indices),
+            )?;
+
+            self.join_metrics.output_batches.add(1);
+            self.join_metrics.output_rows.add(result.num_rows());
+
+            if state.probe_row_idx >= state.batch.num_rows() {
+                self.state = IntervalJoinStreamState::FetchProbeBatch;
+            } else {
+                self.state = IntervalJoinStreamState::ProcessProbeBatch(ProcessProbeBatchState {
+                    batch: state.batch.clone(),
+                    probe_row_idx: state.probe_row_idx,
+                    accumulated_left_matches: Vec::new(),
+                    accumulated_right_indices: Vec::new(),
+                });
+            }
+
+            return Ok(StatefulStreamResult::Ready(Some(result)));
         }
 
         // Build left indexes, handling null markers
@@ -1300,6 +1416,9 @@ impl IntervalJoinStream {
         Ok(StatefulStreamResult::Ready(Some(result)))
     }
     fn process_probe_batch(&mut self) -> Result<StatefulStreamResult<Option<RecordBatch>>> {
+        let join_type = self.join_type;
+        let schema = self.schema.clone();
+        let column_indices = self.column_indices.clone();
         let state = self.state.try_as_process_probe_batch_mut()?;
         let build_side = match self.build_side.as_ref() {
             Some(build_side) => Ok(build_side),
@@ -1310,6 +1429,39 @@ impl IntervalJoinStream {
 
         let start = evaluate_as_i32(self.right_interval.start(), &state.batch)?;
         let end = evaluate_as_i32(self.right_interval.end(), &state.batch)?;
+
+        if Self::is_probe_existence_join(join_type) {
+            let mut right_indices = Vec::with_capacity(state.batch.num_rows());
+
+            for (i, hash_val) in self.hashes_buffer.iter().enumerate() {
+                let mut has_match = false;
+                build_side
+                    .hash_map
+                    .get(*hash_val, start.value(i), end.value(i), |_| {
+                        has_match = true;
+                    });
+
+                if Self::should_emit_probe_row(join_type, has_match) {
+                    right_indices.push(i as u32);
+                }
+            }
+
+            if right_indices.is_empty() {
+                self.state = IntervalJoinStreamState::FetchProbeBatch;
+                timer.done();
+                return Ok(StatefulStreamResult::Continue);
+            }
+
+            let result =
+                Self::build_probe_only_batch(schema, &column_indices, &state.batch, right_indices)?;
+
+            self.join_metrics.output_batches.add(1);
+            self.join_metrics.output_rows.add(result.num_rows());
+            timer.done();
+            self.state = IntervalJoinStreamState::FetchProbeBatch;
+            return Ok(StatefulStreamResult::Ready(Some(result)));
+        }
+
         // Two modes: low-memory (streaming/capped) vs. full-batch (pre-streaming behavior)
         if self.low_memory {
             // Output-size limited processing to prevent memory explosion

--- a/datafusion/bio-function-ranges/src/table_function.rs
+++ b/datafusion/bio-function-ranges/src/table_function.rs
@@ -100,14 +100,14 @@ fn parse_overlap_args(
     fn_name: &str,
 ) -> Result<(ColTriple, ColTriple, FilterOp, OverlapOutputMode)> {
     let extra = &args[2..];
-    let mut end = extra.len();
+    let mut col_args = extra;
     let mut filter_op = FilterOp::Weak;
     let mut output_mode = OverlapOutputMode::Join;
     let mut has_filter_op = false;
     let mut has_output_mode = false;
 
-    while end > 0 {
-        let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = &extra[end - 1] else {
+    while !matches!(col_args.len(), 0 | 3 | 6) {
+        let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = &col_args[col_args.len() - 1] else {
             break;
         };
 
@@ -115,33 +115,33 @@ fn parse_overlap_args(
             "strict" if !has_filter_op => {
                 filter_op = FilterOp::Strict;
                 has_filter_op = true;
-                end -= 1;
+                col_args = &col_args[..col_args.len() - 1];
             }
             "weak" if !has_filter_op => {
                 filter_op = FilterOp::Weak;
                 has_filter_op = true;
-                end -= 1;
+                col_args = &col_args[..col_args.len() - 1];
             }
             "left" | "left_distinct" if !has_output_mode => {
                 output_mode = OverlapOutputMode::LeftDistinct;
                 has_output_mode = true;
-                end -= 1;
+                col_args = &col_args[..col_args.len() - 1];
             }
             "left_all" | "left_multiple" if !has_output_mode => {
                 output_mode = OverlapOutputMode::Left;
                 has_output_mode = true;
-                end -= 1;
+                col_args = &col_args[..col_args.len() - 1];
             }
             "join" if !has_output_mode => {
                 output_mode = OverlapOutputMode::Join;
                 has_output_mode = true;
-                end -= 1;
+                col_args = &col_args[..col_args.len() - 1];
             }
             _ => break,
         }
     }
 
-    let (cols_left, cols_right, filter_op) = parse_col_triples(&extra[..end], filter_op, fn_name)?;
+    let (cols_left, cols_right, filter_op) = parse_col_triples(col_args, filter_op, fn_name)?;
     Ok((cols_left, cols_right, filter_op, output_mode))
 }
 

--- a/datafusion/bio-function-ranges/src/table_function.rs
+++ b/datafusion/bio-function-ranges/src/table_function.rs
@@ -122,7 +122,12 @@ fn parse_overlap_args(
                 has_filter_op = true;
                 end -= 1;
             }
-            "left" if !has_output_mode => {
+            "left" | "left_distinct" if !has_output_mode => {
+                output_mode = OverlapOutputMode::LeftDistinct;
+                has_output_mode = true;
+                end -= 1;
+            }
+            "left_all" | "left_multiple" if !has_output_mode => {
                 output_mode = OverlapOutputMode::Left;
                 has_output_mode = true;
                 end -= 1;

--- a/datafusion/bio-function-ranges/src/table_function.rs
+++ b/datafusion/bio-function-ranges/src/table_function.rs
@@ -13,7 +13,7 @@ use crate::count_overlaps::CountOverlapsProvider;
 use crate::filter_op::FilterOp;
 use crate::merge::MergeProvider;
 use crate::nearest::NearestProvider;
-use crate::overlap::OverlapProvider;
+use crate::overlap::{OverlapOutputMode, OverlapProvider};
 use crate::subtract::SubtractProvider;
 
 /// Resolve a table's Arrow schema synchronously, handling both inside and
@@ -91,6 +91,61 @@ fn parse_col_args_extra(extra: &[Expr], fn_name: &str) -> Result<(ColTriple, Col
             (extra, FilterOp::Weak)
         };
 
+    parse_col_triples(col_args, filter_op, fn_name)
+}
+
+#[allow(clippy::type_complexity)]
+fn parse_overlap_args(
+    args: &[Expr],
+    fn_name: &str,
+) -> Result<(ColTriple, ColTriple, FilterOp, OverlapOutputMode)> {
+    let extra = &args[2..];
+    let mut end = extra.len();
+    let mut filter_op = FilterOp::Weak;
+    let mut output_mode = OverlapOutputMode::Join;
+    let mut has_filter_op = false;
+    let mut has_output_mode = false;
+
+    while end > 0 {
+        let Expr::Literal(ScalarValue::Utf8(Some(val)), _) = &extra[end - 1] else {
+            break;
+        };
+
+        match val.to_lowercase().as_str() {
+            "strict" if !has_filter_op => {
+                filter_op = FilterOp::Strict;
+                has_filter_op = true;
+                end -= 1;
+            }
+            "weak" if !has_filter_op => {
+                filter_op = FilterOp::Weak;
+                has_filter_op = true;
+                end -= 1;
+            }
+            "left" if !has_output_mode => {
+                output_mode = OverlapOutputMode::Left;
+                has_output_mode = true;
+                end -= 1;
+            }
+            "join" if !has_output_mode => {
+                output_mode = OverlapOutputMode::Join;
+                has_output_mode = true;
+                end -= 1;
+            }
+            _ => break,
+        }
+    }
+
+    let (cols_left, cols_right, filter_op) = parse_col_triples(&extra[..end], filter_op, fn_name)?;
+    Ok((cols_left, cols_right, filter_op, output_mode))
+}
+
+#[allow(clippy::type_complexity)]
+fn parse_col_triples(
+    col_args: &[Expr],
+    filter_op: FilterOp,
+    fn_name: &str,
+) -> Result<(ColTriple, ColTriple, FilterOp)> {
     match col_args.len() {
         0 => {
             let cols = (
@@ -329,7 +384,7 @@ impl TableFunctionImpl for OverlapTableFunction {
 
         let left_table = extract_string_arg(&args[0], "left_table", self.name)?;
         let right_table = extract_string_arg(&args[1], "right_table", self.name)?;
-        let (cols_left, cols_right, filter_op) = parse_col_args(args, self.name)?;
+        let (cols_left, cols_right, filter_op, output_mode) = parse_overlap_args(args, self.name)?;
 
         let (left_schema, right_schema) = match tokio::runtime::Handle::try_current() {
             Ok(handle) => tokio::task::block_in_place(|| {
@@ -352,7 +407,7 @@ impl TableFunctionImpl for OverlapTableFunction {
             }
         }?;
 
-        Ok(Arc::new(OverlapProvider::new(
+        Ok(Arc::new(OverlapProvider::new_with_output_mode(
             Arc::clone(&self.session),
             left_table,
             right_table,
@@ -361,6 +416,7 @@ impl TableFunctionImpl for OverlapTableFunction {
             vec![cols_left.0, cols_left.1, cols_left.2],
             vec![cols_right.0, cols_right.1, cols_right.2],
             filter_op,
+            output_mode,
         )))
     }
 }

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1829,6 +1829,59 @@ async fn test_overlap_udtf_custom_columns() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_overlap_udtf_custom_column_names_can_match_mode_tokens() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE a (chr TEXT, start INTEGER, "join" INTEGER) AS VALUES
+        ('a', 100, 200)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE b (chr TEXT, start INTEGER, "join" INTEGER) AS VALUES
+        ('a', 150, 250)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql(r#"SELECT * FROM overlap('a', 'b', 'chr', 'start', 'join')"#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(result.iter().map(|b| b.num_rows()).sum::<usize>(), 1);
+    assert_eq!(result[0].schema().field(2).name(), "left_join");
+    assert_eq!(result[0].schema().field(5).name(), "right_join");
+
+    ctx.sql(
+        r#"
+        CREATE TABLE c (chr TEXT, start INTEGER, "left" INTEGER) AS VALUES
+        ('a', 100, 200)
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE d (chr TEXT, start INTEGER, "left" INTEGER) AS VALUES
+        ('a', 200, 300)
+    "#,
+    )
+    .await?;
+
+    let strict = ctx
+        .sql(r#"SELECT * FROM overlap('c', 'd', 'chr', 'start', 'left', 'strict')"#)
+        .await?
+        .collect()
+        .await?;
+    assert_eq!(strict.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_overlap_udtf_left_output_preserves_left_rows() -> Result<()> {
     let ctx = create_bio_session();
 

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1902,6 +1902,65 @@ async fn test_overlap_udtf_left_output_preserves_left_rows() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_overlap_udtf_left_all_output_preserves_overlap_multiplicity() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER, name TEXT) AS VALUES
+        ('chr1', 100, 200, 'dup'),
+        ('chr1', 100, 200, 'dup'),
+        ('chr1', 1000, 1100, 'miss'),
+        ('chr2', 50, 60, 'other')
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('chr1', 90, 150),
+        ('chr1', 120, 180),
+        ('chr2', 55, 56)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql(
+            r#"
+            SELECT * FROM overlap('reads', 'targets', 'left_all')
+            ORDER BY contig, pos_start, pos_end, name
+        "#,
+        )
+        .await?
+        .collect()
+        .await?;
+
+    let expected = [
+        "+--------+-----------+---------+-------+",
+        "| contig | pos_start | pos_end | name  |",
+        "+--------+-----------+---------+-------+",
+        "| chr1   | 100       | 200     | dup   |",
+        "| chr1   | 100       | 200     | dup   |",
+        "| chr1   | 100       | 200     | dup   |",
+        "| chr1   | 100       | 200     | dup   |",
+        "| chr2   | 50        | 60      | other |",
+        "+--------+-----------+---------+-------+",
+    ];
+
+    assert_batches_sorted_eq!(expected, &result);
+
+    let plan = ctx
+        .sql("EXPLAIN SELECT * FROM overlap('reads', 'targets', 'left_all')")
+        .await?
+        .collect()
+        .await?;
+    assert_contains!(pretty_format_batches(&plan)?.to_string(), "join_type=Inner");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_overlap_udtf_left_output_custom_columns_and_strict() -> Result<()> {
     let ctx = create_bio_session();
 

--- a/datafusion/bio-function-ranges/tests/integration_test.rs
+++ b/datafusion/bio-function-ranges/tests/integration_test.rs
@@ -1828,6 +1828,123 @@ async fn test_overlap_udtf_custom_columns() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_overlap_udtf_left_output_preserves_left_rows() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE reads (contig TEXT, pos_start INTEGER, pos_end INTEGER, name TEXT) AS VALUES
+        ('chr1', 100, 200, 'dup'),
+        ('chr1', 100, 200, 'dup'),
+        ('chr1', 1000, 1100, 'miss'),
+        ('chr2', 50, 60, 'other')
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE targets (contig TEXT, pos_start INTEGER, pos_end INTEGER) AS VALUES
+        ('chr1', 90, 150),
+        ('chr1', 120, 180),
+        ('chr2', 55, 56)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql(
+            r#"
+            SELECT * FROM overlap('reads', 'targets', 'left')
+            ORDER BY contig, pos_start, pos_end, name
+        "#,
+        )
+        .await?
+        .collect()
+        .await?;
+
+    let expected = [
+        "+--------+-----------+---------+-------+",
+        "| contig | pos_start | pos_end | name  |",
+        "+--------+-----------+---------+-------+",
+        "| chr1   | 100       | 200     | dup   |",
+        "| chr1   | 100       | 200     | dup   |",
+        "| chr2   | 50        | 60      | other |",
+        "+--------+-----------+---------+-------+",
+    ];
+
+    assert_batches_sorted_eq!(expected, &result);
+
+    let plan = ctx
+        .sql("EXPLAIN SELECT * FROM overlap('reads', 'targets', 'left')")
+        .await?
+        .collect()
+        .await?;
+    assert_contains!(
+        pretty_format_batches(&plan)?.to_string(),
+        "join_type=RightSemi"
+    );
+
+    ctx.sql("SET bio.interval_join_low_memory = true").await?;
+    let low_memory_result = ctx
+        .sql(
+            r#"
+            SELECT * FROM overlap('reads', 'targets', 'left')
+            ORDER BY contig, pos_start, pos_end, name
+        "#,
+        )
+        .await?
+        .collect()
+        .await?;
+    assert_batches_sorted_eq!(expected, &low_memory_result);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_overlap_udtf_left_output_custom_columns_and_strict() -> Result<()> {
+    let ctx = create_bio_session();
+
+    ctx.sql(
+        r#"
+        CREATE TABLE a (chr TEXT, s INTEGER, e INTEGER, label TEXT) AS VALUES
+        ('a', 100, 200, 'touching'),
+        ('a', 100, 201, 'overlap')
+    "#,
+    )
+    .await?;
+    ctx.sql(
+        r#"
+        CREATE TABLE b (chr TEXT, s INTEGER, e INTEGER) AS VALUES
+        ('a', 200, 300)
+    "#,
+    )
+    .await?;
+
+    let result = ctx
+        .sql(
+            r#"
+            SELECT * FROM overlap('a', 'b', 'chr', 's', 'e', 'strict', 'left')
+            ORDER BY label
+        "#,
+        )
+        .await?
+        .collect()
+        .await?;
+
+    let expected = [
+        "+-----+-----+-----+---------+",
+        "| chr | s   | e   | label   |",
+        "+-----+-----+-----+---------+",
+        "| a   | 100 | 201 | overlap |",
+        "+-----+-----+-----+---------+",
+    ];
+
+    assert_batches_sorted_eq!(expected, &result);
+
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Merge UDTF tests
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `OverlapOutputMode` to `OverlapProvider` with existing join output preserved as the default.
- Add left-only overlap modes: one row per overlap and one row per overlapping left row.
- Fix probe-side semi/anti interval join materialization so `RightSemi` emits probe rows once by row identity.
- Extend the overlap table function parser with `left`, `left_all`, and `left_multiple` modes.

Supports biodatageeks/polars-bio#369.

## Verification
- `cargo check -p datafusion-bio-function-ranges`
- `cargo test -p datafusion-bio-function-ranges overlap_udtf_left -- --nocapture`
- pre-commit hooks: fmt, clippy