### PR TITLE
Add redb variation cache backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "noodles-fasta",
  "noodles-vcf 0.80.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "parquet",
+ "redb",
  "serde_json",
  "tempfile",
  "tokio",
@@ -4527,6 +4528,15 @@ checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This workspace provides a collection of Rust crates that implement DataFusion UD
 |-------|-------------|--------|
 | **[datafusion-bio-function-pileup](datafusion/bio-function-pileup)** | Depth-of-coverage (pileup) computation from BAM alignments | ✅ |
 | **[datafusion-bio-function-ranges](datafusion/bio-function-ranges)** | Interval join, coverage, count-overlaps, nearest-neighbor, overlap, merge, cluster, complement, and subtract operations | ✅ |
-| **[datafusion-bio-function-vep](datafusion/bio-function-vep)** | VEP variant annotation via `lookup_variants()` table function with parquet + Fjall KV cache backends | ✅ |
+| **[datafusion-bio-function-vep](datafusion/bio-function-vep)** | VEP variant annotation via `lookup_variants()` table function with parquet, fjall, and redb cache backends | ✅ |
 
 ## Features
 
@@ -46,9 +46,9 @@ This workspace provides a collection of Rust crates that implement DataFusion UD
 ### VEP Annotation (lookup + consequence scaffolding)
 
 - **`lookup_variants()` Table Function**: SQL-based variant annotation against a pre-built VEP cache
-- **KV Cache Backend**: fjall LSM-tree store with zstd dictionary compression for compact on-disk storage
+- **KV Cache Backends**: fjall LSM-tree or redb single-file store with zstd dictionary compression for compact on-disk storage
 - **Match Modes**: `exact`, `exact_or_colocated_ids`, `exact_or_vep_existing` (indel-aware relaxed matching)
-- **`annotate_vep()` Table Function**: backend-unified consequence annotation entrypoint (`parquet` or `fjall`) with phased CSQ rollout
+- **`annotate_vep()` Table Function**: backend-unified consequence annotation entrypoint (`parquet`, `fjall`, or `redb`) with phased CSQ rollout
 - **Session Configuration**: Tunable parameters via SQL `SET` statements under the `bio.annotation` namespace
 
 #### `annotate_vep` API (Phase 1)
@@ -64,7 +64,7 @@ annotate_vep(
 
 - `vcf_table`: registered input VCF table.
 - `cache_source`: backend-specific source path/identifier.
-- `backend`: `parquet` or `fjall`.
+- `backend`: `parquet`, `fjall`, or `redb`.
 - `options_json` (optional): backend/runtime options. Current keys:
   - `transcripts_table`: registered table name with transcript intervals/coding context.
   - `exons_table`: registered table name with exon intervals/order.
@@ -92,9 +92,9 @@ Feature comparison snapshot:
 | Transcript consequence engine | ✅ (full SO consequence model) | 🚧 transcript/exon phase-2 baseline merged (not full VEP parity) |
 | Supported consequence terms | 41/41 | 🚧 41/41 term handlers wired; codon-accurate parity still in progress |
 | Most severe consequence output | ✅ | 🚧 ranked SO output when transcript/exon context is available; fallback placeholder otherwise |
-| Backend abstraction | Cache/files in VEP ecosystem | ✅ unified API for `parquet` + `fjall` entrypoint |
+| Backend abstraction | Cache/files in VEP ecosystem | ✅ unified API for `parquet`, `fjall`, and `redb` entrypoints |
 | Native SQL execution in DataFusion | ❌ | ✅ |
-| Fjall KV backend | ❌ | ✅ |
+| KV backends | ❌ | ✅ fjall + redb |
 
 #### Golden Benchmark (`annotate_vep` vs Ensembl VEP 115)
 
@@ -123,7 +123,7 @@ Output report:
 `lookup_variants(vcf_table, cache_table, ...)` supports both backends through the same API:
 
 - **Parquet or other scan-capable table providers**: uses interval-join execution.
-- **Fjall `KvCacheTableProvider`**: dispatches to direct KV lookup execution.
+- **KV cache table providers**: dispatch to direct position-key lookup execution.
 
 Both cache backends must expose the same required cache column names:
 `chrom`, `start`, `end`, `variation_name`, `allele_string`.
@@ -141,7 +141,7 @@ lookup_variants(
 ```
 
 - `vcf_table`: registered VCF input table name.
-- `cache_table`: registered annotation cache table/provider name (Parquet or Fjall).
+- `cache_table`: registered annotation cache table/provider name (Parquet, fjall, or redb).
 - `columns` (optional): comma-separated cache columns to project. Default: all cache columns except `chrom,start,end` and `source_*`.
 - `match_mode` (optional, default `exact`):
   - `exact`: interval overlap + exact allele matching only.
@@ -189,19 +189,22 @@ let df = ctx
     .await?;
 ```
 
-#### Create Fjall Cache
+#### Create KV Cache
 
-Create a full Fjall cache from a Parquet variation cache:
+Create a full fjall or redb cache from a Parquet variation cache:
 
 ```bash
 cargo run -p datafusion-bio-function-vep --example load_cache_full --features kv-cache --release -- \
   /path/to/115_GRCh38_variants.parquet \
   /path/to/variation_fjall \
-  8
+  8 \
+  fjall
 ```
 
 - Third argument is thread count (`target_partitions` + loader parallelism).
+- Optional fourth argument is backend: `fjall` (default) or `redb`.
 - Output path is recreated if it already exists.
+- For annotation with `backend='redb'`, place the redb file at `<cache_dir>/variation.redb` alongside partitioned context parquet directories.
 
 Create a filtered cache (single chromosome) and optionally tune compression:
 
@@ -212,10 +215,11 @@ cargo run -p datafusion-bio-function-vep --example load_cache --features kv-cach
   22 \
   8 \
   9 \
-  256
+  256 \
+  fjall
 ```
 
-- Args: `<parquet_path> <fjall_output_path> [chrom_filter] [partitions] [zstd_level] [dict_size_kb]`
+- Args: `<parquet_path> <cache_output_path> [chrom_filter] [partitions] [zstd_level] [dict_size_kb] [fjall|redb]`
 - Defaults for `load_cache`: `zstd_level=3`, `dict_size_kb=112`.
 
 #### Annotation Configuration

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -15,6 +15,7 @@ futures.workspace = true
 log.workspace = true
 async-trait = "0.1.88"
 fjall = { version = "3.1.1", optional = true }
+redb = { version = "4.1.0", optional = true }
 arrow-ipc = { version = "56", features = ["lz4", "zstd"], optional = true }
 lz4_flex = { version = "0.12.1", optional = true }
 zstd = { version = "0.13.3", optional = true }
@@ -82,7 +83,7 @@ required-features = []
 
 [features]
 default = ["kv-cache"]
-kv-cache = ["dep:fjall", "dep:arrow-ipc", "dep:lz4_flex", "dep:zstd", "dep:ahash"]
+kv-cache = ["dep:fjall", "dep:redb", "dep:arrow-ipc", "dep:lz4_flex", "dep:zstd", "dep:ahash"]
 cache-builder = ["kv-cache", "dep:datafusion-bio-format-ensembl-cache"]
 
 # Regression tests that bake per-transcript sequence fixtures via

--- a/datafusion/bio-function-vep/README.md
+++ b/datafusion/bio-function-vep/README.md
@@ -38,7 +38,7 @@ Full VEP-style annotation: consequence prediction, population frequencies, clini
 SELECT * FROM annotate_vep(
   'my_vcf_table',
   '/path/to/cache',
-  'parquet',                                          -- backend: parquet | fjall
+  'parquet',                                          -- backend: parquet | fjall | redb
   '{"everything":true,"extended_probes":true,
     "reference_fasta_path":"/path/to/reference.fa"}'  -- options (optional)
 )
@@ -232,6 +232,10 @@ Ensembl variation cache converted to Parquet format. Supports per-chromosome par
 
 LSM-tree backend using [fjall](https://crates.io/crates/fjall) with zstd compression. Requires the `kv-cache` feature (enabled by default).
 
+### redb (KV store)
+
+Single-file backend using [redb](https://crates.io/crates/redb) with the same position-entry and zstd metadata format as fjall. Annotation opens `variation.redb` via redb's `ReadOnlyDatabase`, allowing multiple annotator processes to read the same cache in parallel.
+
 Configuration via `AnnotationConfig` (session-level):
 
 | Option | Default | Description |
@@ -286,8 +290,8 @@ cargo run --release --example annotate_vep_golden_bench -- \
 | # | Argument | Description |
 |---|----------|-------------|
 | 1 | `source_vcf_gz` | Input VCF (bgzipped) |
-| 2 | `cache_source` | Variation cache path (parquet file or fjall directory) |
-| 3 | `backend` | `parquet` or `fjall` |
+| 2 | `cache_source` | Variation cache path (parquet file, fjall directory, or cache dir containing `variation.redb`) |
+| 3 | `backend` | `parquet`, `fjall`, or `redb` |
 | 4 | `sample_limit` | Number of variants to sample (0 = all) |
 | 5 | `vep_cache_dir` | Directory with golden VEP output / Docker VEP cache |
 | 6 | `local_copy_vcf_gz` | Local copy path for the input VCF |
@@ -328,7 +332,7 @@ cargo run --release --features kv-cache --example bench_annotate_vcf -- \
   --compression gzip
 ```
 
-**Options:** `--input`, `--cache`, `--output`, `--backend parquet|fjall`, `--everything`, `--extended-probes`, `--reference-fasta`, `--compression none|gzip|bgzf`, `--limit`
+**Options:** `--input`, `--cache`, `--output`, `--backend parquet|fjall|redb`, `--everything`, `--extended-probes`, `--reference-fasta`, `--compression none|gzip|bgzf`, `--limit`
 
 ### Other benchmarks
 
@@ -336,7 +340,7 @@ cargo run --release --features kv-cache --example bench_annotate_vcf -- \
 |---------|---------|-------------|
 | `bench_annotate` | `kv-cache` | Arrow-level annotation performance (fjall) |
 | `lookup_parquet_bench` | — | `lookup_variants()` with parquet backend |
-| `lookup_kv_bench` | `kv-cache` | `lookup_variants()` with fjall backend |
+| `lookup_kv_bench` | `kv-cache` | `lookup_variants()` with KV backend |
 | `bench_fjall_gets` | `kv-cache` | Raw fjall KV store read throughput |
 | `bench_sift_queries` | `kv-cache` | SIFT prediction query performance |
 
@@ -350,7 +354,7 @@ cargo run --release [--features kv-cache] --example <name> -- <args>
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `kv-cache` | yes | Fjall LSM-tree backend with zstd compression |
+| `kv-cache` | yes | fjall and redb KV backends with zstd compression |
 
 ## License
 

--- a/datafusion/bio-function-vep/examples/bench_annotate_vcf.rs
+++ b/datafusion/bio-function-vep/examples/bench_annotate_vcf.rs
@@ -8,7 +8,7 @@
 //!     --input <vcf_path> \
 //!     --cache <cache_dir> \
 //!     --output <output.vcf> \
-//!     [--backend parquet|fjall] \
+//!     [--backend parquet|fjall|redb] \
 //!     [--everything] \
 //!     [--extended-probes] \
 //!     [--reference-fasta <path>] \
@@ -153,6 +153,7 @@ async fn main() -> Result<()> {
         extended_probes: args.extended_probes,
         reference_fasta_path: args.reference_fasta.clone(),
         use_fjall: args.backend == "fjall",
+        use_redb: args.backend == "redb",
         compression: args.compression,
         show_progress: true,
         ..Default::default()
@@ -162,7 +163,7 @@ async fn main() -> Result<()> {
     let rows = vcf_sink::annotate_to_vcf(
         &args.input,
         &args.cache,
-        "parquet",
+        &args.backend,
         &args.output,
         &annotate_config,
     )

--- a/datafusion/bio-function-vep/examples/load_cache.rs
+++ b/datafusion/bio-function-vep/examples/load_cache.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use datafusion::prelude::{SessionConfig, SessionContext};
-use datafusion_bio_function_vep::kv_cache::{CacheLoader, VepKvStore};
+use datafusion_bio_function_vep::kv_cache::{CacheBackend, CacheLoader, VepKvStore, VepRedbStore};
 
 #[tokio::main]
 async fn main() -> datafusion::common::Result<()> {
@@ -11,7 +11,7 @@ async fn main() -> datafusion::common::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 3 {
         eprintln!(
-            "Usage: {} <parquet_path> <fjall_output_path> [chrom_filter] [partitions] [zstd_level] [dict_size_kb]",
+            "Usage: {} <parquet_path> <cache_output_path> [chrom_filter] [partitions] [zstd_level] [dict_size_kb] [fjall|redb]",
             args[0]
         );
         eprintln!(
@@ -27,6 +27,11 @@ async fn main() -> datafusion::common::Result<()> {
     let target_partitions: Option<usize> = args.get(4).and_then(|s| s.parse().ok());
     let zstd_level: i32 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(3);
     let dict_size_kb: u32 = args.get(6).and_then(|s| s.parse().ok()).unwrap_or(112);
+    let backend = args
+        .get(7)
+        .map(|value| CacheBackend::parse(value))
+        .transpose()?
+        .unwrap_or(CacheBackend::Fjall);
 
     let ctx = if let Some(partitions) = target_partitions {
         let config = SessionConfig::new().with_target_partitions(partitions);
@@ -62,22 +67,22 @@ async fn main() -> datafusion::common::Result<()> {
         .unwrap()
         .value(0);
 
-    // Clean output dir if exists
+    // Clean output if exists.
     if Path::new(output_path).exists() {
-        std::fs::remove_dir_all(output_path).ok();
+        remove_existing(output_path);
     }
 
-    // Load into fjall
+    // Load into the selected KV backend.
     let load_start = Instant::now();
     let loader = CacheLoader::new(source_table, output_path)
         .with_zstd_level(zstd_level)
-        .with_dict_size_kb(dict_size_kb);
+        .with_dict_size_kb(dict_size_kb)
+        .with_backend(backend);
     let stats = loader.load(&ctx).await?;
     let load_elapsed = load_start.elapsed().as_secs_f64();
 
     // Verify + measure disk
-    let store = VepKvStore::open(output_path)?;
-    let dir_size = walkdir(output_path);
+    let dir_size = path_size(output_path);
     let avg_variants_per_pos = if stats.total_positions > 0 {
         row_count as f64 / stats.total_positions as f64
     } else {
@@ -96,10 +101,7 @@ async fn main() -> datafusion::common::Result<()> {
     let read_start = Instant::now();
     let mut read_iters = 0u32;
     for pos in 0..20u64 {
-        if store
-            .get_position_entry_decompressed(chrom_code, pos as i64)?
-            .is_some()
-        {
+        if read_decompressed_exists(backend, output_path, chrom_code, pos as i64)? {
             read_iters += 1;
         }
     }
@@ -112,13 +114,12 @@ async fn main() -> datafusion::common::Result<()> {
     // Single lookup from mid-range
     let mid_pos = stats.total_positions / 2;
     let single_start = Instant::now();
-    let _ = store.get_position_entry_decompressed(chrom_code, mid_pos as i64)?;
+    let _ = read_decompressed_exists(backend, output_path, chrom_code, mid_pos as i64)?;
     let single_read_ms = single_start.elapsed().as_secs_f64() * 1000.0;
 
-    drop(store);
-
     println!(
-        "zstd_level={} dict_kb={} | variants={:>10} | positions={:>6} | avg/pos={:>8.0} | load={:>5.1}s | disk={:>7.1}MB | avg_pos_disk={:>6.0}KB | read={:>6.1}ms avg | single={:>6.1}ms",
+        "backend={} zstd_level={} dict_kb={} | variants={:>10} | positions={:>6} | avg/pos={:>8.0} | load={:>5.1}s | disk={:>7.1}MB | avg_pos_disk={:>6.0}KB | read={:>6.1}ms avg | single={:>6.1}ms",
+        backend.as_str(),
         zstd_level,
         dict_size_kb,
         row_count,
@@ -134,7 +135,48 @@ async fn main() -> datafusion::common::Result<()> {
     Ok(())
 }
 
-fn walkdir(path: &str) -> u64 {
+fn read_decompressed_exists(
+    backend: CacheBackend,
+    output_path: &str,
+    chrom_code: u16,
+    pos: i64,
+) -> datafusion::common::Result<bool> {
+    match backend {
+        CacheBackend::Fjall => {
+            let store = VepKvStore::open(output_path)?;
+            Ok(store
+                .get_position_entry_decompressed(chrom_code, pos)?
+                .is_some())
+        }
+        CacheBackend::Redb => {
+            let store = VepRedbStore::open(output_path)?;
+            Ok(store
+                .get_position_entry_decompressed(chrom_code, pos)?
+                .is_some())
+        }
+    }
+}
+
+fn remove_existing(path: &str) {
+    let path = Path::new(path);
+    if path.is_dir() {
+        std::fs::remove_dir_all(path).ok();
+    } else {
+        std::fs::remove_file(path).ok();
+    }
+}
+
+fn path_size(path: &str) -> u64 {
+    let path = Path::new(path);
+    if let Ok(meta) = path.metadata()
+        && meta.is_file()
+    {
+        return meta.len();
+    }
+    walkdir(path)
+}
+
+fn walkdir(path: &Path) -> u64 {
     let mut total = 0u64;
     if let Ok(entries) = std::fs::read_dir(path) {
         for entry in entries.flatten() {
@@ -143,7 +185,7 @@ fn walkdir(path: &str) -> u64 {
                 if m.is_file() {
                     total += m.len();
                 } else if m.is_dir() {
-                    total += walkdir(&entry.path().to_string_lossy());
+                    total += walkdir(&entry.path());
                 }
             }
         }

--- a/datafusion/bio-function-vep/examples/load_cache_full.rs
+++ b/datafusion/bio-function-vep/examples/load_cache_full.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::time::Instant;
 
 use datafusion::prelude::{SessionConfig, SessionContext};
-use datafusion_bio_function_vep::kv_cache::CacheLoader;
+use datafusion_bio_function_vep::kv_cache::{CacheBackend, CacheLoader};
 
 #[tokio::main]
 async fn main() -> datafusion::common::Result<()> {
@@ -11,7 +11,7 @@ async fn main() -> datafusion::common::Result<()> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 4 {
         eprintln!(
-            "Usage: {} <parquet_path> <fjall_output_path> <threads>",
+            "Usage: {} <parquet_path> <cache_output_path> <threads> [fjall|redb]",
             args[0]
         );
         std::process::exit(1);
@@ -22,6 +22,11 @@ async fn main() -> datafusion::common::Result<()> {
     let threads: usize = args[3].parse().map_err(|e| {
         datafusion::common::DataFusionError::Execution(format!("invalid threads: {e}"))
     })?;
+    let backend = args
+        .get(4)
+        .map(|value| CacheBackend::parse(value))
+        .transpose()?
+        .unwrap_or(CacheBackend::Fjall);
 
     let config = SessionConfig::new().with_target_partitions(threads);
     let ctx = SessionContext::new_with_config(config);
@@ -29,15 +34,18 @@ async fn main() -> datafusion::common::Result<()> {
         .await?;
 
     if Path::new(output_path).exists() {
-        std::fs::remove_dir_all(output_path).ok();
+        remove_existing(output_path);
     }
 
     let start = Instant::now();
-    let loader = CacheLoader::new("vep_source", output_path).with_parallelism(threads);
+    let loader = CacheLoader::new("vep_source", output_path)
+        .with_parallelism(threads)
+        .with_backend(backend);
     let stats = loader.load(&ctx).await?;
 
     println!(
-        "Loaded: variants={} positions={} bytes={} elapsed={:.1}s threads={}",
+        "Loaded: backend={} variants={} positions={} bytes={} elapsed={:.1}s threads={}",
+        backend.as_str(),
         stats.total_variants,
         stats.total_positions,
         stats.total_bytes,
@@ -46,4 +54,13 @@ async fn main() -> datafusion::common::Result<()> {
     );
 
     Ok(())
+}
+
+fn remove_existing(path: &str) {
+    let path = Path::new(path);
+    if path.is_dir() {
+        std::fs::remove_dir_all(path).ok();
+    } else {
+        std::fs::remove_file(path).ok();
+    }
 }

--- a/datafusion/bio-function-vep/examples/profile_annotation.rs
+++ b/datafusion/bio-function-vep/examples/profile_annotation.rs
@@ -167,10 +167,14 @@ async fn main() -> Result<()> {
 
     let mut options = Vec::new();
 
-    // Detect fjall stores inside a partitioned cache directory.
+    // Detect KV stores inside a partitioned cache directory.
     let has_fjall = cache_dir.join("variation.fjall").is_dir();
+    let has_redb = cache_dir.join("variation.redb").is_file();
     if has_fjall {
         eprintln!("[PREP] Detected variation.fjall — enabling use_fjall=true");
+    }
+    if has_redb {
+        eprintln!("[PREP] Detected variation.redb — enabling use_redb=true");
     }
 
     if is_partitioned {
@@ -179,6 +183,9 @@ async fn main() -> Result<()> {
         options.push("\"partitioned\":true".to_string());
         if has_fjall {
             options.push("\"use_fjall\":true".to_string());
+        }
+        if has_redb {
+            options.push("\"use_redb\":true".to_string());
         }
         eprintln!("[PREP] Partitioned mode — context tables loaded per contig internally");
     } else {

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -2744,7 +2744,7 @@ fn lookup_sift_polyphen(
     protein_position: Option<&str>,
     amino_acids: Option<&str>,
     cache: &mut SiftPolyphenCache,
-    #[cfg(feature = "kv-cache")] sift_kv: &Option<crate::kv_cache::SiftKvStore>,
+    #[cfg(feature = "kv-cache")] sift_kv: &Option<crate::kv_cache::SiftPredictionStore>,
     #[cfg(not(feature = "kv-cache"))] _sift_kv: &Option<()>,
 ) -> (String, String) {
     let empty = || (String::new(), String::new());
@@ -2771,7 +2771,7 @@ fn lookup_sift_polyphen(
         return empty();
     };
 
-    // Lazy load from fjall sift keyspace on cache miss.
+    // Lazy load from a SIFT KV store on cache miss.
     if cache.get(tx_id).is_none() {
         #[cfg(feature = "kv-cache")]
         if let Some(kv) = sift_kv {
@@ -4248,7 +4248,7 @@ impl AnnotateProvider {
         cache: &PartitionedParquetCache,
         translations_sift_table: Option<&str>,
         #[cfg(feature = "kv-cache")] kv_store: Option<Arc<dyn PositionEntryStore>>,
-        #[cfg(feature = "kv-cache")] use_fjall_sift: bool,
+        #[cfg(feature = "kv-cache")] sift_kv_store: Option<crate::kv_cache::SiftPredictionStore>,
         fetch_limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if profiling_enabled() {
@@ -4336,19 +4336,9 @@ impl AnnotateProvider {
             #[cfg(feature = "kv-cache")]
             use_kv_cache: kv_store.is_some(),
             #[cfg(feature = "kv-cache")]
-            use_fjall_sift,
+            use_kv_sift: sift_kv_store.is_some(),
             #[cfg(feature = "kv-cache")]
-            sift_kv_store: if use_fjall_sift {
-                kv_store.as_ref().and_then(|store| {
-                    let parent = store.root_path().parent()?;
-                    let sift_path = parent.join("translation_sift.fjall");
-                    crate::kv_cache::SiftKvStore::open_path(&sift_path)
-                        .ok()
-                        .flatten()
-                })
-            } else {
-                None
-            },
+            sift_kv_store,
             #[cfg(feature = "kv-cache")]
             kv_store,
         };
@@ -4379,7 +4369,7 @@ impl AnnotateProvider {
         ctx: &PreparedContext<'_>,
         colocated_map: &HashMap<ColocatedKey, ColocatedData>,
         sift_cache: &mut SiftPolyphenCache,
-        #[cfg(feature = "kv-cache")] sift_kv: &Option<crate::kv_cache::SiftKvStore>,
+        #[cfg(feature = "kv-cache")] sift_kv: &Option<crate::kv_cache::SiftPredictionStore>,
         #[cfg(not(feature = "kv-cache"))] _sift_kv: &Option<()>,
         skip_csq: bool,
         skip_typed_cols: bool,
@@ -7452,15 +7442,15 @@ struct ContigAnnotationConfig {
     /// When true, use a KV store for variation lookup instead of parquet.
     #[cfg(feature = "kv-cache")]
     use_kv_cache: bool,
-    /// When true, use the fjall SIFT store in addition to KV variation lookup.
+    /// When true, use a SIFT KV store in addition to KV variation lookup.
     #[cfg(feature = "kv-cache")]
-    use_fjall_sift: bool,
+    use_kv_sift: bool,
     /// Shared KV variation store handle (opened once, reused across contigs).
     #[cfg(feature = "kv-cache")]
     kv_store: Option<Arc<dyn PositionEntryStore>>,
     /// Shared SIFT store (opened once, reused across contigs).
     #[cfg(feature = "kv-cache")]
-    sift_kv_store: Option<crate::kv_cache::SiftKvStore>,
+    sift_kv_store: Option<crate::kv_cache::SiftPredictionStore>,
 }
 
 /// Leaf `ExecutionPlan` that processes contigs one at a time via a state-machine
@@ -7632,9 +7622,9 @@ struct ContigAnnotationState {
     sift_cache: SiftPolyphenCache,
     sift_direct: Option<SiftDirectReader>,
     loaded_sift_windows: HashSet<(String, i64)>,
-    /// Fjall-backed SIFT store for lazy per-transcript lookups (used when use_fjall=true).
+    /// SIFT KV store for lazy per-transcript lookups.
     #[cfg(feature = "kv-cache")]
-    sift_kv: Option<crate::kv_cache::SiftKvStore>,
+    sift_kv: Option<crate::kv_cache::SiftPredictionStore>,
     // Annotation engine + provider.
     tmp_provider: AnnotateProvider,
     engine: TranscriptConsequenceEngine,
@@ -8490,16 +8480,15 @@ impl Stream for ContigAnnotationStream {
                                 .build_from_path(path)
                                 .ok()
                         });
-                        // SIFT source: when enabled, use SiftKvStore from fjall
-                        // for lazy per-transcript lookups; otherwise use parquet
-                        // SiftDirectReader.
+                        // SIFT source: when enabled, use a KV store for lazy
+                        // per-transcript lookups; otherwise use parquet SiftDirectReader.
                         #[cfg(feature = "kv-cache")]
-                        let use_fjall_sift = config.use_fjall_sift;
+                        let use_kv_sift = config.use_kv_sift;
                         #[cfg(not(feature = "kv-cache"))]
-                        let use_fjall_sift = false;
+                        let use_kv_sift = false;
 
                         let sift_direct: Option<SiftDirectReader> = if config.flags.everything
-                            && !use_fjall_sift
+                            && !use_kv_sift
                         {
                             config
                                 .translations_sift_table
@@ -8523,11 +8512,10 @@ impl Stream for ContigAnnotationStream {
                             None
                         };
 
-                        // Reuse the pre-opened SiftKvStore from config (opened
-                        // once, shared across contigs) rather than re-opening
-                        // the fjall DB every contig.
+                        // Reuse the pre-opened SIFT KV store from config rather
+                        // than re-opening it every contig.
                         #[cfg(feature = "kv-cache")]
-                        let sift_kv = if use_fjall_sift && config.flags.everything {
+                        let sift_kv = if use_kv_sift && config.flags.everything {
                             config.sift_kv_store.clone()
                         } else {
                             None
@@ -9126,7 +9114,25 @@ impl TableProvider for AnnotateProvider {
                 _ => None,
             };
             #[cfg(feature = "kv-cache")]
-            let use_fjall_sift = matches!(kv_backend, Some(AnnotationBackend::Fjall));
+            let sift_kv_store: Option<crate::kv_cache::SiftPredictionStore> = match kv_backend {
+                Some(AnnotationBackend::Fjall) => {
+                    let sift_path =
+                        std::path::Path::new(&self.cache_source).join("translation_sift.fjall");
+                    crate::kv_cache::SiftKvStore::open_path(&sift_path)
+                        .ok()
+                        .flatten()
+                        .map(crate::kv_cache::SiftPredictionStore::Fjall)
+                }
+                Some(AnnotationBackend::Redb) => {
+                    let sift_path =
+                        std::path::Path::new(&self.cache_source).join("translation_sift.redb");
+                    crate::kv_cache::SiftRedbStore::open_path(&sift_path)
+                        .ok()
+                        .flatten()
+                        .map(crate::kv_cache::SiftPredictionStore::Redb)
+                }
+                _ => None,
+            };
 
             let (available_cache_columns, sample_table_to_deregister) = if use_kv_cache {
                 #[cfg(feature = "kv-cache")]
@@ -9209,7 +9215,7 @@ impl TableProvider for AnnotateProvider {
                     #[cfg(feature = "kv-cache")]
                     kv_store_arc,
                     #[cfg(feature = "kv-cache")]
-                    use_fjall_sift,
+                    sift_kv_store,
                     limit,
                 )
                 .await;
@@ -9909,6 +9915,43 @@ mod tests {
         );
         assert!(sift.is_empty());
         assert!(polyphen.is_empty());
+    }
+
+    #[test]
+    fn test_lookup_sift_polyphen_loads_from_redb_sift_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let redb_path = dir.path().join("translation_sift.redb");
+        let entries = make_sift_cache(vec![(
+            "ENST00000001",
+            42,
+            "I",
+            "deleterious",
+            0.01,
+            "probably damaging",
+            0.999,
+        )]);
+        let preds = entries.get("ENST00000001").unwrap().clone();
+        crate::kv_cache::SiftRedbStore::ingest_sorted(
+            &redb_path,
+            vec![("ENST00000001".to_string(), preds)].into_iter(),
+        )
+        .unwrap();
+        let redb = crate::kv_cache::SiftRedbStore::open_path(&redb_path)
+            .unwrap()
+            .unwrap();
+        let sift_store = crate::kv_cache::SiftPredictionStore::Redb(redb);
+
+        let mut cache = SiftPolyphenCache::new();
+        let (sift, polyphen) = lookup_sift_polyphen(
+            Some("ENST00000001"),
+            Some("42"),
+            Some("V/I"),
+            &mut cache,
+            &Some(sift_store),
+        );
+
+        assert_eq!(sift, "deleterious(0.01)");
+        assert_eq!(polyphen, "probably_damaging(0.999)");
     }
 
     // ── lookup_domains ─────────────────────────────────────────────────

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9122,6 +9122,14 @@ impl TableProvider for AnnotateProvider {
             // When using a KV backend, get schema from the KV store; otherwise
             // from a sample variation parquet file.
             #[cfg(feature = "kv-cache")]
+            let kv_cache_size_bytes = self
+                .options_json
+                .as_deref()
+                .and_then(|opts| Self::parse_json_i64_option(opts, "cache_size_mb"))
+                .filter(|mb| *mb > 0)
+                .map(|mb| mb as u64 * 1024 * 1024)
+                .unwrap_or(1024 * 1024 * 1024);
+            #[cfg(feature = "kv-cache")]
             let kv_store_arc: Option<Arc<dyn PositionEntryStore>> = match kv_backend {
                 Some(AnnotationBackend::Fjall) => {
                     let fjall_path =
@@ -9132,7 +9140,10 @@ impl TableProvider for AnnotateProvider {
                             fjall_path.display()
                         )));
                     }
-                    Some(Arc::new(crate::kv_cache::VepKvStore::open(&fjall_path)?))
+                    Some(Arc::new(crate::kv_cache::VepKvStore::open_with_cache_size(
+                        &fjall_path,
+                        kv_cache_size_bytes,
+                    )?))
                 }
                 Some(AnnotationBackend::Redb) => {
                     let redb_path = std::path::Path::new(&self.cache_source).join("variation.redb");
@@ -9142,7 +9153,12 @@ impl TableProvider for AnnotateProvider {
                             redb_path.display()
                         )));
                     }
-                    Some(Arc::new(crate::kv_cache::VepRedbStore::open(&redb_path)?))
+                    Some(Arc::new(
+                        crate::kv_cache::VepRedbStore::open_with_cache_size(
+                            &redb_path,
+                            kv_cache_size_bytes as usize,
+                        )?,
+                    ))
                 }
                 _ => None,
             };

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -15,6 +15,8 @@ use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::io::{BufRead, Seek};
+#[cfg(feature = "kv-cache")]
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context as TaskCtx, Poll};
@@ -2795,6 +2797,37 @@ fn lookup_sift_polyphen(
         .unwrap_or_default();
 
     (sift, polyphen)
+}
+
+#[cfg(feature = "kv-cache")]
+fn open_sift_prediction_store_for_backend(
+    cache_source: &Path,
+    backend: AnnotationBackend,
+) -> Result<Option<crate::kv_cache::SiftPredictionStore>> {
+    match backend {
+        AnnotationBackend::Fjall => {
+            let sift_path = cache_source.join("translation_sift.fjall");
+            let store = crate::kv_cache::SiftKvStore::open_path(&sift_path)?.ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "annotate_vep(): backend=fjall but no fjall SIFT store found at '{}'",
+                    sift_path.display()
+                ))
+            })?;
+            Ok(Some(crate::kv_cache::SiftPredictionStore::Fjall(store)))
+        }
+        AnnotationBackend::Redb => {
+            let sift_path = cache_source.join("translation_sift.redb");
+            let store =
+                crate::kv_cache::SiftRedbStore::open_path(&sift_path)?.ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "annotate_vep(): backend=redb but no redb SIFT store found at '{}'",
+                        sift_path.display()
+                    ))
+                })?;
+            Ok(Some(crate::kv_cache::SiftPredictionStore::Redb(store)))
+        }
+        AnnotationBackend::Parquet => Ok(None),
+    }
 }
 
 /// Format a SIFT/PolyPhen prediction as `prediction(score)` with spaces→underscores.
@@ -9071,7 +9104,7 @@ impl TableProvider for AnnotateProvider {
                         {
                             match kv_backend {
                                 Some(AnnotationBackend::Fjall) => " [fjall variation+sift]",
-                                Some(AnnotationBackend::Redb) => " [redb variation]",
+                                Some(AnnotationBackend::Redb) => " [redb variation+sift]",
                                 _ => "",
                             }
                         }
@@ -9115,23 +9148,10 @@ impl TableProvider for AnnotateProvider {
             };
             #[cfg(feature = "kv-cache")]
             let sift_kv_store: Option<crate::kv_cache::SiftPredictionStore> = match kv_backend {
-                Some(AnnotationBackend::Fjall) => {
-                    let sift_path =
-                        std::path::Path::new(&self.cache_source).join("translation_sift.fjall");
-                    crate::kv_cache::SiftKvStore::open_path(&sift_path)
-                        .ok()
-                        .flatten()
-                        .map(crate::kv_cache::SiftPredictionStore::Fjall)
+                Some(backend) => {
+                    open_sift_prediction_store_for_backend(Path::new(&self.cache_source), backend)?
                 }
-                Some(AnnotationBackend::Redb) => {
-                    let sift_path =
-                        std::path::Path::new(&self.cache_source).join("translation_sift.redb");
-                    crate::kv_cache::SiftRedbStore::open_path(&sift_path)
-                        .ok()
-                        .flatten()
-                        .map(crate::kv_cache::SiftPredictionStore::Redb)
-                }
-                _ => None,
+                None => None,
             };
 
             let (available_cache_columns, sample_table_to_deregister) = if use_kv_cache {
@@ -9952,6 +9972,32 @@ mod tests {
 
         assert_eq!(sift, "deleterious(0.01)");
         assert_eq!(polyphen, "probably_damaging(0.999)");
+    }
+
+    #[test]
+    fn test_fjall_backend_requires_sift_kv_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = match open_sift_prediction_store_for_backend(dir.path(), AnnotationBackend::Fjall)
+        {
+            Ok(_) => panic!("expected missing fjall SIFT store to error"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("backend=fjall"), "{msg}");
+        assert!(msg.contains("translation_sift.fjall"), "{msg}");
+    }
+
+    #[test]
+    fn test_redb_backend_requires_sift_kv_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = match open_sift_prediction_store_for_backend(dir.path(), AnnotationBackend::Redb)
+        {
+            Ok(_) => panic!("expected missing redb SIFT store to error"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("backend=redb"), "{msg}");
+        assert!(msg.contains("translation_sift.redb"), "{msg}");
     }
 
     // ── lookup_domains ─────────────────────────────────────────────────

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -85,7 +85,9 @@ use crate::allele::{
 use crate::annotation_store::{AnnotationBackend, build_store};
 use crate::config;
 #[cfg(feature = "kv-cache")]
-use crate::kv_cache::KvCacheTableProvider;
+use crate::kv_cache::PositionCacheTableProvider;
+#[cfg(feature = "kv-cache")]
+use crate::kv_cache::cache_exec::PositionEntryStore;
 use crate::lookup_provider::LookupProvider;
 use crate::miss_worklist::{MissWorklist, collect_miss_worklist};
 use crate::partitioned_cache::PartitionedParquetCache;
@@ -4245,7 +4247,8 @@ impl AnnotateProvider {
         extended_probes: bool,
         cache: &PartitionedParquetCache,
         translations_sift_table: Option<&str>,
-        #[cfg(feature = "kv-cache")] kv_store: Option<Arc<crate::kv_cache::VepKvStore>>,
+        #[cfg(feature = "kv-cache")] kv_store: Option<Arc<dyn PositionEntryStore>>,
+        #[cfg(feature = "kv-cache")] use_fjall_sift: bool,
         fetch_limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         if profiling_enabled() {
@@ -4331,15 +4334,21 @@ impl AnnotateProvider {
             annotation_column_count: self.annotation_column_count(),
             fetch_limit,
             #[cfg(feature = "kv-cache")]
-            use_fjall: kv_store.is_some(),
+            use_kv_cache: kv_store.is_some(),
             #[cfg(feature = "kv-cache")]
-            sift_kv_store: kv_store.as_ref().and_then(|store| {
-                let parent = store.root_path().parent()?;
-                let sift_path = parent.join("translation_sift.fjall");
-                crate::kv_cache::SiftKvStore::open_path(&sift_path)
-                    .ok()
-                    .flatten()
-            }),
+            use_fjall_sift,
+            #[cfg(feature = "kv-cache")]
+            sift_kv_store: if use_fjall_sift {
+                kv_store.as_ref().and_then(|store| {
+                    let parent = store.root_path().parent()?;
+                    let sift_path = parent.join("translation_sift.fjall");
+                    crate::kv_cache::SiftKvStore::open_path(&sift_path)
+                        .ok()
+                        .flatten()
+                })
+            } else {
+                None
+            },
             #[cfg(feature = "kv-cache")]
             kv_store,
         };
@@ -7440,13 +7449,16 @@ struct ContigAnnotationConfig {
     /// Maximum number of output rows (LIMIT pushdown).
     fetch_limit: Option<usize>,
     pick_flags: PickFlags,
-    /// When true, use fjall KV store for variation lookup + SIFT instead of parquet.
+    /// When true, use a KV store for variation lookup instead of parquet.
     #[cfg(feature = "kv-cache")]
-    use_fjall: bool,
-    /// Shared fjall KV store handle (opened once, reused across contigs).
+    use_kv_cache: bool,
+    /// When true, use the fjall SIFT store in addition to KV variation lookup.
     #[cfg(feature = "kv-cache")]
-    kv_store: Option<Arc<crate::kv_cache::VepKvStore>>,
-    /// Shared fjall SIFT store (opened once, reused across contigs).
+    use_fjall_sift: bool,
+    /// Shared KV variation store handle (opened once, reused across contigs).
+    #[cfg(feature = "kv-cache")]
+    kv_store: Option<Arc<dyn PositionEntryStore>>,
+    /// Shared SIFT store (opened once, reused across contigs).
     #[cfg(feature = "kv-cache")]
     sift_kv_store: Option<crate::kv_cache::SiftKvStore>,
 }
@@ -7716,7 +7728,7 @@ impl ContigAnnotationStream {
         match &mut self.state {
             StreamState::AnnotatingContig(ann) => {
                 deregister_tables_sync(&ann.session, &ann.ephemeral_tables);
-                if ann.config.use_fjall {
+                if ann.config.use_kv_cache {
                     let _ = ann.session.deregister_table("__vep_kv_variation");
                 }
                 ann.ephemeral_tables.clear();
@@ -7726,13 +7738,13 @@ impl ContigAnnotationStream {
                 ..
             } => {
                 deregister_tables_sync(&ann.session, &ann.ephemeral_tables);
-                if ann.config.use_fjall {
+                if ann.config.use_kv_cache {
                     let _ = ann.session.deregister_table("__vep_kv_variation");
                 }
                 ann.ephemeral_tables.clear();
             }
             StreamState::CleaningUp(_) | StreamState::ErrorCleaningUp(_, _) => {
-                if self.config.use_fjall {
+                if self.config.use_kv_cache {
                     let _ = self.session.deregister_table("__vep_kv_variation");
                 }
             }
@@ -7740,7 +7752,7 @@ impl ContigAnnotationStream {
             | StreamState::PreparingContig(_)
             | StreamState::FinalCleanup(_)
             | StreamState::Done => {
-                if self.config.use_fjall {
+                if self.config.use_kv_cache {
                     let _ = self.session.deregister_table("__vep_kv_variation");
                 }
             }
@@ -8396,10 +8408,10 @@ impl Stream for ContigAnnotationStream {
                     }
                     let Some(chrom) = self.contigs.pop_front() else {
                         // All contigs processed. Deregister the global KV
-                        // variation table if fjall was used, via async cleanup
+                        // variation table if a KV backend was used, via async cleanup
                         // future (safe on any Tokio runtime flavor).
                         #[cfg(feature = "kv-cache")]
-                        if self.config.use_fjall {
+                        if self.config.use_kv_cache {
                             let session = Arc::clone(&self.session);
                             let fut: CleanupFuture = Box::pin(async move {
                                 crate::partitioned_cache::deregister_table(
@@ -8478,11 +8490,11 @@ impl Stream for ContigAnnotationStream {
                                 .build_from_path(path)
                                 .ok()
                         });
-                        // SIFT source: when use_fjall, use SiftKvStore from fjall
+                        // SIFT source: when enabled, use SiftKvStore from fjall
                         // for lazy per-transcript lookups; otherwise use parquet
                         // SiftDirectReader.
                         #[cfg(feature = "kv-cache")]
-                        let use_fjall_sift = config.use_fjall;
+                        let use_fjall_sift = config.use_fjall_sift;
                         #[cfg(not(feature = "kv-cache"))]
                         let use_fjall_sift = false;
 
@@ -8815,11 +8827,11 @@ async fn prepare_contig_context(
 
     // Variation table: either per-chrom parquet or global fjall KV store.
     #[cfg(feature = "kv-cache")]
-    let use_fjall = config.use_fjall;
+    let use_kv_cache = config.use_kv_cache;
     #[cfg(not(feature = "kv-cache"))]
-    let use_fjall = false;
+    let use_kv_cache = false;
 
-    let var_table = if use_fjall {
+    let var_table = if use_kv_cache {
         #[cfg(feature = "kv-cache")]
         {
             // Register the shared fjall KV store as a table (idempotent).
@@ -8828,8 +8840,8 @@ async fn prepare_contig_context(
                 let store = config
                     .kv_store
                     .as_ref()
-                    .expect("kv_store must be set when use_fjall=true");
-                let kv_provider = KvCacheTableProvider::from_store(Arc::clone(store));
+                    .expect("kv_store must be set when a KV backend is enabled");
+                let kv_provider = PositionCacheTableProvider::from_store(Arc::clone(store));
                 session.register_table(&kv_table_name, Arc::new(kv_provider))?;
             }
             // Don't add to ephemeral_tables — the global KV table persists
@@ -8838,7 +8850,7 @@ async fn prepare_contig_context(
         }
         #[cfg(not(feature = "kv-cache"))]
         {
-            unreachable!("use_fjall requires kv-cache feature")
+            unreachable!("KV backend requires kv-cache feature")
         }
     } else {
         let var_table =
@@ -9015,20 +9027,41 @@ impl TableProvider for AnnotateProvider {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let _store = build_store(self.backend, self.cache_source.clone());
 
-        // Parse use_fjall option — when true, use fjall KV store for variation
-        // lookup + SIFT while keeping context from partitioned parquet.
+        // Select optional KV variation backend while keeping context from
+        // partitioned parquet. The backend argument is authoritative; legacy
+        // `use_fjall`/`use_redb` options remain accepted for parquet calls.
         #[cfg(feature = "kv-cache")]
-        let use_fjall = self
-            .options_json
-            .as_deref()
-            .and_then(|opts| Self::parse_json_bool_option(opts, "use_fjall"))
-            .unwrap_or(false);
+        let kv_backend = match self.backend {
+            AnnotationBackend::Fjall => Some(AnnotationBackend::Fjall),
+            AnnotationBackend::Redb => Some(AnnotationBackend::Redb),
+            AnnotationBackend::Parquet => {
+                let use_fjall = self
+                    .options_json
+                    .as_deref()
+                    .and_then(|opts| Self::parse_json_bool_option(opts, "use_fjall"))
+                    .unwrap_or(false);
+                let use_redb = self
+                    .options_json
+                    .as_deref()
+                    .and_then(|opts| Self::parse_json_bool_option(opts, "use_redb"))
+                    .unwrap_or(false);
+                if use_redb {
+                    Some(AnnotationBackend::Redb)
+                } else if use_fjall {
+                    Some(AnnotationBackend::Fjall)
+                } else {
+                    None
+                }
+            }
+        };
+        #[cfg(feature = "kv-cache")]
+        let use_kv_cache = kv_backend.is_some();
         #[cfg(not(feature = "kv-cache"))]
-        let use_fjall = false;
+        let use_kv_cache = false;
 
         // Check for partitioned per-chromosome cache layout.
         // Opt-in/out via "partitioned": true/false in options_json.
-        // Both parquet-only and fjall paths require partitioned context parquet.
+        // All paths require partitioned context parquet.
         let partitioned_opt = self
             .options_json
             .as_deref()
@@ -9045,8 +9078,19 @@ impl TableProvider for AnnotateProvider {
                     "[VEP_PROFILE] detected partitioned cache: {} chroms in {}{}",
                     cache.available_chroms().len(),
                     self.cache_source,
-                    if use_fjall {
-                        " [fjall variation+sift]"
+                    if use_kv_cache {
+                        #[cfg(feature = "kv-cache")]
+                        {
+                            match kv_backend {
+                                Some(AnnotationBackend::Fjall) => " [fjall variation+sift]",
+                                Some(AnnotationBackend::Redb) => " [redb variation]",
+                                _ => "",
+                            }
+                        }
+                        #[cfg(not(feature = "kv-cache"))]
+                        {
+                            ""
+                        }
                     } else {
                         ""
                     },
@@ -9054,37 +9098,48 @@ impl TableProvider for AnnotateProvider {
             }
 
             // Determine requested cache columns.
-            // When using fjall, get schema from the KV store; otherwise from
-            // a sample variation parquet file.
+            // When using a KV backend, get schema from the KV store; otherwise
+            // from a sample variation parquet file.
             #[cfg(feature = "kv-cache")]
-            let kv_store_arc: Option<Arc<crate::kv_cache::VepKvStore>> = if use_fjall {
-                let fjall_path = std::path::Path::new(&self.cache_source).join("variation.fjall");
-                if !fjall_path.exists() {
-                    return Err(DataFusionError::Execution(format!(
-                        "annotate_vep(): use_fjall=true but no fjall store found at '{}'",
-                        fjall_path.display()
-                    )));
+            let kv_store_arc: Option<Arc<dyn PositionEntryStore>> = match kv_backend {
+                Some(AnnotationBackend::Fjall) => {
+                    let fjall_path =
+                        std::path::Path::new(&self.cache_source).join("variation.fjall");
+                    if !fjall_path.exists() {
+                        return Err(DataFusionError::Execution(format!(
+                            "annotate_vep(): backend=fjall but no fjall store found at '{}'",
+                            fjall_path.display()
+                        )));
+                    }
+                    Some(Arc::new(crate::kv_cache::VepKvStore::open(&fjall_path)?))
                 }
-                Some(Arc::new(crate::kv_cache::VepKvStore::open(&fjall_path)?))
-            } else {
-                None
+                Some(AnnotationBackend::Redb) => {
+                    let redb_path = std::path::Path::new(&self.cache_source).join("variation.redb");
+                    if !redb_path.exists() {
+                        return Err(DataFusionError::Execution(format!(
+                            "annotate_vep(): backend=redb but no redb store found at '{}'",
+                            redb_path.display()
+                        )));
+                    }
+                    Some(Arc::new(crate::kv_cache::VepRedbStore::open(&redb_path)?))
+                }
+                _ => None,
             };
+            #[cfg(feature = "kv-cache")]
+            let use_fjall_sift = matches!(kv_backend, Some(AnnotationBackend::Fjall));
 
-            let (available_cache_columns, sample_table_to_deregister) = if use_fjall {
+            let (available_cache_columns, sample_table_to_deregister) = if use_kv_cache {
                 #[cfg(feature = "kv-cache")]
                 {
                     let store = kv_store_arc.as_ref().unwrap();
-                    let cols: HashSet<String> = store
-                        .schema()
-                        .fields()
-                        .iter()
-                        .map(|f| f.name().clone())
-                        .collect();
+                    let schema = store.schema();
+                    let cols: HashSet<String> =
+                        schema.fields().iter().map(|f| f.name().clone()).collect();
                     (cols, None)
                 }
                 #[cfg(not(feature = "kv-cache"))]
                 {
-                    unreachable!("use_fjall requires kv-cache feature")
+                    unreachable!("KV backend requires kv-cache feature")
                 }
             } else {
                 let sample_chrom = &cache.available_chroms()[0];
@@ -9153,6 +9208,8 @@ impl TableProvider for AnnotateProvider {
                     translations_sift_table.as_deref(),
                     #[cfg(feature = "kv-cache")]
                     kv_store_arc,
+                    #[cfg(feature = "kv-cache")]
+                    use_fjall_sift,
                     limit,
                 )
                 .await;

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -2746,7 +2746,7 @@ fn lookup_sift_polyphen(
     protein_position: Option<&str>,
     amino_acids: Option<&str>,
     cache: &mut SiftPolyphenCache,
-    #[cfg(feature = "kv-cache")] sift_kv: &Option<crate::kv_cache::SiftPredictionStore>,
+    #[cfg(feature = "kv-cache")] sift_kv: &Option<crate::kv_cache::SiftPredictionLookupSession<'_>>,
     #[cfg(not(feature = "kv-cache"))] _sift_kv: &Option<()>,
 ) -> (String, String) {
     let empty = || (String::new(), String::new());
@@ -4629,6 +4629,11 @@ impl AnnotateProvider {
             transcript_selection,
             include_pick_output,
         );
+        #[cfg(feature = "kv-cache")]
+        let sift_kv_session = match sift_kv {
+            Some(store) => Some(store.begin_lookup_session()?),
+            None => None,
+        };
 
         for row in 0..batch.num_rows() {
             let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
@@ -5063,7 +5068,7 @@ impl AnnotateProvider {
                                 tc.amino_acids.as_deref(),
                                 sift_cache,
                                 #[cfg(feature = "kv-cache")]
-                                sift_kv,
+                                &sift_kv_session,
                                 #[cfg(not(feature = "kv-cache"))]
                                 _sift_kv,
                             );
@@ -5483,7 +5488,7 @@ impl AnnotateProvider {
                                 tc.amino_acids.as_deref(),
                                 sift_cache,
                                 #[cfg(feature = "kv-cache")]
-                                sift_kv,
+                                &sift_kv_session,
                                 #[cfg(not(feature = "kv-cache"))]
                                 _sift_kv,
                             );
@@ -9976,6 +9981,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let sift_store = crate::kv_cache::SiftPredictionStore::Redb(redb);
+        let sift_session = sift_store.begin_lookup_session().unwrap();
 
         let mut cache = SiftPolyphenCache::new();
         let (sift, polyphen) = lookup_sift_polyphen(
@@ -9983,7 +9989,7 @@ mod tests {
             Some("42"),
             Some("V/I"),
             &mut cache,
-            &Some(sift_store),
+            &Some(sift_session),
         );
 
         assert_eq!(sift, "deleterious(0.01)");

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -175,8 +175,10 @@ fn resolve_table_sync(
 mod tests {
     use crate::create_vep_session;
     #[cfg(feature = "kv-cache")]
-    use crate::kv_cache::{VepKvStore, position_entry::serialize_position_entry};
+    use crate::kv_cache::{SiftKvStore, VepKvStore, position_entry::serialize_position_entry};
     use crate::so_terms::SoTerm;
+    #[cfg(feature = "kv-cache")]
+    use crate::transcript_consequence::{CachedPredictions, CompactPrediction};
     use datafusion::arrow::array::{
         Array, Float64Array, Int64Array, ListArray, RecordBatch, StringArray,
     };
@@ -304,6 +306,31 @@ mod tests {
         }
 
         store.persist().expect("persist fjall cache");
+    }
+
+    #[cfg(feature = "kv-cache")]
+    fn write_dummy_sift_fjall(tmpdir: &TempDir) {
+        let fjall_dir = tmpdir.path().join("translation_sift.fjall");
+        let db = fjall::Database::builder(&fjall_dir)
+            .cache_size(64 * 1024 * 1024)
+            .worker_threads(1)
+            .open()
+            .expect("open sift fjall database");
+        let store = SiftKvStore::create(&db).expect("create sift fjall cache");
+        let preds = CachedPredictions {
+            sift: vec![CompactPrediction {
+                position: 1,
+                amino_acid: CompactPrediction::encode_amino_acid("A").unwrap(),
+                prediction: CompactPrediction::encode_prediction("tolerated"),
+                score: 0.05,
+            }],
+            polyphen: Vec::new(),
+        };
+        store
+            .put("ENST00000000000", &preds)
+            .expect("write sift fjall prediction");
+        db.persist(fjall::PersistMode::SyncAll)
+            .expect("persist sift fjall cache");
     }
 
     fn vcf_table() -> MemTable {
@@ -3912,6 +3939,7 @@ mod tests {
         let cache_batch = multi_row_cache_batch();
         write_batch_to_cache(&tmpdir, "variation", &cache_batch);
         write_batch_to_fjall(&tmpdir, &cache_batch);
+        write_dummy_sift_fjall(&tmpdir);
 
         let ctx = create_vep_session();
         ctx.register_table("vcf_data", Arc::new(multi_row_vcf_table()))

--- a/datafusion/bio-function-vep/src/annotation_store.rs
+++ b/datafusion/bio-function-vep/src/annotation_store.rs
@@ -10,6 +10,7 @@ use datafusion::common::{DataFusionError, Result};
 pub enum AnnotationBackend {
     Parquet,
     Fjall,
+    Redb,
 }
 
 impl AnnotationBackend {
@@ -18,8 +19,9 @@ impl AnnotationBackend {
         match value {
             "parquet" => Ok(Self::Parquet),
             "fjall" => Ok(Self::Fjall),
+            "redb" => Ok(Self::Redb),
             other => Err(DataFusionError::Plan(format!(
-                "annotate_vep() backend must be one of: parquet, fjall; got: {other}"
+                "annotate_vep() backend must be one of: parquet, fjall, redb; got: {other}"
             ))),
         }
     }
@@ -29,6 +31,7 @@ impl AnnotationBackend {
         match self {
             Self::Parquet => "parquet",
             Self::Fjall => "fjall",
+            Self::Redb => "redb",
         }
     }
 }
@@ -87,11 +90,34 @@ impl AnnotationStore for FjallAnnotationStore {
     }
 }
 
+/// redb-backed annotation store descriptor.
+#[derive(Debug, Clone)]
+pub struct RedbAnnotationStore {
+    source: String,
+}
+
+impl RedbAnnotationStore {
+    pub fn new(source: String) -> Self {
+        Self { source }
+    }
+}
+
+impl AnnotationStore for RedbAnnotationStore {
+    fn backend(&self) -> AnnotationBackend {
+        AnnotationBackend::Redb
+    }
+
+    fn source(&self) -> &str {
+        &self.source
+    }
+}
+
 /// Build a store descriptor for the selected backend.
 pub fn build_store(backend: AnnotationBackend, source: String) -> Box<dyn AnnotationStore> {
     match backend {
         AnnotationBackend::Parquet => Box::new(ParquetAnnotationStore::new(source)),
         AnnotationBackend::Fjall => Box::new(FjallAnnotationStore::new(source)),
+        AnnotationBackend::Redb => Box::new(RedbAnnotationStore::new(source)),
     }
 }
 
@@ -108,6 +134,10 @@ mod tests {
         assert_eq!(
             AnnotationBackend::parse("fjall").unwrap(),
             AnnotationBackend::Fjall
+        );
+        assert_eq!(
+            AnnotationBackend::parse("redb").unwrap(),
+            AnnotationBackend::Redb
         );
     }
 

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -128,6 +128,7 @@ pub struct CacheBuilder {
     partitions: usize,
     build_fjall: bool,
     overwrite: bool,
+    compact_redb_after_load: bool,
     zstd_level: i32,
     dict_size_kb: u32,
     on_progress: Option<Arc<OnProgress>>,
@@ -141,6 +142,7 @@ impl CacheBuilder {
             partitions: 8,
             build_fjall: true,
             overwrite: false,
+            compact_redb_after_load: false,
             zstd_level: 3,
             dict_size_kb: 112,
             on_progress: None,
@@ -159,6 +161,11 @@ impl CacheBuilder {
 
     pub fn with_overwrite(mut self, overwrite: bool) -> Self {
         self.overwrite = overwrite;
+        self
+    }
+
+    pub fn with_compact_redb_after_load(mut self, enabled: bool) -> Self {
+        self.compact_redb_after_load = enabled;
         self
     }
 
@@ -992,6 +999,15 @@ impl CacheBuilder {
         let parquet_dir = format!("{}/variation", self.output_dir);
         let redb_path = format!("{}/variation.redb", self.output_dir);
 
+        if Path::new(&redb_path).exists() && !self.overwrite {
+            info!("variation.redb already exists, skipping (use overwrite to rebuild)");
+            return Ok(vec![EntityStats {
+                entity: "variation".to_string(),
+                parquet_files: vec![],
+                fjall_stats: None,
+            }]);
+        }
+
         let mut parquet_files: Vec<(u16, String)> = Vec::new();
         for entry in std::fs::read_dir(&parquet_dir).map_err(|e| {
             DataFusionError::Execution(format!("Failed to read dir {parquet_dir}: {e}"))
@@ -1255,13 +1271,17 @@ impl CacheBuilder {
             );
         }
 
-        info!("Running redb compaction on variation.redb...");
-        let compact_start = Instant::now();
-        store.optimize_after_load()?;
-        info!(
-            "redb compaction completed in {:.1}s",
-            compact_start.elapsed().as_secs_f64()
-        );
+        if self.compact_redb_after_load {
+            info!("Running redb compaction on variation.redb...");
+            let compact_start = Instant::now();
+            store.optimize_after_load()?;
+            info!(
+                "redb compaction completed in {:.1}s",
+                compact_start.elapsed().as_secs_f64()
+            );
+        } else {
+            info!("Skipping redb compaction on variation.redb");
+        }
 
         store.persist()?;
         drop(store);
@@ -3880,6 +3900,18 @@ mod tests {
         assert!(builder.overwrite);
     }
 
+    #[test]
+    fn test_builder_redb_compaction_default_false() {
+        let builder = CacheBuilder::new("/cache", "/output");
+        assert!(!builder.compact_redb_after_load);
+    }
+
+    #[test]
+    fn test_builder_with_redb_compaction() {
+        let builder = CacheBuilder::new("/cache", "/output").with_compact_redb_after_load(true);
+        assert!(builder.compact_redb_after_load);
+    }
+
     // -----------------------------------------------------------------------
     // skip logic integration
     // -----------------------------------------------------------------------
@@ -3995,6 +4027,67 @@ mod tests {
 
         let redb_path = dir.path().join("variation.redb");
         assert!(redb_path.is_file());
+
+        let store = crate::kv_cache::VepRedbStore::open(&redb_path).unwrap();
+        let chrom_code = crate::kv_cache::key_encoding::chrom_to_code("1");
+        let raw = store
+            .get_position_entry_decompressed(chrom_code, 100)
+            .unwrap()
+            .unwrap();
+        let reader = crate::kv_cache::position_entry::PositionEntryReader::new(&raw).unwrap();
+        assert_eq!(reader.num_alleles(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_variation_redb_skips_existing_without_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().to_str().unwrap();
+        let redb_path = dir.path().join("variation.redb");
+        std::fs::write(&redb_path, b"existing redb placeholder").unwrap();
+
+        let builder = CacheBuilder::new("/nonexistent_cache", output);
+        let stats = builder.build_variation_redb_from_parquet().await.unwrap();
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].entity, "variation");
+        assert!(stats[0].parquet_files.is_empty());
+        assert!(stats[0].fjall_stats.is_none());
+        assert_eq!(
+            std::fs::read(&redb_path).unwrap(),
+            b"existing redb placeholder"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_variation_redb_overwrite_rebuilds_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().to_str().unwrap();
+
+        let var_dir = dir.path().join("variation");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        let parquet_path = var_dir.join("chr1.parquet");
+        write_parquet(
+            parquet_path.to_str().unwrap(),
+            &[make_batch(
+                vec!["1", "1", "1"],
+                vec![100, 100, 200],
+                vec![100, 101, 200],
+                vec!["A/G", "A/T", "C/T"],
+                vec!["rs1", "rs2", "rs3"],
+            )],
+        );
+
+        let redb_path = dir.path().join("variation.redb");
+        std::fs::write(&redb_path, b"existing redb placeholder").unwrap();
+
+        let builder = CacheBuilder::new("/nonexistent_cache", output)
+            .with_partitions(2)
+            .with_overwrite(true);
+        let stats = builder.build_variation_redb_from_parquet().await.unwrap();
+
+        let redb_stats = stats[0].fjall_stats.as_ref().unwrap();
+        assert_eq!(redb_stats.total_variants, 3);
+        assert_eq!(redb_stats.total_positions, 2);
 
         let store = crate::kv_cache::VepRedbStore::open(&redb_path).unwrap();
         let chrom_code = crate::kv_cache::key_encoding::chrom_to_code("1");

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -36,6 +36,7 @@ use crate::kv_cache::LoadStats;
 use crate::kv_cache::key_encoding::{chrom_to_code, encode_position_key};
 use crate::kv_cache::kv_store::VepKvStore;
 use crate::kv_cache::position_entry::serialize_position_entry;
+use crate::kv_cache::redb_store::VepRedbStore;
 use crate::kv_cache::sift_store::SiftKvStore;
 use crate::transcript_consequence::CachedPredictions;
 
@@ -47,6 +48,31 @@ use crate::transcript_consequence::CachedPredictions;
 /// - `total_rows`: cumulative rows processed so far for this (entity, format)
 /// - `total_expected`: total rows expected (0 if unknown)
 pub type OnProgress = Box<dyn Fn(&str, &str, usize, usize, usize) + Send + Sync>;
+
+trait VariationMetadataStore {
+    fn store_dict(&self, dict_bytes: &[u8]) -> Result<()>;
+    fn store_zstd_level(&self, level: i32) -> Result<()>;
+}
+
+impl VariationMetadataStore for VepKvStore {
+    fn store_dict(&self, dict_bytes: &[u8]) -> Result<()> {
+        VepKvStore::store_dict(self, dict_bytes)
+    }
+
+    fn store_zstd_level(&self, level: i32) -> Result<()> {
+        VepKvStore::store_zstd_level(self, level)
+    }
+}
+
+impl VariationMetadataStore for VepRedbStore {
+    fn store_dict(&self, dict_bytes: &[u8]) -> Result<()> {
+        VepRedbStore::store_dict(self, dict_bytes)
+    }
+
+    fn store_zstd_level(&self, level: i32) -> Result<()> {
+        VepRedbStore::store_zstd_level(self, level)
+    }
+}
 
 /// Main chromosomes that get their own parquet file.
 const MAIN_CHROMS: &[&str] = &[
@@ -957,10 +983,314 @@ impl CacheBuilder {
         }])
     }
 
+    /// Build variation redb from existing parquet files.
+    ///
+    /// Reads chr*.parquet and other.parquet in chrom_code order, reusing the
+    /// same sorted accumulator as the fjall fast path, then commits each
+    /// serialized position batch to redb in a single write transaction.
+    pub async fn build_variation_redb_from_parquet(&self) -> Result<Vec<EntityStats>> {
+        let parquet_dir = format!("{}/variation", self.output_dir);
+        let redb_path = format!("{}/variation.redb", self.output_dir);
+
+        let mut parquet_files: Vec<(u16, String)> = Vec::new();
+        for entry in std::fs::read_dir(&parquet_dir).map_err(|e| {
+            DataFusionError::Execution(format!("Failed to read dir {parquet_dir}: {e}"))
+        })? {
+            let entry = entry.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to read dir entry: {e}"))
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("parquet") {
+                continue;
+            }
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            let chrom = stem.strip_prefix("chr").unwrap_or(stem);
+            let code = if chrom == "other" {
+                u16::MAX
+            } else {
+                chrom_to_code(chrom)
+            };
+            parquet_files.push((code, path.to_string_lossy().to_string()));
+        }
+        parquet_files.sort_by_key(|(code, _)| *code);
+
+        if parquet_files.is_empty() {
+            return Err(DataFusionError::Execution(
+                "No parquet files found for variation redb rebuild".to_string(),
+            ));
+        }
+
+        info!(
+            "variation: rebuilding redb from {} parquet files",
+            parquet_files.len()
+        );
+
+        if Path::new(&redb_path).exists() {
+            let path = Path::new(&redb_path);
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to remove existing {redb_path}: {e}"
+                    ))
+                })?;
+            } else {
+                std::fs::remove_file(path).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to remove existing {redb_path}: {e}"
+                    ))
+                })?;
+            }
+            info!("variation.redb: removed existing DB for clean rebuild");
+        }
+
+        let read_ctx =
+            SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+        read_ctx
+            .register_parquet("_probe", &parquet_files[0].1, Default::default())
+            .await?;
+        let probe_df = read_ctx.sql("SELECT * FROM _probe LIMIT 0").await?;
+        let schema: SchemaRef = Arc::new(probe_df.schema().as_arrow().clone());
+        read_ctx.deregister_table("_probe")?;
+
+        let store = VepRedbStore::create(Path::new(&redb_path), schema.clone())?;
+
+        {
+            let mut all_contigs: HashSet<String> = HashSet::new();
+            for (_, path) in &parquet_files {
+                let stem = Path::new(path)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                let chrom = stem.strip_prefix("chr").unwrap_or(stem);
+                if chrom != "other" && !CHROM_TO_CODE_SET.contains(&chrom) {
+                    all_contigs.insert(chrom.to_string());
+                }
+            }
+            let other_path = parquet_files
+                .iter()
+                .find(|(code, _)| *code == u16::MAX)
+                .map(|(_, p)| p.clone());
+            if let Some(ref other_path) = other_path {
+                read_ctx
+                    .register_parquet("_other_scan", other_path, Default::default())
+                    .await?;
+                let distinct_df = read_ctx
+                    .sql("SELECT DISTINCT chrom FROM _other_scan")
+                    .await?;
+                let batches = distinct_df.collect().await?;
+                read_ctx.deregister_table("_other_scan")?;
+                for batch in &batches {
+                    let chrom_col = batch.column(0);
+                    for row in 0..batch.num_rows() {
+                        let chrom = string_value(chrom_col.as_ref(), row);
+                        if !CHROM_TO_CODE_SET.contains(&chrom) {
+                            all_contigs.insert(chrom.to_string());
+                        }
+                    }
+                }
+            }
+
+            if !all_contigs.is_empty() {
+                let refs: Vec<&str> = all_contigs.iter().map(|s| s.as_str()).collect();
+                let mapping = crate::kv_cache::key_encoding::register_non_canonical_contigs(&refs);
+                store.store_contig_codes(&mapping)?;
+                info!(
+                    "variation: registered {} non-canonical contigs for redb rebuild",
+                    mapping.len()
+                );
+            }
+        }
+
+        let dict = {
+            read_ctx
+                .register_parquet("_sample", &parquet_files[0].1, Default::default())
+                .await?;
+            let sample_df = read_ctx.sql("SELECT * FROM _sample LIMIT 10000").await?;
+            let batches = sample_df.collect().await?;
+            read_ctx.deregister_table("_sample")?;
+            self.train_dict_from_batches(&store, &schema, &batches)
+                .await?
+        };
+
+        let chrom_col_idx = schema.index_of("chrom")?;
+        let start_col_idx = schema.index_of("start")?;
+        let allele_col_idx = schema.index_of("allele_string")?;
+        let col_indices: Vec<usize> = (0..schema.fields().len())
+            .filter(|&i| i != chrom_col_idx && i != start_col_idx)
+            .collect();
+
+        let mut total_positions = 0u64;
+        let mut total_variants = 0u64;
+        let mut total_bytes = 0u64;
+        let start_time = Instant::now();
+
+        for (file_idx, (_, parquet_path)) in parquet_files.iter().enumerate() {
+            let file_start = Instant::now();
+            let (tx, rx) = std::sync::mpsc::sync_channel::<(Vec<PositionAccumulator>, u64)>(2);
+
+            let parquet_path_clone = parquet_path.clone();
+            let chrom_col_idx_c = chrom_col_idx;
+            let start_col_idx_c = start_col_idx;
+
+            let producer = std::thread::spawn(move || -> Result<()> {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| DataFusionError::Execution(format!("tokio runtime: {e}")))?;
+
+                rt.block_on(async {
+                    let read_config = SessionConfig::new().with_target_partitions(1);
+                    let read_ctx = SessionContext::new_with_config(read_config);
+
+                    let mut accum: Option<PositionAccumulator> = None;
+                    let mut pending: Vec<PositionAccumulator> =
+                        Vec::with_capacity(PARALLEL_FLUSH_BATCH);
+                    let mut variants_in_batch = 0u64;
+
+                    read_ctx
+                        .register_parquet("_part", &parquet_path_clone, Default::default())
+                        .await?;
+                    let df = read_ctx.sql("SELECT * FROM _part").await?;
+                    let mut stream = df.execute_stream().await?;
+                    read_ctx.deregister_table("_part")?;
+
+                    while let Some(batch_result) = stream.next().await {
+                        let batch = batch_result?;
+                        if batch.num_rows() == 0 {
+                            continue;
+                        }
+                        let starts = batch.column(start_col_idx_c).as_primitive::<Int64Type>();
+                        let chrom_col = batch.column(chrom_col_idx_c);
+
+                        for row in 0..batch.num_rows() {
+                            let start = starts.value(row);
+                            let row_chrom = string_value(chrom_col.as_ref(), row);
+                            let chrom_code = chrom_to_code(row_chrom);
+
+                            let should_flush = accum
+                                .as_ref()
+                                .is_some_and(|a| a.chrom_code != chrom_code || a.start != start);
+
+                            if should_flush {
+                                pending.push(accum.take().unwrap());
+                                if pending.len() >= PARALLEL_FLUSH_BATCH {
+                                    let batch_to_send = std::mem::replace(
+                                        &mut pending,
+                                        Vec::with_capacity(PARALLEL_FLUSH_BATCH),
+                                    );
+                                    if tx.send((batch_to_send, variants_in_batch)).is_err() {
+                                        return Ok(());
+                                    }
+                                    variants_in_batch = 0;
+                                }
+                            }
+
+                            variants_in_batch += 1;
+
+                            match &mut accum {
+                                Some(a) => a.add_row(row, &batch),
+                                None => {
+                                    accum = Some(PositionAccumulator::new(
+                                        chrom_code,
+                                        row_chrom.to_string(),
+                                        start,
+                                        row,
+                                        &batch,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(a) = accum.take() {
+                        pending.push(a);
+                    }
+                    if !pending.is_empty() {
+                        let _ = tx.send((pending, variants_in_batch));
+                    }
+
+                    Ok(())
+                })
+            });
+
+            let max_threads = self.partitions;
+            while let Ok((mut batch, batch_variants)) = rx.recv() {
+                total_variants += batch_variants;
+                let mut entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(batch.len());
+                flush_positions_parallel(
+                    &mut batch,
+                    &col_indices,
+                    allele_col_idx,
+                    &dict,
+                    self.zstd_level,
+                    max_threads,
+                    &mut |k, v| {
+                        entries.push((k.to_vec(), v.to_vec()));
+                        Ok(())
+                    },
+                    &mut total_positions,
+                    &mut total_bytes,
+                )?;
+                store.batch_insert_raw(&entries)?;
+            }
+
+            producer
+                .join()
+                .expect("producer thread panicked")
+                .map_err(|e| DataFusionError::Execution(format!("producer error: {e}")))?;
+
+            let stem = Path::new(parquet_path)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("?");
+            info!(
+                "variation.redb: {stem} ingested in {:.1}s ({}/{} files, {} positions)",
+                file_start.elapsed().as_secs_f64(),
+                file_idx + 1,
+                parquet_files.len(),
+                total_positions,
+            );
+        }
+
+        info!("Running redb compaction on variation.redb...");
+        let compact_start = Instant::now();
+        store.optimize_after_load()?;
+        info!(
+            "redb compaction completed in {:.1}s",
+            compact_start.elapsed().as_secs_f64()
+        );
+
+        store.persist()?;
+        drop(store);
+
+        let elapsed = start_time.elapsed().as_secs_f64();
+        info!(
+            "variation.redb rebuilt: {} positions, {} variants, {:.1} MB in {:.1}s",
+            total_positions,
+            total_variants,
+            total_bytes as f64 / 1_048_576.0,
+            elapsed
+        );
+
+        Ok(vec![EntityStats {
+            entity: "variation".to_string(),
+            parquet_files: vec![],
+            fjall_stats: Some(LoadStats {
+                total_variants,
+                total_positions,
+                total_bytes,
+                elapsed_secs: elapsed,
+            }),
+        }])
+    }
+
     /// Train zstd dictionary from pre-collected batches.
     async fn train_dict_from_batches(
         &self,
-        store: &VepKvStore,
+        store: &impl VariationMetadataStore,
         schema: &SchemaRef,
         batches: &[RecordBatch],
     ) -> Result<Option<Arc<Vec<u8>>>> {
@@ -3423,6 +3753,88 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    fn make_synthetic_variation_batch(start: i64, rows: usize) -> RecordBatch {
+        RecordBatch::try_new(
+            variation_schema(),
+            vec![
+                Arc::new(StringArray::from_iter_values((0..rows).map(|_| "1"))),
+                Arc::new(Int64Array::from_iter_values(
+                    (0..rows).map(|i| start + i as i64),
+                )),
+                Arc::new(Int64Array::from_iter_values(
+                    (0..rows).map(|i| start + i as i64 + 1),
+                )),
+                Arc::new(StringArray::from_iter_values((0..rows).map(|_| "A/G"))),
+                Arc::new(StringArray::from_iter_values(
+                    (0..rows).map(|i| format!("rs{}", start + i as i64)),
+                )),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn write_synthetic_variation_parquet(path: &str, rows: usize) {
+        let file = File::create(path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, variation_schema(), None).unwrap();
+        let chunk_size = 20_000;
+        let mut written = 0usize;
+        while written < rows {
+            let chunk_rows = (rows - written).min(chunk_size);
+            let batch = make_synthetic_variation_batch(written as i64 + 1, chunk_rows);
+            writer.write(&batch).unwrap();
+            written += chunk_rows;
+        }
+        writer.close().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore] // release-only synthetic benchmark
+    async fn test_variation_redb_bulk_vs_fjall_bulk_timing_synthetic() {
+        use std::time::Instant;
+
+        let rows = std::env::var("VEP_BULK_BENCH_ROWS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(100_000);
+        let partitions = std::env::var("VEP_BULK_BENCH_PARTITIONS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(1);
+
+        let output = tempfile::tempdir().unwrap();
+        let output_dir = output.path().to_str().unwrap();
+        let var_dir = format!("{output_dir}/variation");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        let parquet_path = format!("{var_dir}/chr1.parquet");
+        write_synthetic_variation_parquet(&parquet_path, rows);
+
+        let builder = CacheBuilder::new("/nonexistent_cache", output_dir)
+            .with_partitions(partitions)
+            .with_build_fjall(true);
+
+        let fjall_start = Instant::now();
+        let fjall = builder.build_variation_fjall_from_parquet().await.unwrap();
+        let fjall_elapsed = fjall_start.elapsed().as_secs_f64();
+        let fjall_stats = fjall[0].fjall_stats.as_ref().unwrap();
+
+        let redb_start = Instant::now();
+        let redb = builder.build_variation_redb_from_parquet().await.unwrap();
+        let redb_elapsed = redb_start.elapsed().as_secs_f64();
+        let redb_stats = redb[0].fjall_stats.as_ref().unwrap();
+
+        eprintln!(
+            "synthetic variation bulk benchmark rows={rows} partitions={partitions}: fjall={fjall_elapsed:.3}s redb={redb_elapsed:.3}s ratio={:.2}x",
+            redb_elapsed / fjall_elapsed
+        );
+        eprintln!("fjall stats: {fjall_stats:?}");
+        eprintln!("redb stats: {redb_stats:?}");
+
+        assert_eq!(fjall_stats.total_variants, rows as u64);
+        assert_eq!(redb_stats.total_variants, rows as u64);
+        assert_eq!(fjall_stats.total_positions, rows as u64);
+        assert_eq!(redb_stats.total_positions, rows as u64);
+    }
+
     // -----------------------------------------------------------------------
     // dir_has_parquet_files
     // -----------------------------------------------------------------------
@@ -3552,6 +3964,46 @@ mod tests {
             result.is_err(),
             "should attempt fjall rebuild and fail on fake parquet"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_variation_rebuilds_redb_from_parquet() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().to_str().unwrap();
+
+        let var_dir = dir.path().join("variation");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        let parquet_path = var_dir.join("chr1.parquet");
+        write_parquet(
+            parquet_path.to_str().unwrap(),
+            &[make_batch(
+                vec!["1", "1", "1"],
+                vec![100, 100, 200],
+                vec![100, 101, 200],
+                vec!["A/G", "A/T", "C/T"],
+                vec!["rs1", "rs2", "rs3"],
+            )],
+        );
+
+        let builder = CacheBuilder::new("/nonexistent_cache", output).with_partitions(2);
+        let stats = builder.build_variation_redb_from_parquet().await.unwrap();
+
+        assert_eq!(stats.len(), 1);
+        let redb_stats = stats[0].fjall_stats.as_ref().unwrap();
+        assert_eq!(redb_stats.total_variants, 3);
+        assert_eq!(redb_stats.total_positions, 2);
+
+        let redb_path = dir.path().join("variation.redb");
+        assert!(redb_path.is_file());
+
+        let store = crate::kv_cache::VepRedbStore::open(&redb_path).unwrap();
+        let chrom_code = crate::kv_cache::key_encoding::chrom_to_code("1");
+        let raw = store
+            .get_position_entry_decompressed(chrom_code, 100)
+            .unwrap()
+            .unwrap();
+        let reader = crate::kv_cache::position_entry::PositionEntryReader::new(&raw).unwrap();
+        assert_eq!(reader.num_alleles(), 2);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -37,7 +37,7 @@ use crate::kv_cache::key_encoding::{chrom_to_code, encode_position_key};
 use crate::kv_cache::kv_store::VepKvStore;
 use crate::kv_cache::position_entry::serialize_position_entry;
 use crate::kv_cache::redb_store::VepRedbStore;
-use crate::kv_cache::sift_store::SiftKvStore;
+use crate::kv_cache::sift_store::{SiftKvStore, SiftRedbStore};
 use crate::transcript_consequence::CachedPredictions;
 
 /// Progress callback: `(entity, format, batch_rows, total_rows, total_expected)`.
@@ -1874,6 +1874,166 @@ impl CacheBuilder {
         }))
     }
 
+    /// Build translation_sift redb from existing parquet files.
+    pub async fn build_sift_redb_from_parquet(&self) -> Result<Vec<EntityStats>> {
+        let sift_dir = format!("{}/translation_sift", self.output_dir);
+        let redb_path = format!("{}/translation_sift.redb", self.output_dir);
+
+        if Path::new(&redb_path).exists() && !self.overwrite {
+            info!("translation_sift.redb already exists, skipping (use overwrite to rebuild)");
+            return Ok(vec![EntityStats {
+                entity: "translation_sift".to_string(),
+                parquet_files: vec![],
+                fjall_stats: None,
+            }]);
+        }
+
+        let mut parquet_files = Vec::new();
+        for entry in std::fs::read_dir(&sift_dir).map_err(|e| {
+            DataFusionError::Execution(format!("Failed to read dir {sift_dir}: {e}"))
+        })? {
+            let entry = entry.map_err(|e| {
+                DataFusionError::Execution(format!("Failed to read dir entry: {e}"))
+            })?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("parquet") {
+                parquet_files.push(path.to_string_lossy().to_string());
+            }
+        }
+        parquet_files.sort();
+
+        if parquet_files.is_empty() {
+            return Err(DataFusionError::Execution(
+                "No parquet files found for translation_sift redb rebuild".to_string(),
+            ));
+        }
+
+        if Path::new(&redb_path).exists() {
+            let path = Path::new(&redb_path);
+            if path.is_dir() {
+                std::fs::remove_dir_all(path).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to remove existing {redb_path}: {e}"
+                    ))
+                })?;
+            } else {
+                std::fs::remove_file(path).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "Failed to remove existing {redb_path}: {e}"
+                    ))
+                })?;
+            }
+            info!("translation_sift.redb: removed existing DB for clean rebuild");
+        }
+
+        let start_time = Instant::now();
+        let read_ctx =
+            SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+
+        let mut total_rows = 0usize;
+        let mut duplicate_rows = 0usize;
+        let mut replacement_rows = 0usize;
+        let mut sorted_preds: BTreeMap<String, SiftBuildEntry> = BTreeMap::new();
+
+        for parquet_path in &parquet_files {
+            read_ctx
+                .register_parquet("_sift_redb", parquet_path, Default::default())
+                .await?;
+            let df = read_ctx.sql("SELECT * FROM _sift_redb").await?;
+            let mut stream = df.execute_stream().await?;
+            read_ctx.deregister_table("_sift_redb")?;
+
+            while let Some(batch_result) = stream.next().await {
+                let batch = batch_result?;
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+
+                let schema = batch.schema();
+                let chrom_idx = schema.index_of("chrom")?;
+                let tid_idx = schema.index_of("transcript_id")?;
+                let sift_idx = schema.index_of("sift_predictions").ok();
+                let poly_idx = schema.index_of("polyphen_predictions").ok();
+
+                for row in 0..batch.num_rows() {
+                    let chrom = string_value(batch.column(chrom_idx).as_ref(), row).to_string();
+                    let transcript_id =
+                        string_value(batch.column(tid_idx).as_ref(), row).to_string();
+
+                    let mut preds = CachedPredictions::default();
+                    if let Some(idx) = sift_idx {
+                        preds.sift = read_compact_predictions(batch.column(idx).as_ref(), row);
+                    }
+                    if let Some(idx) = poly_idx {
+                        preds.polyphen = read_compact_predictions(batch.column(idx).as_ref(), row);
+                    }
+                    preds.sort();
+
+                    let new_entry = SiftBuildEntry {
+                        chrom,
+                        predictions: preds,
+                    };
+                    match sorted_preds.entry(transcript_id) {
+                        std::collections::btree_map::Entry::Vacant(slot) => {
+                            slot.insert(new_entry);
+                        }
+                        std::collections::btree_map::Entry::Occupied(mut slot) => {
+                            duplicate_rows += 1;
+                            if should_replace_sift_build_entry(
+                                slot.get(),
+                                &new_entry.chrom,
+                                &new_entry.predictions,
+                            ) {
+                                slot.insert(new_entry);
+                                replacement_rows += 1;
+                            }
+                        }
+                    }
+                    total_rows += 1;
+                }
+
+                if let Some(ref cb) = self.on_progress {
+                    cb("translation_sift", "redb", batch.num_rows(), total_rows, 0);
+                }
+            }
+        }
+
+        let transcript_count = sorted_preds.len();
+        if duplicate_rows > 0 {
+            info!(
+                "translation_sift.redb: resolved {duplicate_rows} duplicate transcript rows, replaced {replacement_rows} with preferred sources"
+            );
+        }
+        info!(
+            "translation_sift.redb: ingesting {} transcripts from {} rows...",
+            transcript_count, total_rows
+        );
+        let store = SiftRedbStore::ingest_sorted(
+            &redb_path,
+            sorted_preds
+                .into_iter()
+                .map(|(transcript_id, entry)| (transcript_id, entry.predictions)),
+        )?;
+        drop(store);
+
+        let elapsed = start_time.elapsed().as_secs_f64();
+        info!(
+            "translation_sift.redb: {} transcripts from {} rows in {:.1}s",
+            transcript_count, total_rows, elapsed
+        );
+
+        Ok(vec![EntityStats {
+            entity: "translation_sift".to_string(),
+            parquet_files: vec![],
+            fjall_stats: Some(LoadStats {
+                total_variants: total_rows as u64,
+                total_positions: transcript_count as u64,
+                total_bytes: 0,
+                elapsed_secs: elapsed,
+            }),
+        }])
+    }
+
     /// Build a parquet-only entity (transcript, exon, regulatory, motif).
     async fn build_parquet_entity(&self, kind: EnsemblEntityKind) -> Result<Vec<(String, usize)>> {
         let table_name = entity_table_name(kind);
@@ -2510,7 +2670,10 @@ fn string_value(col: &dyn Array, row: usize) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{Int64Array, StringArray};
+    use datafusion::arrow::array::{
+        ArrayRef, Float32Builder, Int32Builder, Int64Array, ListBuilder, StringArray,
+        StringBuilder, StructBuilder,
+    };
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -2543,6 +2706,76 @@ mod tests {
                 Arc::new(Int64Array::from(ends)),
                 Arc::new(StringArray::from(alleles)),
                 Arc::new(StringArray::from(names)),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn prediction_list_array(rows: Vec<Vec<(i32, &str, &str, f32)>>) -> ArrayRef {
+        let fields = vec![
+            Field::new("position", DataType::Int32, false),
+            Field::new("amino_acid", DataType::Utf8, false),
+            Field::new("prediction", DataType::Utf8, false),
+            Field::new("score", DataType::Float32, false),
+        ];
+        let struct_builder = StructBuilder::new(
+            fields,
+            vec![
+                Box::new(Int32Builder::new()),
+                Box::new(StringBuilder::new()),
+                Box::new(StringBuilder::new()),
+                Box::new(Float32Builder::new()),
+            ],
+        );
+        let mut list_builder = ListBuilder::new(struct_builder);
+
+        for row in rows {
+            for (position, amino_acid, prediction, score) in row {
+                let values = list_builder.values();
+                values
+                    .field_builder::<Int32Builder>(0)
+                    .unwrap()
+                    .append_value(position);
+                values
+                    .field_builder::<StringBuilder>(1)
+                    .unwrap()
+                    .append_value(amino_acid);
+                values
+                    .field_builder::<StringBuilder>(2)
+                    .unwrap()
+                    .append_value(prediction);
+                values
+                    .field_builder::<Float32Builder>(3)
+                    .unwrap()
+                    .append_value(score);
+                values.append(true);
+            }
+            list_builder.append(true);
+        }
+
+        Arc::new(list_builder.finish())
+    }
+
+    fn make_translation_sift_batch() -> RecordBatch {
+        let schema = datafusion_bio_format_ensembl_cache::translation_sift_schema(false);
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![
+                    "ENST00000111111",
+                    "ENST00000222222",
+                ])),
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(Int64Array::from(vec![100, 200])),
+                Arc::new(Int64Array::from(vec![150, 250])),
+                prediction_list_array(vec![
+                    vec![(42, "I", "deleterious", 0.01)],
+                    vec![(20, "V", "tolerated", 0.88)],
+                ]),
+                prediction_list_array(vec![
+                    vec![(42, "I", "probably damaging", 0.99)],
+                    vec![(20, "V", "benign", 0.10)],
+                ]),
             ],
         )
         .unwrap()
@@ -4097,6 +4330,59 @@ mod tests {
             .unwrap();
         let reader = crate::kv_cache::position_entry::PositionEntryReader::new(&raw).unwrap();
         assert_eq!(reader.num_alleles(), 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_translation_sift_redb_rebuilds_from_parquet() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().to_str().unwrap();
+
+        let sift_dir = dir.path().join("translation_sift");
+        std::fs::create_dir_all(&sift_dir).unwrap();
+        let parquet_path = sift_dir.join("chr1.parquet");
+        write_parquet(
+            parquet_path.to_str().unwrap(),
+            &[make_translation_sift_batch()],
+        );
+
+        let builder = CacheBuilder::new("/nonexistent_cache", output);
+        let stats = builder.build_sift_redb_from_parquet().await.unwrap();
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].entity, "translation_sift");
+        let redb_stats = stats[0].fjall_stats.as_ref().unwrap();
+        assert_eq!(redb_stats.total_variants, 2);
+        assert_eq!(redb_stats.total_positions, 2);
+
+        let redb_path = dir.path().join("translation_sift.redb");
+        assert!(redb_path.is_file());
+        let store = crate::kv_cache::SiftRedbStore::open_path(&redb_path)
+            .unwrap()
+            .unwrap();
+        let preds = store.get("ENST00000111111").unwrap().unwrap();
+        assert_eq!(preds.sift.len(), 1);
+        assert_eq!(preds.polyphen.len(), 1);
+        assert_eq!(preds.sift[0].position, 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_translation_sift_redb_skips_existing_without_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().to_str().unwrap();
+        let redb_path = dir.path().join("translation_sift.redb");
+        std::fs::write(&redb_path, b"existing redb placeholder").unwrap();
+
+        let builder = CacheBuilder::new("/nonexistent_cache", output);
+        let stats = builder.build_sift_redb_from_parquet().await.unwrap();
+
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].entity, "translation_sift");
+        assert!(stats[0].parquet_files.is_empty());
+        assert!(stats[0].fjall_stats.is_none());
+        assert_eq!(
+            std::fs::read(&redb_path).unwrap(),
+            b"existing redb placeholder"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/datafusion/bio-function-vep/src/kv_cache/cache_exec.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/cache_exec.rs
@@ -4,6 +4,7 @@
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::{Debug, Formatter};
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -44,13 +45,54 @@ pub enum KvMatchMode {
     Exact,
 }
 
+/// Position-keyed variation cache used by the shared KV lookup executor.
+///
+/// Fjall and redb store the same serialized position entries. Keeping this
+/// trait narrow lets both backends share all allele matching and output logic.
+pub trait PositionEntryStore: Send + Sync {
+    fn schema(&self) -> SchemaRef;
+    fn root_path(&self) -> &Path;
+    fn create_decompressor(&self) -> Result<Option<zstd::bulk::Decompressor<'static>>>;
+    fn get_position_entry_fast(
+        &self,
+        chrom_code: u16,
+        start: i64,
+        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
+        buf: &mut Vec<u8>,
+    ) -> Result<bool>;
+}
+
+impl PositionEntryStore for VepKvStore {
+    fn schema(&self) -> SchemaRef {
+        VepKvStore::schema(self).clone()
+    }
+
+    fn root_path(&self) -> &Path {
+        VepKvStore::root_path(self)
+    }
+
+    fn create_decompressor(&self) -> Result<Option<zstd::bulk::Decompressor<'static>>> {
+        VepKvStore::create_decompressor(self)
+    }
+
+    fn get_position_entry_fast(
+        &self,
+        chrom_code: u16,
+        start: i64,
+        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
+        buf: &mut Vec<u8>,
+    ) -> Result<bool> {
+        VepKvStore::get_position_entry_fast(self, chrom_code, start, decompressor, buf)
+    }
+}
+
 /// Physical execution plan for KV-backed variant lookup.
 ///
 /// Takes a VCF input plan, probes a fjall KV store per-position,
 /// and emits LEFT JOIN output (unmatched VCF rows get NULL cache columns).
 pub struct KvLookupExec {
     input: Arc<dyn ExecutionPlan>,
-    store: Arc<VepKvStore>,
+    store: Arc<dyn PositionEntryStore>,
     cache_columns: Vec<String>,
     match_mode: KvMatchMode,
     exact_matcher: AlleleMatcher,
@@ -78,7 +120,7 @@ impl KvLookupExec {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
-        store: Arc<VepKvStore>,
+        store: Arc<dyn PositionEntryStore>,
         cache_columns: Vec<String>,
         match_mode: KvMatchMode,
         exact_matcher: AlleleMatcher,
@@ -245,7 +287,7 @@ impl ExecutionPlan for KvLookupExec {
 /// the colocated map — matching the buffering behavior of `VariantLookupExec`.
 struct KvLookupStream {
     input: SendableRecordBatchStream,
-    store: Arc<VepKvStore>,
+    store: Arc<dyn PositionEntryStore>,
     schema: SchemaRef,
     cache_columns: Vec<String>,
     _match_mode: KvMatchMode,
@@ -396,7 +438,7 @@ impl KvLookupStream {
     #[allow(clippy::too_many_arguments)]
     fn new(
         input: SendableRecordBatchStream,
-        store: Arc<VepKvStore>,
+        store: Arc<dyn PositionEntryStore>,
         schema: SchemaRef,
         cache_columns: Vec<String>,
         match_mode: KvMatchMode,
@@ -413,7 +455,7 @@ impl KvLookupStream {
         // Resolve colocated column indices within the KV entry if we have a sink.
         let coloc_col_indices = colocated_sink
             .as_ref()
-            .and_then(|_| resolve_kv_coloc_indices(&store));
+            .and_then(|_| resolve_kv_coloc_indices(store.as_ref()));
 
         // Open the reference FASTA reader if a path is provided and we have a
         // colocated sink (shift state is only needed for colocated matching).
@@ -1162,7 +1204,7 @@ fn canonical_event_lengths(ref_allele: &str, alt_allele: &str) -> (usize, usize)
 ///
 /// The entry stores all cache schema columns except chrom/start, in schema order
 /// minus those two. `end` is stored as a regular column inside the entry.
-fn resolve_kv_coloc_indices(store: &VepKvStore) -> Option<KvColocIndices> {
+fn resolve_kv_coloc_indices(store: &dyn PositionEntryStore) -> Option<KvColocIndices> {
     let cache_schema = store.schema();
 
     let cache_chrom_idx = cache_schema.index_of("chrom").unwrap_or(usize::MAX);

--- a/datafusion/bio-function-vep/src/kv_cache/cache_exec.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/cache_exec.rs
@@ -53,13 +53,33 @@ pub trait PositionEntryStore: Send + Sync {
     fn schema(&self) -> SchemaRef;
     fn root_path(&self) -> &Path;
     fn create_decompressor(&self) -> Result<Option<zstd::bulk::Decompressor<'static>>>;
+    fn begin_lookup_session(&self) -> Result<Box<dyn PositionEntryLookupSession + '_>>;
+}
+
+pub trait PositionEntryLookupSession {
     fn get_position_entry_fast(
-        &self,
+        &mut self,
         chrom_code: u16,
         start: i64,
         decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
         buf: &mut Vec<u8>,
     ) -> Result<bool>;
+}
+
+struct FjallPositionEntryLookupSession<'a> {
+    store: &'a VepKvStore,
+}
+
+impl PositionEntryLookupSession for FjallPositionEntryLookupSession<'_> {
+    fn get_position_entry_fast(
+        &mut self,
+        chrom_code: u16,
+        start: i64,
+        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
+        buf: &mut Vec<u8>,
+    ) -> Result<bool> {
+        VepKvStore::get_position_entry_fast(self.store, chrom_code, start, decompressor, buf)
+    }
 }
 
 impl PositionEntryStore for VepKvStore {
@@ -75,14 +95,8 @@ impl PositionEntryStore for VepKvStore {
         VepKvStore::create_decompressor(self)
     }
 
-    fn get_position_entry_fast(
-        &self,
-        chrom_code: u16,
-        start: i64,
-        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
-        buf: &mut Vec<u8>,
-    ) -> Result<bool> {
-        VepKvStore::get_position_entry_fast(self, chrom_code, start, decompressor, buf)
+    fn begin_lookup_session(&self) -> Result<Box<dyn PositionEntryLookupSession + '_>> {
+        Ok(Box::new(FjallPositionEntryLookupSession { store: self }))
     }
 }
 
@@ -503,6 +517,7 @@ impl KvLookupStream {
     /// For each VCF row, fetch the per-position entry from fjall, match alleles,
     /// and append matched column values directly into ArrayBuilders.
     fn process_batch(&mut self, vcf_batch: &RecordBatch) -> Result<RecordBatch> {
+        let store = Arc::clone(&self.store);
         let vcf_schema = vcf_batch.schema();
         let chrom_idx = vcf_schema.index_of("chrom")?;
         let start_idx = vcf_schema.index_of("start")?;
@@ -547,7 +562,7 @@ impl KvLookupStream {
         let mut vcf_indices: Vec<u32> = Vec::with_capacity(num_rows);
 
         // Reusable zstd decompressor — created once, amortized across all lookups.
-        let mut decompressor = self.store.create_decompressor()?;
+        let mut decompressor = store.create_decompressor()?;
 
         // Reusable decompression / raw-value buffer — avoids alloc per lookup.
         let mut decompress_buf: Vec<u8> = Vec::with_capacity(4096);
@@ -558,7 +573,7 @@ impl KvLookupStream {
         // Determine which column indices in the entry correspond to our output columns.
         // Entry stores all columns except chrom/start, in schema order minus those 2.
         // (`end` is stored as a regular column inside the entry.)
-        let cache_schema = self.store.schema();
+        let cache_schema = store.schema();
         let cache_chrom_idx = cache_schema.index_of("chrom").unwrap_or(usize::MAX);
         let cache_start_idx = cache_schema.index_of("start").unwrap_or(usize::MAX);
 
@@ -593,6 +608,7 @@ impl KvLookupStream {
         } else {
             None
         };
+        let mut lookup_session = store.begin_lookup_session()?;
 
         // Local buffer for colocated data (flushed to the shared sink after the loop).
         let mut coloc_buf: Option<HashMap<ColocatedKey, ColocatedSinkValue>> =
@@ -639,7 +655,7 @@ impl KvLookupStream {
 
             let mut emitted_match = false;
             for probe_start in &probe_starts {
-                let found = self.store.get_position_entry_fast(
+                let found = lookup_session.get_position_entry_fast(
                     chrom_code,
                     *probe_start,
                     decompressor.as_mut(),

--- a/datafusion/bio-function-vep/src/kv_cache/cache_provider.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/cache_provider.rs
@@ -13,6 +13,7 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
 
+use super::cache_exec::PositionEntryStore;
 use super::kv_store::VepKvStore;
 
 /// TableProvider backed by a fjall KV store containing VEP cache data.
@@ -78,6 +79,62 @@ impl TableProvider for KvCacheTableProvider {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         Err(datafusion::common::DataFusionError::NotImplemented(
             "Direct scan of KvCacheTableProvider is not yet supported. \
+             Use lookup_variants() table function instead."
+                .to_string(),
+        ))
+    }
+}
+
+/// Backend-neutral TableProvider for an already-opened position cache store.
+pub(crate) struct PositionCacheTableProvider {
+    store: Arc<dyn PositionEntryStore>,
+    schema: SchemaRef,
+}
+
+impl PositionCacheTableProvider {
+    pub(crate) fn from_store(store: Arc<dyn PositionEntryStore>) -> Self {
+        let schema = store.schema();
+        Self { store, schema }
+    }
+
+    pub(crate) fn store(&self) -> &Arc<dyn PositionEntryStore> {
+        &self.store
+    }
+}
+
+impl Debug for PositionCacheTableProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PositionCacheTableProvider {{ schema: {:?} }}",
+            self.schema
+        )
+    }
+}
+
+#[async_trait]
+impl TableProvider for PositionCacheTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(datafusion::common::DataFusionError::NotImplemented(
+            "Direct scan of PositionCacheTableProvider is not yet supported. \
              Use lookup_variants() table function instead."
                 .to_string(),
         ))

--- a/datafusion/bio-function-vep/src/kv_cache/kv_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/kv_store.rs
@@ -42,11 +42,11 @@ pub struct VepKvStore {
     zstd_dict: Option<Arc<Vec<u8>>>,
 }
 
-fn arrow_err(e: datafusion::arrow::error::ArrowError) -> DataFusionError {
+pub(crate) fn arrow_err(e: datafusion::arrow::error::ArrowError) -> DataFusionError {
     DataFusionError::ArrowError(Box::new(e), None)
 }
 
-fn fjall_err(e: fjall::Error) -> DataFusionError {
+pub(crate) fn fjall_err(e: fjall::Error) -> DataFusionError {
     DataFusionError::External(Box::new(e))
 }
 
@@ -479,7 +479,7 @@ impl VepKvStore {
 }
 
 /// Serialize schema to IPC bytes by writing an empty batch.
-fn schema_to_ipc_bytes(schema: &SchemaRef) -> Result<Vec<u8>> {
+pub(crate) fn schema_to_ipc_bytes(schema: &SchemaRef) -> Result<Vec<u8>> {
     let empty_batch = RecordBatch::new_empty(schema.clone());
     let mut buf = Vec::new();
     {
@@ -492,7 +492,7 @@ fn schema_to_ipc_bytes(schema: &SchemaRef) -> Result<Vec<u8>> {
 }
 
 /// Deserialize schema from IPC bytes (empty batch carrying schema).
-fn schema_from_ipc_bytes(data: &[u8]) -> Result<SchemaRef> {
+pub(crate) fn schema_from_ipc_bytes(data: &[u8]) -> Result<SchemaRef> {
     let cursor = Cursor::new(data);
     let reader = arrow_ipc::reader::StreamReader::try_new(cursor, None).map_err(arrow_err)?;
     Ok(reader.schema())

--- a/datafusion/bio-function-vep/src/kv_cache/loader.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/loader.rs
@@ -30,9 +30,11 @@ use datafusion::prelude::SessionContext;
 use futures::StreamExt;
 use log::{debug, info};
 
+use super::cache_exec::PositionEntryStore;
 use super::key_encoding::{chrom_to_code, encode_position_key};
 use super::kv_store::{VepKvStore, decompress_into_buffer_with_retry};
 use super::position_entry::{PositionEntryReader, make_builder, serialize_position_entry};
+use super::redb_store::VepRedbStore;
 
 /// Statistics returned after loading.
 #[derive(Debug, Clone)]
@@ -41,6 +43,32 @@ pub struct LoadStats {
     pub total_positions: u64,
     pub total_bytes: u64,
     pub elapsed_secs: f64,
+}
+
+/// Storage backend to use when building a position-keyed variation cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheBackend {
+    Fjall,
+    Redb,
+}
+
+impl CacheBackend {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "fjall" => Ok(Self::Fjall),
+            "redb" => Ok(Self::Redb),
+            other => Err(DataFusionError::Execution(format!(
+                "cache backend must be one of: fjall, redb; got: {other}"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Fjall => "fjall",
+            Self::Redb => "redb",
+        }
+    }
 }
 
 /// Per-partition stats accumulated during streaming.
@@ -80,9 +108,108 @@ impl ShardedPositionLock {
     }
 }
 
+trait CacheLoadStore: PositionEntryStore + 'static {
+    fn put_position_entry(&self, chrom: &str, start: i64, value: &[u8]) -> Result<()>;
+    fn get_position_entry_raw(&self, chrom_code: u16, start: i64) -> Result<Option<Vec<u8>>>;
+    fn get_position_entry_decompressed(
+        &self,
+        chrom_code: u16,
+        start: i64,
+    ) -> Result<Option<Vec<u8>>>;
+    fn store_dict(&self, dict_bytes: &[u8]) -> Result<()>;
+    fn store_zstd_level(&self, level: i32) -> Result<()>;
+    fn persist(&self) -> Result<()>;
+    fn optimize_after_load(&self) -> Result<()>;
+}
+
+impl CacheLoadStore for VepKvStore {
+    fn put_position_entry(&self, chrom: &str, start: i64, value: &[u8]) -> Result<()> {
+        VepKvStore::put_position_entry(self, chrom, start, value)
+    }
+
+    fn get_position_entry_raw(&self, chrom_code: u16, start: i64) -> Result<Option<Vec<u8>>> {
+        VepKvStore::get_position_entry(self, chrom_code, start)
+            .map(|value| value.map(|raw| raw.to_vec()))
+    }
+
+    fn get_position_entry_decompressed(
+        &self,
+        chrom_code: u16,
+        start: i64,
+    ) -> Result<Option<Vec<u8>>> {
+        VepKvStore::get_position_entry_decompressed(self, chrom_code, start)
+    }
+
+    fn store_dict(&self, dict_bytes: &[u8]) -> Result<()> {
+        VepKvStore::store_dict(self, dict_bytes)
+    }
+
+    fn store_zstd_level(&self, level: i32) -> Result<()> {
+        VepKvStore::store_zstd_level(self, level)
+    }
+
+    fn persist(&self) -> Result<()> {
+        VepKvStore::persist(self)
+    }
+
+    fn optimize_after_load(&self) -> Result<()> {
+        info!("Running major compaction on fjall data keyspace...");
+        let compact_start = Instant::now();
+        self.data_partition()
+            .major_compact()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        info!(
+            "Fjall major compaction completed in {:.1}s",
+            compact_start.elapsed().as_secs_f64()
+        );
+        Ok(())
+    }
+}
+
+impl CacheLoadStore for VepRedbStore {
+    fn put_position_entry(&self, chrom: &str, start: i64, value: &[u8]) -> Result<()> {
+        VepRedbStore::put_position_entry(self, chrom, start, value)
+    }
+
+    fn get_position_entry_raw(&self, chrom_code: u16, start: i64) -> Result<Option<Vec<u8>>> {
+        VepRedbStore::get_position_entry(self, chrom_code, start)
+    }
+
+    fn get_position_entry_decompressed(
+        &self,
+        chrom_code: u16,
+        start: i64,
+    ) -> Result<Option<Vec<u8>>> {
+        VepRedbStore::get_position_entry_decompressed(self, chrom_code, start)
+    }
+
+    fn store_dict(&self, dict_bytes: &[u8]) -> Result<()> {
+        VepRedbStore::store_dict(self, dict_bytes)
+    }
+
+    fn store_zstd_level(&self, level: i32) -> Result<()> {
+        VepRedbStore::store_zstd_level(self, level)
+    }
+
+    fn persist(&self) -> Result<()> {
+        VepRedbStore::persist(self)
+    }
+
+    fn optimize_after_load(&self) -> Result<()> {
+        info!("Running redb compaction...");
+        let compact_start = Instant::now();
+        VepRedbStore::optimize_after_load(self)?;
+        info!(
+            "redb compaction completed in {:.1}s",
+            compact_start.elapsed().as_secs_f64()
+        );
+        Ok(())
+    }
+}
+
 /// Shared context passed to each partition's streaming task.
 struct StreamContext {
-    store: Arc<VepKvStore>,
+    store: Arc<dyn CacheLoadStore>,
     schema: SchemaRef,
     /// Pre-trained dictionary bytes shared by all partitions. `None` if training
     /// was skipped (too few samples) — partitions store entries uncompressed.
@@ -97,6 +224,7 @@ struct StreamContext {
 pub struct CacheLoader {
     source_table: String,
     target_path: String,
+    backend: CacheBackend,
     parallelism: Option<usize>,
     zstd_level: i32,
     dict_size_kb: u32,
@@ -111,6 +239,7 @@ impl CacheLoader {
         Self {
             source_table: source_table.into(),
             target_path: target_path.into(),
+            backend: CacheBackend::Fjall,
             parallelism: None,
             zstd_level: 3,
             dict_size_kb: 112,
@@ -121,6 +250,12 @@ impl CacheLoader {
     /// Default is `None` — all partitions run concurrently.
     pub fn with_parallelism(mut self, n: usize) -> Self {
         self.parallelism = Some(n);
+        self
+    }
+
+    /// Set the storage backend (default: fjall).
+    pub fn with_backend(mut self, backend: CacheBackend) -> Self {
+        self.backend = backend;
         self
     }
 
@@ -151,15 +286,23 @@ impl CacheLoader {
         let source_df = session.table(&self.source_table).await?;
         let schema: SchemaRef = Arc::new(source_df.schema().as_arrow().clone());
 
-        let store = Arc::new(VepKvStore::create(
-            Path::new(&self.target_path),
-            schema.clone(),
-        )?);
+        let store: Arc<dyn CacheLoadStore> = match self.backend {
+            CacheBackend::Fjall => Arc::new(VepKvStore::create(
+                Path::new(&self.target_path),
+                schema.clone(),
+            )?),
+            CacheBackend::Redb => Arc::new(VepRedbStore::create(
+                Path::new(&self.target_path),
+                schema.clone(),
+            )?),
+        };
 
         // Phase 1: Train zstd dictionary from a sample of the source data.
         // This happens once before any parallel work, ensuring all partitions
         // share the same dictionary.
-        let dict = self.train_dictionary(session, &store, &schema).await?;
+        let dict = self
+            .train_dictionary(session, store.as_ref(), &schema)
+            .await?;
 
         // Phase 2: Stream all partitions in parallel with the shared dictionary.
         let source_df = session.table(&self.source_table).await?;
@@ -225,18 +368,8 @@ impl CacheLoader {
 
         store.persist()?;
 
-        // Major-compact the data keyspace so the LSM tree is fully optimized
-        // for reads (bloom filters built, levels merged) before first use.
-        info!("Running major compaction on data keyspace...");
-        let compact_start = Instant::now();
-        store
-            .data_partition()
-            .major_compact()
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        info!(
-            "Major compaction completed in {:.1}s",
-            compact_start.elapsed().as_secs_f64()
-        );
+        // Optimize the backend for read-mostly annotation before first use.
+        store.optimize_after_load()?;
 
         let elapsed = start_time.elapsed().as_secs_f64();
         info!(
@@ -266,7 +399,7 @@ impl CacheLoader {
     async fn train_dictionary(
         &self,
         session: &SessionContext,
-        store: &VepKvStore,
+        store: &dyn CacheLoadStore,
         schema: &SchemaRef,
     ) -> Result<Option<Arc<Vec<u8>>>> {
         let sample_df = session
@@ -406,7 +539,7 @@ async fn stream_partition(
             let locks = Arc::clone(&ctx.position_locks);
             let (comp_back, dec_back, positions, bytes) = tokio::task::spawn_blocking(move || {
                 let result = flush_positions_compressed(
-                    &store,
+                    store.as_ref(),
                     &schema,
                     &batch_clone,
                     &mut comp,
@@ -424,7 +557,7 @@ async fn stream_partition(
         } else {
             let locks = Arc::clone(&ctx.position_locks);
             let (positions, bytes) = tokio::task::spawn_blocking(move || {
-                flush_positions_uncompressed(&store, &schema, &batch_clone, &locks)
+                flush_positions_uncompressed(store.as_ref(), &schema, &batch_clone, &locks)
             })
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))??;
@@ -445,7 +578,7 @@ async fn stream_partition(
 
 /// Flush position entries without compression (fallback when dictionary training was skipped).
 fn flush_positions_uncompressed(
-    store: &VepKvStore,
+    store: &dyn CacheLoadStore,
     schema: &SchemaRef,
     batch: &RecordBatch,
     position_locks: &ShardedPositionLock,
@@ -494,7 +627,7 @@ fn flush_positions_uncompressed(
 
 /// Compress and flush position entries using a pre-trained zstd dictionary compressor.
 fn flush_positions_compressed(
-    store: &VepKvStore,
+    store: &dyn CacheLoadStore,
     schema: &SchemaRef,
     batch: &RecordBatch,
     compressor: &mut zstd::bulk::Compressor<'_>,
@@ -531,7 +664,7 @@ fn flush_positions_compressed(
         let mut raw_value = serialize_position_entry(rows, batch, &col_indices, allele_col_idx)?;
         // Per-position lock: only serializes merges at the same (chrom, start).
         let _guard = position_locks.lock_for(chrom_code, *start);
-        if let Some(existing_compressed) = store.get_position_entry(chrom_code, *start)? {
+        if let Some(existing_compressed) = store.get_position_entry_raw(chrom_code, *start)? {
             let mut existing_raw = Vec::new();
             decompress_into_buffer_with_retry(
                 decompressor,
@@ -890,6 +1023,36 @@ mod tests {
         assert!(entry.is_none());
 
         // Verify a position entry can be deserialized after decompression.
+        let raw = store
+            .get_position_entry_decompressed(chrom_code_1, 100)
+            .unwrap()
+            .unwrap();
+        let reader = crate::kv_cache::position_entry::PositionEntryReader::new(&raw).unwrap();
+        assert!(reader.num_alleles() >= 1);
+        assert!(reader.num_cols() > 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_loader_basic_redb_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let redb_path = dir.path().join("variation.redb");
+        let ctx = SessionContext::new();
+
+        let (schema, table) = make_test_table();
+        ctx.register_table("source_redb", Arc::new(table)).unwrap();
+
+        let loader = CacheLoader::new("source_redb", redb_path.to_str().unwrap())
+            .with_backend(CacheBackend::Redb);
+        let stats = loader.load(&ctx).await.unwrap();
+
+        assert_eq!(stats.total_variants, 4);
+        assert!(stats.total_positions > 0);
+
+        let store = VepRedbStore::open(&redb_path).unwrap();
+        assert_eq!(store.format_version(), FORMAT_V0);
+        assert_eq!(store.schema().as_ref(), schema.as_ref());
+
+        let chrom_code_1 = crate::kv_cache::key_encoding::chrom_to_code("1");
         let raw = store
             .get_position_entry_decompressed(chrom_code_1, 100)
             .unwrap()

--- a/datafusion/bio-function-vep/src/kv_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/mod.rs
@@ -20,4 +20,4 @@ pub use context_store::{ExonKvStore, TranslationKvStore};
 pub use kv_store::VepKvStore;
 pub use loader::{CacheBackend, CacheLoader, LoadStats};
 pub use redb_store::{RedbCacheTableProvider, VepRedbStore};
-pub use sift_store::SiftKvStore;
+pub use sift_store::{SiftKvStore, SiftPredictionStore, SiftRedbStore};

--- a/datafusion/bio-function-vep/src/kv_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/mod.rs
@@ -20,4 +20,5 @@ pub use context_store::{ExonKvStore, TranslationKvStore};
 pub use kv_store::VepKvStore;
 pub use loader::{CacheBackend, CacheLoader, LoadStats};
 pub use redb_store::{RedbCacheTableProvider, VepRedbStore};
+pub(crate) use sift_store::SiftPredictionLookupSession;
 pub use sift_store::{SiftKvStore, SiftPredictionStore, SiftRedbStore};

--- a/datafusion/bio-function-vep/src/kv_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/mod.rs
@@ -11,10 +11,13 @@ pub mod key_encoding;
 pub mod kv_store;
 pub mod loader;
 pub mod position_entry;
+pub mod redb_store;
 pub mod sift_store;
 
 pub use cache_provider::KvCacheTableProvider;
+pub(crate) use cache_provider::PositionCacheTableProvider;
 pub use context_store::{ExonKvStore, TranslationKvStore};
 pub use kv_store::VepKvStore;
-pub use loader::{CacheLoader, LoadStats};
+pub use loader::{CacheBackend, CacheLoader, LoadStats};
+pub use redb_store::{RedbCacheTableProvider, VepRedbStore};
 pub use sift_store::SiftKvStore;

--- a/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
@@ -150,6 +150,35 @@ impl VepRedbStore {
         Ok(())
     }
 
+    pub(crate) fn batch_insert_raw(&self, entries: &[(Vec<u8>, Vec<u8>)]) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|e| DataFusionError::Execution(format!("redb write mutex poisoned: {e}")))?;
+        let RedbHandle::Writable(db) = &self.db else {
+            return Err(DataFusionError::Execution(
+                "redb cache was opened read-only; writes are not allowed".to_string(),
+            ));
+        };
+        let db = db.lock().map_err(|e| {
+            DataFusionError::Execution(format!("redb database mutex poisoned: {e}"))
+        })?;
+        let write_txn = db.begin_write().map_err(redb_err)?;
+        {
+            let mut table = write_txn.open_table(DATA_TABLE).map_err(redb_err)?;
+            for (key, value) in entries {
+                table
+                    .insert(key.as_slice(), value.as_slice())
+                    .map_err(redb_err)?;
+            }
+        }
+        write_txn.commit().map_err(redb_err)?;
+        Ok(())
+    }
+
     pub fn get_position_entry(&self, chrom_code: u16, start: i64) -> Result<Option<Vec<u8>>> {
         let mut key_buf = Vec::with_capacity(10);
         super::key_encoding::encode_position_key_buf(chrom_code, start, &mut key_buf);
@@ -468,5 +497,31 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(value, b"entry");
+    }
+
+    #[test]
+    fn redb_store_batch_insert_raw_writes_multiple_entries() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let store = VepRedbStore::create(file.path(), test_schema()).unwrap();
+        let key_100 = crate::kv_cache::key_encoding::encode_position_key("1", 100);
+        let key_200 = crate::kv_cache::key_encoding::encode_position_key("1", 200);
+
+        store
+            .batch_insert_raw(&[
+                (key_100.clone(), b"entry-100".to_vec()),
+                (key_200.clone(), b"entry-200".to_vec()),
+            ])
+            .unwrap();
+        drop(store);
+
+        let reopened = VepRedbStore::open(file.path()).unwrap();
+        assert_eq!(
+            reopened.get_position_entry_raw(&key_100).unwrap().unwrap(),
+            b"entry-100"
+        );
+        assert_eq!(
+            reopened.get_position_entry_raw(&key_200).unwrap().unwrap(),
+            b"entry-200"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
@@ -331,7 +331,7 @@ impl VepRedbStore {
         let mut db = db.lock().map_err(|e| {
             DataFusionError::Execution(format!("redb database mutex poisoned: {e}"))
         })?;
-        while db.compact().map_err(redb_err)? {}
+        db.compact().map_err(redb_err)?;
         Ok(())
     }
 

--- a/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
@@ -1,0 +1,472 @@
+//! redb KV cache backend for VEP variant lookup.
+//!
+//! The on-disk value format matches the fjall-backed store: one serialized
+//! position entry per `(chrom, start)` key, with optional zstd dictionary
+//! compression recorded in metadata. Annotation opens redb through
+//! `ReadOnlyDatabase` so separate annotator processes can read the same cache
+//! concurrently.
+
+use std::any::Any;
+use std::fmt::{Debug, Formatter};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::Session;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::Expr;
+use redb::{
+    Database, ReadOnlyDatabase, ReadTransaction, ReadableDatabase, ReadableTable, TableDefinition,
+};
+
+use super::cache_exec::PositionEntryStore;
+use super::kv_store::{
+    FORMAT_V0, decompress_into_buffer_with_retry, schema_from_ipc_bytes, schema_to_ipc_bytes,
+};
+
+const META_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("meta");
+const DATA_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("data");
+
+const SCHEMA_KEY: &str = "schema";
+const FORMAT_VERSION_KEY: &str = "format_version";
+const ZSTD_DICT_KEY: &str = "zstd_dict";
+const ZSTD_LEVEL_KEY: &str = "zstd_level";
+const CONTIG_CODES_KEY: &str = "contig_codes";
+
+enum RedbHandle {
+    Writable(Mutex<Database>),
+    ReadOnly(ReadOnlyDatabase),
+}
+
+type RedbMetadata = (SchemaRef, u8, Option<Arc<Vec<u8>>>);
+
+/// redb-backed variant cache store.
+///
+/// Use [`Self::create`] while building caches. Use [`Self::open`] for
+/// annotation/lookups; it opens a process-safe read-only database handle.
+pub struct VepRedbStore {
+    root_path: PathBuf,
+    db: RedbHandle,
+    schema: SchemaRef,
+    format_version: u8,
+    zstd_dict: Option<Arc<Vec<u8>>>,
+    write_lock: Mutex<()>,
+}
+
+fn redb_err(e: impl std::fmt::Display) -> DataFusionError {
+    DataFusionError::Execution(format!("redb error: {e}"))
+}
+
+impl VepRedbStore {
+    /// Open an existing redb cache for annotation using `ReadOnlyDatabase`.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let root_path = path.as_ref().to_path_buf();
+        let db = ReadOnlyDatabase::open(&root_path).map_err(redb_err)?;
+        let (schema, format_version, zstd_dict) = Self::read_metadata(&db)?;
+        Ok(Self {
+            root_path,
+            db: RedbHandle::ReadOnly(db),
+            schema,
+            format_version,
+            zstd_dict,
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    /// Create or open a writable redb cache and initialize metadata.
+    pub fn create(path: impl AsRef<Path>, schema: SchemaRef) -> Result<Self> {
+        let root_path = path.as_ref().to_path_buf();
+        let db = Database::create(&root_path).map_err(redb_err)?;
+
+        {
+            let write_txn = db.begin_write().map_err(redb_err)?;
+            {
+                let mut meta = write_txn.open_table(META_TABLE).map_err(redb_err)?;
+                let schema_bytes = schema_to_ipc_bytes(&schema)?;
+                meta.insert(SCHEMA_KEY, schema_bytes.as_slice())
+                    .map_err(redb_err)?;
+                meta.insert(FORMAT_VERSION_KEY, [FORMAT_V0].as_slice())
+                    .map_err(redb_err)?;
+            }
+            {
+                let _data = write_txn.open_table(DATA_TABLE).map_err(redb_err)?;
+            }
+            write_txn.commit().map_err(redb_err)?;
+        }
+
+        Ok(Self {
+            root_path,
+            db: RedbHandle::Writable(Mutex::new(db)),
+            schema,
+            format_version: FORMAT_V0,
+            zstd_dict: None,
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn root_path(&self) -> &Path {
+        &self.root_path
+    }
+
+    pub fn format_version(&self) -> u8 {
+        self.format_version
+    }
+
+    pub fn has_dict(&self) -> bool {
+        self.zstd_dict.is_some()
+    }
+
+    pub fn put_position_entry(&self, chrom: &str, start: i64, value: &[u8]) -> Result<()> {
+        let key = super::key_encoding::encode_position_key(chrom, start);
+        self.put_position_entry_raw(&key, value)
+    }
+
+    pub(crate) fn put_position_entry_raw(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|e| DataFusionError::Execution(format!("redb write mutex poisoned: {e}")))?;
+        let RedbHandle::Writable(db) = &self.db else {
+            return Err(DataFusionError::Execution(
+                "redb cache was opened read-only; writes are not allowed".to_string(),
+            ));
+        };
+        let db = db.lock().map_err(|e| {
+            DataFusionError::Execution(format!("redb database mutex poisoned: {e}"))
+        })?;
+        let write_txn = db.begin_write().map_err(redb_err)?;
+        {
+            let mut table = write_txn.open_table(DATA_TABLE).map_err(redb_err)?;
+            table.insert(key, value).map_err(redb_err)?;
+        }
+        write_txn.commit().map_err(redb_err)?;
+        Ok(())
+    }
+
+    pub fn get_position_entry(&self, chrom_code: u16, start: i64) -> Result<Option<Vec<u8>>> {
+        let mut key_buf = Vec::with_capacity(10);
+        super::key_encoding::encode_position_key_buf(chrom_code, start, &mut key_buf);
+        self.get_position_entry_raw(&key_buf)
+    }
+
+    pub(crate) fn get_position_entry_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let read_txn = self.begin_read()?;
+        let table = read_txn.open_table(DATA_TABLE).map_err(redb_err)?;
+        table
+            .get(key)
+            .map_err(redb_err)
+            .map(|value| value.map(|guard| guard.value().to_vec()))
+    }
+
+    pub fn get_position_entry_decompressed(
+        &self,
+        chrom_code: u16,
+        start: i64,
+    ) -> Result<Option<Vec<u8>>> {
+        let raw = self.get_position_entry(chrom_code, start)?;
+        match raw {
+            None => Ok(None),
+            Some(compressed) => {
+                if let Some(dict) = &self.zstd_dict {
+                    let mut decompressor = zstd::bulk::Decompressor::with_dictionary(dict)
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "failed to create zstd decompressor: {e}"
+                            ))
+                        })?;
+                    let mut decompressed = Vec::with_capacity(4096);
+                    decompress_into_buffer_with_retry(
+                        &mut decompressor,
+                        &compressed,
+                        &mut decompressed,
+                        "zstd decompression failed",
+                    )?;
+                    Ok(Some(decompressed))
+                } else {
+                    Ok(Some(compressed))
+                }
+            }
+        }
+    }
+
+    pub fn create_decompressor(&self) -> Result<Option<zstd::bulk::Decompressor<'static>>> {
+        match &self.zstd_dict {
+            Some(dict) => {
+                let decompressor =
+                    zstd::bulk::Decompressor::with_dictionary(dict).map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "failed to create zstd decompressor: {e}"
+                        ))
+                    })?;
+                Ok(Some(decompressor))
+            }
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_position_entry_fast(
+        &self,
+        chrom_code: u16,
+        start: i64,
+        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
+        buf: &mut Vec<u8>,
+    ) -> Result<bool> {
+        let mut key_buf = Vec::with_capacity(10);
+        super::key_encoding::encode_position_key_buf(chrom_code, start, &mut key_buf);
+        let read_txn = self.begin_read()?;
+        let table = read_txn.open_table(DATA_TABLE).map_err(redb_err)?;
+        let Some(raw) = table.get(key_buf.as_slice()).map_err(redb_err)? else {
+            return Ok(false);
+        };
+        let compressed = raw.value();
+        match decompressor {
+            Some(dec) => {
+                decompress_into_buffer_with_retry(
+                    dec,
+                    compressed,
+                    buf,
+                    "zstd decompression failed",
+                )?;
+            }
+            None => {
+                buf.clear();
+                buf.extend_from_slice(compressed);
+            }
+        }
+        Ok(true)
+    }
+
+    pub fn store_dict(&self, dict_bytes: &[u8]) -> Result<()> {
+        self.put_metadata(ZSTD_DICT_KEY, dict_bytes)
+    }
+
+    pub fn store_zstd_level(&self, level: i32) -> Result<()> {
+        self.put_metadata(ZSTD_LEVEL_KEY, &level.to_le_bytes())
+    }
+
+    pub fn store_contig_codes(&self, mapping: &[(String, u16)]) -> Result<()> {
+        let bytes = super::key_encoding::serialize_contig_codes(mapping);
+        self.put_metadata(CONTIG_CODES_KEY, &bytes)
+    }
+
+    pub fn put_metadata(&self, key: &str, value: &[u8]) -> Result<()> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|e| DataFusionError::Execution(format!("redb write mutex poisoned: {e}")))?;
+        let RedbHandle::Writable(db) = &self.db else {
+            return Err(DataFusionError::Execution(
+                "redb cache was opened read-only; writes are not allowed".to_string(),
+            ));
+        };
+        let db = db.lock().map_err(|e| {
+            DataFusionError::Execution(format!("redb database mutex poisoned: {e}"))
+        })?;
+        let write_txn = db.begin_write().map_err(redb_err)?;
+        {
+            let mut meta = write_txn.open_table(META_TABLE).map_err(redb_err)?;
+            meta.insert(key, value).map_err(redb_err)?;
+        }
+        write_txn.commit().map_err(redb_err)?;
+        Ok(())
+    }
+
+    pub fn get_metadata(&self, key: &str) -> Result<Option<Vec<u8>>> {
+        let read_txn = self.begin_read()?;
+        let table = read_txn.open_table(META_TABLE).map_err(redb_err)?;
+        table
+            .get(key)
+            .map_err(redb_err)
+            .map(|value| value.map(|guard| guard.value().to_vec()))
+    }
+
+    pub fn persist(&self) -> Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn optimize_after_load(&self) -> Result<()> {
+        let RedbHandle::Writable(db) = &self.db else {
+            return Ok(());
+        };
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|e| DataFusionError::Execution(format!("redb write mutex poisoned: {e}")))?;
+        let mut db = db.lock().map_err(|e| {
+            DataFusionError::Execution(format!("redb database mutex poisoned: {e}"))
+        })?;
+        while db.compact().map_err(redb_err)? {}
+        Ok(())
+    }
+
+    fn begin_read(&self) -> Result<ReadTransaction> {
+        match &self.db {
+            RedbHandle::Writable(db) => {
+                let db = db.lock().map_err(|e| {
+                    DataFusionError::Execution(format!("redb database mutex poisoned: {e}"))
+                })?;
+                db.begin_read().map_err(redb_err)
+            }
+            RedbHandle::ReadOnly(db) => db.begin_read().map_err(redb_err),
+        }
+    }
+
+    fn read_metadata(db: &impl ReadableDatabase) -> Result<RedbMetadata> {
+        let read_txn = db.begin_read().map_err(redb_err)?;
+        let meta = read_txn.open_table(META_TABLE).map_err(redb_err)?;
+
+        let schema_raw = meta.get(SCHEMA_KEY).map_err(redb_err)?.ok_or_else(|| {
+            DataFusionError::Execution("redb store missing schema metadata".to_string())
+        })?;
+        let schema = schema_from_ipc_bytes(schema_raw.value())?;
+
+        let version_raw = meta
+            .get(FORMAT_VERSION_KEY)
+            .map_err(redb_err)?
+            .ok_or_else(|| {
+                DataFusionError::Execution("redb cache format metadata missing".to_string())
+            })?;
+        let version = version_raw.value()[0];
+        if version != FORMAT_V0 {
+            return Err(DataFusionError::Execution(format!(
+                "unsupported redb cache format version {version}: only version {FORMAT_V0} is supported"
+            )));
+        }
+
+        let zstd_dict = meta
+            .get(ZSTD_DICT_KEY)
+            .map_err(redb_err)?
+            .map(|raw| Arc::new(raw.value().to_vec()));
+
+        if let Some(raw) = meta.get(CONTIG_CODES_KEY).map_err(redb_err)? {
+            if let Some(mapping) = super::key_encoding::deserialize_contig_codes(raw.value()) {
+                super::key_encoding::load_non_canonical_registry(&mapping);
+            }
+        }
+
+        Ok((schema, version, zstd_dict))
+    }
+}
+
+impl PositionEntryStore for VepRedbStore {
+    fn schema(&self) -> SchemaRef {
+        VepRedbStore::schema(self).clone()
+    }
+
+    fn root_path(&self) -> &Path {
+        VepRedbStore::root_path(self)
+    }
+
+    fn create_decompressor(&self) -> Result<Option<zstd::bulk::Decompressor<'static>>> {
+        VepRedbStore::create_decompressor(self)
+    }
+
+    fn get_position_entry_fast(
+        &self,
+        chrom_code: u16,
+        start: i64,
+        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
+        buf: &mut Vec<u8>,
+    ) -> Result<bool> {
+        VepRedbStore::get_position_entry_fast(self, chrom_code, start, decompressor, buf)
+    }
+}
+
+/// TableProvider backed by a redb read-only VEP variation cache.
+pub struct RedbCacheTableProvider {
+    store: Arc<VepRedbStore>,
+    schema: SchemaRef,
+}
+
+impl RedbCacheTableProvider {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let store = Arc::new(VepRedbStore::open(path)?);
+        let schema = store.schema().clone();
+        Ok(Self { store, schema })
+    }
+
+    pub fn from_store(store: Arc<VepRedbStore>) -> Self {
+        let schema = store.schema().clone();
+        Self { store, schema }
+    }
+
+    pub fn store(&self) -> &Arc<VepRedbStore> {
+        &self.store
+    }
+}
+
+impl Debug for RedbCacheTableProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RedbCacheTableProvider {{ schema: {:?} }}", self.schema)
+    }
+}
+
+#[async_trait]
+impl TableProvider for RedbCacheTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        _projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(DataFusionError::NotImplemented(
+            "Direct scan of RedbCacheTableProvider is not yet supported. \
+             Use lookup_variants() table function instead."
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    fn test_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("variation_name", DataType::Utf8, true),
+            Field::new("allele_string", DataType::Utf8, false),
+        ]))
+    }
+
+    #[test]
+    fn redb_store_reopens_read_only_and_reads_position_entry() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let store = VepRedbStore::create(file.path(), test_schema()).unwrap();
+        store.put_position_entry("1", 100, b"entry").unwrap();
+        store.persist().unwrap();
+        drop(store);
+
+        let reopened = VepRedbStore::open(file.path()).unwrap();
+        assert_eq!(reopened.format_version(), FORMAT_V0);
+        let chrom_code = crate::kv_cache::key_encoding::chrom_to_code("1");
+        let value = reopened
+            .get_position_entry(chrom_code, 100)
+            .unwrap()
+            .unwrap();
+        assert_eq!(value, b"entry");
+    }
+}

--- a/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/redb_store.rs
@@ -19,10 +19,11 @@ use datafusion::datasource::{TableProvider, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
 use redb::{
-    Database, ReadOnlyDatabase, ReadTransaction, ReadableDatabase, ReadableTable, TableDefinition,
+    Database, ReadOnlyDatabase, ReadOnlyTable, ReadTransaction, ReadableDatabase, ReadableTable,
+    TableDefinition,
 };
 
-use super::cache_exec::PositionEntryStore;
+use super::cache_exec::{PositionEntryLookupSession, PositionEntryStore};
 use super::kv_store::{
     FORMAT_V0, decompress_into_buffer_with_retry, schema_from_ipc_bytes, schema_to_ipc_bytes,
 };
@@ -63,8 +64,16 @@ fn redb_err(e: impl std::fmt::Display) -> DataFusionError {
 impl VepRedbStore {
     /// Open an existing redb cache for annotation using `ReadOnlyDatabase`.
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        Self::open_with_cache_size(path, 1024 * 1024 * 1024)
+    }
+
+    /// Open an existing redb cache with a custom page cache size.
+    pub fn open_with_cache_size(path: impl AsRef<Path>, cache_size_bytes: usize) -> Result<Self> {
         let root_path = path.as_ref().to_path_buf();
-        let db = ReadOnlyDatabase::open(&root_path).map_err(redb_err)?;
+        let db = redb::Builder::new()
+            .set_cache_size(cache_size_bytes)
+            .open_read_only(&root_path)
+            .map_err(redb_err)?;
         let (schema, format_version, zstd_dict) = Self::read_metadata(&db)?;
         Ok(Self {
             root_path,
@@ -247,29 +256,16 @@ impl VepRedbStore {
         decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
         buf: &mut Vec<u8>,
     ) -> Result<bool> {
-        let mut key_buf = Vec::with_capacity(10);
-        super::key_encoding::encode_position_key_buf(chrom_code, start, &mut key_buf);
         let read_txn = self.begin_read()?;
         let table = read_txn.open_table(DATA_TABLE).map_err(redb_err)?;
-        let Some(raw) = table.get(key_buf.as_slice()).map_err(redb_err)? else {
-            return Ok(false);
-        };
-        let compressed = raw.value();
-        match decompressor {
-            Some(dec) => {
-                decompress_into_buffer_with_retry(
-                    dec,
-                    compressed,
-                    buf,
-                    "zstd decompression failed",
-                )?;
-            }
-            None => {
-                buf.clear();
-                buf.extend_from_slice(compressed);
-            }
-        }
-        Ok(true)
+        let mut session = RedbPositionEntryLookupSession::new(read_txn, table);
+        session.get_position_entry_fast(chrom_code, start, decompressor, buf)
+    }
+
+    pub(crate) fn begin_position_lookup_session(&self) -> Result<RedbPositionEntryLookupSession> {
+        let read_txn = self.begin_read()?;
+        let table = read_txn.open_table(DATA_TABLE).map_err(redb_err)?;
+        Ok(RedbPositionEntryLookupSession::new(read_txn, table))
     }
 
     pub fn store_dict(&self, dict_bytes: &[u8]) -> Result<()> {
@@ -384,6 +380,53 @@ impl VepRedbStore {
     }
 }
 
+pub(crate) struct RedbPositionEntryLookupSession {
+    _read_txn: ReadTransaction,
+    table: ReadOnlyTable<&'static [u8], &'static [u8]>,
+    key_buf: Vec<u8>,
+}
+
+impl RedbPositionEntryLookupSession {
+    fn new(read_txn: ReadTransaction, table: ReadOnlyTable<&'static [u8], &'static [u8]>) -> Self {
+        Self {
+            _read_txn: read_txn,
+            table,
+            key_buf: Vec::with_capacity(10),
+        }
+    }
+}
+
+impl PositionEntryLookupSession for RedbPositionEntryLookupSession {
+    fn get_position_entry_fast(
+        &mut self,
+        chrom_code: u16,
+        start: i64,
+        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
+        buf: &mut Vec<u8>,
+    ) -> Result<bool> {
+        super::key_encoding::encode_position_key_buf(chrom_code, start, &mut self.key_buf);
+        let Some(raw) = self.table.get(self.key_buf.as_slice()).map_err(redb_err)? else {
+            return Ok(false);
+        };
+        let compressed = raw.value();
+        match decompressor {
+            Some(dec) => {
+                decompress_into_buffer_with_retry(
+                    dec,
+                    compressed,
+                    buf,
+                    "zstd decompression failed",
+                )?;
+            }
+            None => {
+                buf.clear();
+                buf.extend_from_slice(compressed);
+            }
+        }
+        Ok(true)
+    }
+}
+
 impl PositionEntryStore for VepRedbStore {
     fn schema(&self) -> SchemaRef {
         VepRedbStore::schema(self).clone()
@@ -397,14 +440,8 @@ impl PositionEntryStore for VepRedbStore {
         VepRedbStore::create_decompressor(self)
     }
 
-    fn get_position_entry_fast(
-        &self,
-        chrom_code: u16,
-        start: i64,
-        decompressor: Option<&mut zstd::bulk::Decompressor<'_>>,
-        buf: &mut Vec<u8>,
-    ) -> Result<bool> {
-        VepRedbStore::get_position_entry_fast(self, chrom_code, start, decompressor, buf)
+    fn begin_lookup_session(&self) -> Result<Box<dyn PositionEntryLookupSession + '_>> {
+        Ok(Box::new(self.begin_position_lookup_session()?))
     }
 }
 
@@ -523,5 +560,42 @@ mod tests {
             reopened.get_position_entry_raw(&key_200).unwrap().unwrap(),
             b"entry-200"
         );
+    }
+
+    #[test]
+    fn redb_lookup_session_reads_multiple_entries() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let store = VepRedbStore::create(file.path(), test_schema()).unwrap();
+        store
+            .batch_insert_raw(&[
+                (
+                    crate::kv_cache::key_encoding::encode_position_key("1", 100),
+                    b"entry-100".to_vec(),
+                ),
+                (
+                    crate::kv_cache::key_encoding::encode_position_key("1", 200),
+                    b"entry-200".to_vec(),
+                ),
+            ])
+            .unwrap();
+        drop(store);
+
+        let reopened = VepRedbStore::open(file.path()).unwrap();
+        let chrom_code = crate::kv_cache::key_encoding::chrom_to_code("1");
+        let mut session = reopened.begin_position_lookup_session().unwrap();
+        let mut buf = Vec::new();
+
+        assert!(
+            session
+                .get_position_entry_fast(chrom_code, 100, None, &mut buf)
+                .unwrap()
+        );
+        assert_eq!(buf, b"entry-100");
+        assert!(
+            session
+                .get_position_entry_fast(chrom_code, 200, None, &mut buf)
+                .unwrap()
+        );
+        assert_eq!(buf, b"entry-200");
     }
 }

--- a/datafusion/bio-function-vep/src/kv_cache/sift_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/sift_store.rs
@@ -14,8 +14,8 @@ use std::sync::{Arc, Mutex};
 use datafusion::common::{DataFusionError, Result};
 use fjall::{Database, Keyspace, KeyspaceCreateOptions};
 use redb::{
-    Database as RedbDatabase, ReadOnlyDatabase, ReadTransaction, ReadableDatabase, ReadableTable,
-    TableDefinition,
+    Database as RedbDatabase, ReadOnlyDatabase, ReadOnlyTable, ReadTransaction, ReadableDatabase,
+    ReadableTable, TableDefinition,
 };
 
 use crate::transcript_consequence::{CachedPredictions, CompactPrediction};
@@ -185,12 +185,13 @@ impl SiftRedbStore {
 
     /// Retrieve predictions for a transcript. Returns None on miss.
     pub fn get(&self, transcript_id: &str) -> Result<Option<CachedPredictions>> {
+        self.begin_lookup_session()?.get(transcript_id)
+    }
+
+    fn begin_lookup_session(&self) -> Result<SiftRedbLookupSession> {
         let read_txn = self.begin_read()?;
         let table = read_txn.open_table(REDB_SIFT_TABLE).map_err(redb_err)?;
-        let Some(raw) = table.get(transcript_id).map_err(redb_err)? else {
-            return Ok(None);
-        };
-        deserialize_predictions(raw.value()).map(Some)
+        Ok(SiftRedbLookupSession::new(read_txn, table))
     }
 
     fn batch_insert(
@@ -232,6 +233,27 @@ impl SiftRedbStore {
     }
 }
 
+pub(crate) struct SiftRedbLookupSession {
+    _read_txn: ReadTransaction,
+    table: ReadOnlyTable<&'static str, &'static [u8]>,
+}
+
+impl SiftRedbLookupSession {
+    fn new(read_txn: ReadTransaction, table: ReadOnlyTable<&'static str, &'static [u8]>) -> Self {
+        Self {
+            _read_txn: read_txn,
+            table,
+        }
+    }
+
+    pub(crate) fn get(&self, transcript_id: &str) -> Result<Option<CachedPredictions>> {
+        let Some(raw) = self.table.get(transcript_id).map_err(redb_err)? else {
+            return Ok(None);
+        };
+        deserialize_predictions(raw.value()).map(Some)
+    }
+}
+
 /// SIFT/PolyPhen prediction store used by annotation, regardless of backend.
 #[derive(Clone)]
 pub enum SiftPredictionStore {
@@ -239,11 +261,34 @@ pub enum SiftPredictionStore {
     Redb(SiftRedbStore),
 }
 
+pub(crate) enum SiftPredictionLookupSession<'a> {
+    Fjall(&'a SiftKvStore),
+    Redb(Box<SiftRedbLookupSession>),
+}
+
 impl SiftPredictionStore {
     pub fn get(&self, transcript_id: &str) -> Result<Option<CachedPredictions>> {
         match self {
             Self::Fjall(store) => store.get(transcript_id),
             Self::Redb(store) => store.get(transcript_id),
+        }
+    }
+
+    pub(crate) fn begin_lookup_session(&self) -> Result<SiftPredictionLookupSession<'_>> {
+        match self {
+            Self::Fjall(store) => Ok(SiftPredictionLookupSession::Fjall(store)),
+            Self::Redb(store) => store
+                .begin_lookup_session()
+                .map(|session| SiftPredictionLookupSession::Redb(Box::new(session))),
+        }
+    }
+}
+
+impl SiftPredictionLookupSession<'_> {
+    pub(crate) fn get(&self, transcript_id: &str) -> Result<Option<CachedPredictions>> {
+        match self {
+            Self::Fjall(store) => store.get(transcript_id),
+            Self::Redb(session) => session.get(transcript_id),
         }
     }
 }
@@ -460,6 +505,27 @@ mod tests {
         assert_eq!(preds.sift.len(), 2);
         assert_eq!(preds.polyphen.len(), 1);
         assert_eq!(preds.sift[0].position, 10);
+    }
+
+    #[test]
+    fn test_redb_lookup_session_reuses_table_for_multiple_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let redb_path = dir.path().join("translation_sift.redb");
+        let entries = vec![
+            ("ENST00000111111".to_string(), make_predictions()),
+            ("ENST00000222222".to_string(), make_predictions()),
+        ];
+        SiftRedbStore::ingest_sorted(&redb_path, entries.into_iter()).unwrap();
+
+        let store = SiftRedbStore::open_path(&redb_path)
+            .unwrap()
+            .expect("open_path should return Some for a valid redb sift DB");
+        let prediction_store = SiftPredictionStore::Redb(store);
+        let session = prediction_store.begin_lookup_session().unwrap();
+
+        assert!(session.get("ENST00000111111").unwrap().is_some());
+        assert!(session.get("ENST00000222222").unwrap().is_some());
+        assert!(session.get("MISSING").unwrap().is_none());
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/kv_cache/sift_store.rs
+++ b/datafusion/bio-function-vep/src/kv_cache/sift_store.rs
@@ -9,17 +9,26 @@
 //!   [polyphen_count × 10B CompactPrediction]
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use datafusion::common::{DataFusionError, Result};
 use fjall::{Database, Keyspace, KeyspaceCreateOptions};
+use redb::{
+    Database as RedbDatabase, ReadOnlyDatabase, ReadTransaction, ReadableDatabase, ReadableTable,
+    TableDefinition,
+};
 
 use crate::transcript_consequence::{CachedPredictions, CompactPrediction};
 
 const SIFT_KEYSPACE: &str = "sift";
+const REDB_SIFT_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("sift");
 
 fn fjall_err(e: fjall::Error) -> DataFusionError {
     DataFusionError::External(Box::new(e))
+}
+
+fn redb_err(e: impl std::fmt::Display) -> DataFusionError {
+    DataFusionError::Execution(format!("redb error: {e}"))
 }
 
 /// Store for SIFT/PolyPhen predictions keyed by transcript_id.
@@ -121,6 +130,121 @@ impl SiftKvStore {
             return Ok(None);
         };
         deserialize_predictions(&raw).map(Some)
+    }
+}
+
+#[derive(Clone)]
+enum SiftRedbHandle {
+    Writable(Arc<Mutex<RedbDatabase>>),
+    ReadOnly(Arc<ReadOnlyDatabase>),
+}
+
+/// redb-backed SIFT/PolyPhen prediction store keyed by transcript_id.
+#[derive(Clone)]
+pub struct SiftRedbStore {
+    db: SiftRedbHandle,
+}
+
+impl SiftRedbStore {
+    /// Open a standalone redb SIFT database at the given path.
+    pub fn open_path(path: impl AsRef<Path>) -> Result<Option<Self>> {
+        let path = path.as_ref();
+        if !path.exists() {
+            return Ok(None);
+        }
+        let db = ReadOnlyDatabase::open(path).map_err(redb_err)?;
+        Ok(Some(Self {
+            db: SiftRedbHandle::ReadOnly(Arc::new(db)),
+        }))
+    }
+
+    /// Create a writable standalone redb SIFT database.
+    pub fn create(path: impl AsRef<Path>) -> Result<Self> {
+        let db = RedbDatabase::create(path).map_err(redb_err)?;
+        {
+            let write_txn = db.begin_write().map_err(redb_err)?;
+            {
+                let _table = write_txn.open_table(REDB_SIFT_TABLE).map_err(redb_err)?;
+            }
+            write_txn.commit().map_err(redb_err)?;
+        }
+        Ok(Self {
+            db: SiftRedbHandle::Writable(Arc::new(Mutex::new(db))),
+        })
+    }
+
+    /// Bulk-load sorted transcript predictions into a new redb database.
+    pub fn ingest_sorted(
+        path: impl AsRef<Path>,
+        sorted_iter: impl Iterator<Item = (String, CachedPredictions)>,
+    ) -> Result<Self> {
+        let store = Self::create(path)?;
+        store.batch_insert(sorted_iter)?;
+        Ok(store)
+    }
+
+    /// Retrieve predictions for a transcript. Returns None on miss.
+    pub fn get(&self, transcript_id: &str) -> Result<Option<CachedPredictions>> {
+        let read_txn = self.begin_read()?;
+        let table = read_txn.open_table(REDB_SIFT_TABLE).map_err(redb_err)?;
+        let Some(raw) = table.get(transcript_id).map_err(redb_err)? else {
+            return Ok(None);
+        };
+        deserialize_predictions(raw.value()).map(Some)
+    }
+
+    fn batch_insert(
+        &self,
+        sorted_iter: impl Iterator<Item = (String, CachedPredictions)>,
+    ) -> Result<()> {
+        let SiftRedbHandle::Writable(db) = &self.db else {
+            return Err(DataFusionError::Execution(
+                "redb sift store was opened read-only; writes are not allowed".to_string(),
+            ));
+        };
+        let db = db.lock().map_err(|e| {
+            DataFusionError::Execution(format!("redb sift database mutex poisoned: {e}"))
+        })?;
+        let write_txn = db.begin_write().map_err(redb_err)?;
+        {
+            let mut table = write_txn.open_table(REDB_SIFT_TABLE).map_err(redb_err)?;
+            for (transcript_id, preds) in sorted_iter {
+                let value = serialize_predictions(&preds);
+                table
+                    .insert(transcript_id.as_str(), value.as_slice())
+                    .map_err(redb_err)?;
+            }
+        }
+        write_txn.commit().map_err(redb_err)?;
+        Ok(())
+    }
+
+    fn begin_read(&self) -> Result<ReadTransaction> {
+        match &self.db {
+            SiftRedbHandle::Writable(db) => {
+                let db = db.lock().map_err(|e| {
+                    DataFusionError::Execution(format!("redb sift database mutex poisoned: {e}"))
+                })?;
+                db.begin_read().map_err(redb_err)
+            }
+            SiftRedbHandle::ReadOnly(db) => db.begin_read().map_err(redb_err),
+        }
+    }
+}
+
+/// SIFT/PolyPhen prediction store used by annotation, regardless of backend.
+#[derive(Clone)]
+pub enum SiftPredictionStore {
+    Fjall(SiftKvStore),
+    Redb(SiftRedbStore),
+}
+
+impl SiftPredictionStore {
+    pub fn get(&self, transcript_id: &str) -> Result<Option<CachedPredictions>> {
+        match self {
+            Self::Fjall(store) => store.get(transcript_id),
+            Self::Redb(store) => store.get(transcript_id),
+        }
     }
 }
 
@@ -309,6 +433,26 @@ mod tests {
         let store = SiftKvStore::open_path(dir.path())
             .unwrap()
             .expect("open_path should return Some for a valid sift DB");
+        let preds = store
+            .get("ENST00000111111")
+            .unwrap()
+            .expect("predictions should be present");
+        assert_eq!(preds.sift.len(), 2);
+        assert_eq!(preds.polyphen.len(), 1);
+        assert_eq!(preds.sift[0].position, 10);
+    }
+
+    #[test]
+    fn test_redb_open_path_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let redb_path = dir.path().join("translation_sift.redb");
+
+        let entries = vec![("ENST00000111111".to_string(), make_predictions())];
+        SiftRedbStore::ingest_sorted(&redb_path, entries.into_iter()).unwrap();
+
+        let store = SiftRedbStore::open_path(&redb_path)
+            .unwrap()
+            .expect("open_path should return Some for a valid redb sift DB");
         let preds = store
             .get("ENST00000111111")
             .unwrap()

--- a/datafusion/bio-function-vep/src/lookup_provider.rs
+++ b/datafusion/bio-function-vep/src/lookup_provider.rs
@@ -228,18 +228,39 @@ impl TableProvider for LookupProvider {
         #[cfg(feature = "kv-cache")]
         {
             use crate::allele::allele_matches;
-            use crate::kv_cache::KvCacheTableProvider;
             use crate::kv_cache::cache_exec::{KvLookupExec, KvMatchMode};
+            use crate::kv_cache::{
+                KvCacheTableProvider, PositionCacheTableProvider, RedbCacheTableProvider,
+            };
 
             let table_ref = tokio::task::block_in_place(|| {
                 tokio::runtime::Handle::current()
                     .block_on(self.session.table_provider(&self.cache_table))
             });
             if let Ok(provider) = table_ref {
-                if let Some(kv_provider) = provider.as_any().downcast_ref::<KvCacheTableProvider>()
-                {
-                    let store = kv_provider.store().clone();
+                let store: Option<Arc<dyn crate::kv_cache::cache_exec::PositionEntryStore>> =
+                    if let Some(kv_provider) =
+                        provider.as_any().downcast_ref::<KvCacheTableProvider>()
+                    {
+                        Some(kv_provider.store().clone())
+                    } else {
+                        if let Some(position_provider) = provider
+                            .as_any()
+                            .downcast_ref::<PositionCacheTableProvider>()
+                        {
+                            Some(position_provider.store().clone())
+                        } else {
+                            provider
+                                .as_any()
+                                .downcast_ref::<RedbCacheTableProvider>()
+                                .map(|redb_provider| {
+                                    redb_provider.store().clone()
+                                        as Arc<dyn crate::kv_cache::cache_exec::PositionEntryStore>
+                                })
+                        }
+                    };
 
+                if let Some(store) = store {
                     let vcf_has_chr = has_chr_prefix(&self.session, &self.vcf_table).await?;
 
                     let vcf_df = self.session.table(&self.vcf_table).await?;
@@ -330,7 +351,8 @@ mod tests {
     use crate::create_vep_session;
     #[cfg(feature = "kv-cache")]
     use crate::kv_cache::{
-        KvCacheTableProvider, VepKvStore, position_entry::serialize_position_entry,
+        KvCacheTableProvider, RedbCacheTableProvider, VepKvStore, VepRedbStore,
+        position_entry::serialize_position_entry,
     };
     use datafusion::arrow::array::{
         Array, ArrayRef, Int64Array, RecordBatch, StringArray, StringViewArray,
@@ -557,6 +579,85 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&cache_dir);
+    }
+
+    #[cfg(feature = "kv-cache")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_lookup_dispatches_to_kv_exec_for_redb_cache_provider() {
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_data", Arc::new(vcf_table()))
+            .unwrap();
+
+        let cache_schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("variation_name", DataType::Utf8, true),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("clin_sig", DataType::Utf8, true),
+            Field::new("failed", DataType::Int64, false),
+        ]));
+
+        let cache_batch = RecordBatch::try_new(
+            cache_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1"])),
+                Arc::new(Int64Array::from(vec![100])),
+                Arc::new(Int64Array::from(vec![101])),
+                Arc::new(StringArray::from(vec!["rs_redb"])),
+                Arc::new(StringArray::from(vec!["A/G"])),
+                Arc::new(StringArray::from(vec!["benign"])),
+                Arc::new(Int64Array::from(vec![0])),
+            ],
+        )
+        .unwrap();
+
+        let entry = serialize_position_entry(&[0], &cache_batch, &[2, 3, 4, 5, 6], 4).unwrap();
+        let cache_path = unique_temp_dir("vep-redb-dispatch").with_extension("redb");
+
+        let store = VepRedbStore::create(&cache_path, cache_schema).unwrap();
+        store.put_position_entry("1", 100, &entry).unwrap();
+        store.persist().unwrap();
+        drop(store);
+
+        let redb_provider = RedbCacheTableProvider::open(&cache_path).unwrap();
+        ctx.register_table("var_cache", Arc::new(redb_provider))
+            .unwrap();
+
+        let df = ctx
+            .sql(
+                "SELECT * FROM lookup_variants('vcf_data', 'var_cache', 'variation_name,clin_sig')",
+            )
+            .await
+            .unwrap();
+
+        let plan = df.clone().create_physical_plan().await.unwrap();
+        let plan_str = displayable(plan.as_ref()).indent(true).to_string();
+        assert!(
+            plan_str.contains("KvLookupExec"),
+            "Expected KvLookupExec in plan for redb provider, got:\n{plan_str}"
+        );
+        assert!(
+            !plan_str.contains("IntervalJoinExec"),
+            "Did not expect IntervalJoinExec for redb provider, got:\n{plan_str}"
+        );
+
+        let batches = df.collect().await.unwrap();
+        let mut annotations = Vec::new();
+        for batch in &batches {
+            let col = batch.column_by_name("cache_variation_name").unwrap();
+            for value in string_values(col) {
+                if let Some(v) = value {
+                    annotations.push(v);
+                }
+            }
+        }
+        assert!(
+            annotations.contains(&"rs_redb".to_string()),
+            "Expected annotation from redb cache, got: {annotations:?}"
+        );
+
+        let _ = std::fs::remove_file(&cache_path);
     }
 
     #[cfg(feature = "kv-cache")]

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -47,6 +47,8 @@ pub struct AnnotateVcfConfig {
     pub reference_fasta_path: Option<String>,
     /// Use fjall KV store for variation lookup + SIFT.
     pub use_fjall: bool,
+    /// Use redb KV store for variation lookup.
+    pub use_redb: bool,
     /// Enable HGVS notation.
     pub hgvs: bool,
     /// Enable transcript HGVS notation explicitly.
@@ -102,6 +104,7 @@ impl Default for AnnotateVcfConfig {
             extended_probes: false,
             reference_fasta_path: None,
             use_fjall: false,
+            use_redb: false,
             hgvs: false,
             hgvsc: false,
             hgvsp: false,
@@ -172,6 +175,9 @@ impl AnnotateVcfConfig {
         }
         if self.use_fjall {
             opts.insert("use_fjall".into(), serde_json::Value::Bool(true));
+        }
+        if self.use_redb {
+            opts.insert("use_redb".into(), serde_json::Value::Bool(true));
         }
         if self.hgvs {
             opts.insert("hgvs".into(), serde_json::Value::Bool(true));


### PR DESCRIPTION
## Summary
- add a redb-backed VEP variation cache store/provider, using `ReadOnlyDatabase` for annotation-time reads
- share KV lookup execution across fjall/redb and add redb cache-loader support
- wire CLI/examples/docs for selecting `redb` and using `<cache_dir>/variation.redb`

## Test Plan
- `cargo check -p datafusion-bio-function-vep --features kv-cache --examples`
- `cargo test -p datafusion-bio-function-vep --features kv-cache`