### PR TITLE
feat: Add VEP cache source metadata mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c3f611769b05b007e315eed310fcab2c47b636cb#c3f611769b05b007e315eed310fcab2c47b636cb"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=8554b5de4689cf5bcee15d6252759ff198b19f4f#8554b5de4689cf5bcee15d6252759ff198b19f4f"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c3f611769b05b007e315eed310fcab2c47b636cb#c3f611769b05b007e315eed310fcab2c47b636cb"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=8554b5de4689cf5bcee15d6252759ff198b19f4f#8554b5de4689cf5bcee15d6252759ff198b19f4f"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +459,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "autocfg"
@@ -536,7 +558,7 @@ dependencies = [
  "itertools",
  "itertools-num",
  "multimap",
- "ndarray",
+ "ndarray 0.16.1",
  "newtype_derive",
  "num-integer",
  "num-traits",
@@ -629,6 +651,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "blosc-src"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9046dd58971db0226346fde214143d16a6eb12f535b5320d0ea94fcea420631"
+dependencies = [
+ "cc",
+ "libz-sys",
+ "lz4-sys",
+ "snappy_src",
+ "zstd-sys",
+]
+
+[[package]]
+name = "blusc"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e0c17eaa785d2673fe58c22fc817946c2330ed47f3d9f79835d65950d32a45"
+dependencies = [
+ "flate2",
+ "lz4_flex 0.12.1",
+ "pkg-config",
+ "snap",
+ "zstd",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +734,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -860,6 +922,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +973,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -961,6 +1041,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -1167,31 +1257,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc6a6fc26c4300402d9283d69d9d521e96abc60#5fc6a6fc26c4300402d9283d69d9d521e96abc60"
-dependencies = [
- "async-compression",
- "bytes",
- "datafusion",
- "datafusion-execution",
- "futures",
- "log",
- "noodles 0.93.0",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
- "opendal 0.55.0",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "datafusion-bio-format-core"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=8554b5de4689cf5bcee15d6252759ff198b19f4f#8554b5de4689cf5bcee15d6252759ff198b19f4f"
+version = "1.7.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4010e1c34f343de3b099f832560075d0fbf93c9d#4010e1c34f343de3b099f832560075d0fbf93c9d"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1213,12 +1280,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=8554b5de4689cf5bcee15d6252759ff198b19f4f#8554b5de4689cf5bcee15d6252759ff198b19f4f"
+version = "1.7.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4010e1c34f343de3b099f832560075d0fbf93c9d#4010e1c34f343de3b099f832560075d0fbf93c9d"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.6.0",
+ "datafusion-bio-format-core 1.7.0",
  "datafusion-execution",
  "flate2",
  "log",
@@ -1231,15 +1298,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.4.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc6a6fc26c4300402d9283d69d9d521e96abc60#5fc6a6fc26c4300402d9283d69d9d521e96abc60"
+version = "1.7.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=4010e1c34f343de3b099f832560075d0fbf93c9d#4010e1c34f343de3b099f832560075d0fbf93c9d"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.4.0",
+ "datafusion-bio-format-core 1.7.0",
  "datafusion-execution",
  "env_logger",
  "flate2",
@@ -1256,6 +1323,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "zarrs",
 ]
 
 [[package]]
@@ -1950,6 +2018,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "rustc_version 0.4.1",
+ "syn 2.0.117",
+ "unicode-xid 0.2.6",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2203,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2299,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -2392,6 +2510,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
@@ -2414,7 +2533,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2422,6 +2541,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2748,6 +2872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3176,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +3258,16 @@ dependencies = [
  "tempfile",
  "varint-rs",
  "xxhash-rust",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -3192,6 +3365,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "monostate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4cc965c89dd0615a9e822ff8002f7633d2466143d51bd58693e4b2c75aabad"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f5b99488110875b5904839d396c2cdfaf241ff6622638acb879cc7effad5de"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,6 +3434,21 @@ name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -3697,6 +3924,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -4020,6 +4248,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4084,6 +4328,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
@@ -4216,6 +4466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "positioned-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,8 +4605,10 @@ version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
 dependencies = [
+ "ahash",
  "equivalent",
  "hashbrown 0.16.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4508,6 +4771,35 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rayon_iter_concurrent_limit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d09ee01023de07fa073ce14c37cbe0a9e099c6b0b60a29cf4af6d04d9553fed7"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "recursive"
@@ -5123,11 +5415,23 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5251,6 +5555,16 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "snappy_src"
+version = "0.2.5+snappy.1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1432067a55bcfb1fd522d2aca6537a4fcea32bba87ea86921226d14f9bad53"
+dependencies = [
+ "cc",
+ "link-cplusplus",
+]
 
 [[package]]
 name = "socket2"
@@ -5410,6 +5724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5460,6 +5780,15 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -5755,6 +6084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "unsafe_cell_slice"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6659959f702dcdaad77bd6e42a9409a32ceccc06943ec93c8a4306be00eb6cf1"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5807,6 +6142,12 @@ name = "varint-rs"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -6030,6 +6371,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6037,6 +6394,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -6467,6 +6830,198 @@ dependencies = [
  "quote 1.0.45",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zarrs"
+version = "0.23.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251f4ec1a9e60ca9c693ade9b29a0b981a61e68ea3e2ae85fa9da31bcdca5dbe"
+dependencies = [
+ "async-lock",
+ "base64",
+ "blosc-src",
+ "blusc",
+ "bytemuck",
+ "bytes",
+ "crc32c",
+ "derive_more",
+ "flate2",
+ "getrandom 0.3.4",
+ "half",
+ "inventory",
+ "itertools",
+ "itoa",
+ "libz-sys",
+ "log",
+ "lru",
+ "moka",
+ "ndarray 0.17.2",
+ "num",
+ "num-complex",
+ "paste",
+ "quick_cache",
+ "rayon",
+ "rayon_iter_concurrent_limit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "thread_local",
+ "unsafe_cell_slice",
+ "uuid",
+ "zarrs_chunk_grid",
+ "zarrs_chunk_key_encoding",
+ "zarrs_codec",
+ "zarrs_data_type",
+ "zarrs_filesystem",
+ "zarrs_metadata",
+ "zarrs_metadata_ext",
+ "zarrs_plugin",
+ "zarrs_storage",
+ "zstd",
+]
+
+[[package]]
+name = "zarrs_chunk_grid"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf67386fd96a0336cd3e5ab5ca6cb14e0e05aee80f1acae8c4d3cf562a8bb65"
+dependencies = [
+ "derive_more",
+ "inventory",
+ "itertools",
+ "rayon",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "zarrs_metadata",
+ "zarrs_plugin",
+]
+
+[[package]]
+name = "zarrs_chunk_key_encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040e7feaa92d1904d492acd0cd91b97214f1791c5b5738e6c05b2ca4145a382"
+dependencies = [
+ "derive_more",
+ "inventory",
+ "zarrs_metadata",
+ "zarrs_plugin",
+ "zarrs_storage",
+]
+
+[[package]]
+name = "zarrs_codec"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383a129a6a0cbb2c80cdba23809e5cab85159756464b7d0f112468a495c128da"
+dependencies = [
+ "async-trait",
+ "bytemuck",
+ "derive_more",
+ "futures",
+ "inventory",
+ "itertools",
+ "rayon",
+ "thiserror 2.0.18",
+ "unsafe_cell_slice",
+ "zarrs_chunk_grid",
+ "zarrs_data_type",
+ "zarrs_metadata",
+ "zarrs_plugin",
+ "zarrs_storage",
+]
+
+[[package]]
+name = "zarrs_data_type"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc7c594c9363278fcd9db4c205514f009944206eb093ea7ad40b85f50009f31"
+dependencies = [
+ "derive_more",
+ "half",
+ "inventory",
+ "num",
+ "paste",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "zarrs_metadata",
+ "zarrs_plugin",
+]
+
+[[package]]
+name = "zarrs_filesystem"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "270efeb0181651aee5460b3232f2fc83e91bd646cefe75001d1c8f9a4f3abf81"
+dependencies = [
+ "bytes",
+ "derive_more",
+ "itertools",
+ "libc",
+ "page_size",
+ "pathdiff",
+ "positioned-io",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zarrs_storage",
+]
+
+[[package]]
+name = "zarrs_metadata"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60c4c363a8a302d7babb3c29017850a7b4e0af6ca5f9ba2946263a185b62fea"
+dependencies = [
+ "derive_more",
+ "half",
+ "monostate",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "zarrs_metadata_ext"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2048e07848ca99c7450518e0584929300b1b6a3cf442f18b26ffd3520814bd5b"
+dependencies = [
+ "derive_more",
+ "monostate",
+ "num",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "zarrs_metadata",
+]
+
+[[package]]
+name = "zarrs_plugin"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbe0ed432aee86856f70ca33be36eaf4a0dae21ab730750d9280a7ca1e95046"
+dependencies = [
+ "paste",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "zarrs_storage"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d098796d2ed4cf94896569615101e0432e870a7665396da5cc32300fb68f7c1"
+dependencies = [
+ "auto_impl",
+ "bytes",
+ "derive_more",
+ "itertools",
+ "thiserror 2.0.18",
+ "unsafe_cell_slice",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3#ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c3f611769b05b007e315eed310fcab2c47b636cb#c3f611769b05b007e315eed310fcab2c47b636cb"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.6.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3#ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c3f611769b05b007e315eed310fcab2c47b636cb#c3f611769b05b007e315eed310fcab2c47b636cb"
 dependencies = [
  "async-trait",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,29 +1167,6 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=ab1f2a5#ab1f2a51d1725bb3bdc4fc1df2745ad698b076dd"
-dependencies = [
- "async-compression",
- "bytes",
- "datafusion",
- "datafusion-execution",
- "futures",
- "log",
- "noodles 0.93.0",
- "noodles-bgzf 0.36.0",
- "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
- "noodles-sam 0.78.0",
- "opendal 0.55.0",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "datafusion-bio-format-core"
 version = "1.4.0"
 source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=5fc6a6fc26c4300402d9283d69d9d521e96abc60#5fc6a6fc26c4300402d9283d69d9d521e96abc60"
 dependencies = [
@@ -1212,13 +1189,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-bio-format-core"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3#ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3"
+dependencies = [
+ "async-compression",
+ "bytes",
+ "datafusion",
+ "datafusion-execution",
+ "futures",
+ "log",
+ "noodles 0.93.0",
+ "noodles-bgzf 0.36.0",
+ "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=da905fff4909ada93e407c780456332fe113858b)",
+ "noodles-sam 0.78.0",
+ "opendal 0.55.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.3.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=ab1f2a5#ab1f2a51d1725bb3bdc4fc1df2745ad698b076dd"
+version = "1.6.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3#ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.3.1",
+ "datafusion-bio-format-core 1.6.0",
  "datafusion-execution",
  "flate2",
  "log",

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -26,7 +26,7 @@ noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "56", features = ["arrow"] }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc6a6fc26c4300402d9283d69d9d521e96abc60" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3", optional = true }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c3f611769b05b007e315eed310fcab2c47b636cb", optional = true }
 indicatif = "0.18.4"
 
 [dev-dependencies]

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -26,7 +26,7 @@ noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "56", features = ["arrow"] }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc6a6fc26c4300402d9283d69d9d521e96abc60" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "ab1f2a5", optional = true }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3", optional = true }
 indicatif = "0.18.4"
 
 [dev-dependencies]

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -25,8 +25,8 @@ serde_json = "1"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "56", features = ["arrow"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc6a6fc26c4300402d9283d69d9d521e96abc60" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "8554b5de4689cf5bcee15d6252759ff198b19f4f", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4010e1c34f343de3b099f832560075d0fbf93c9d" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "4010e1c34f343de3b099f832560075d0fbf93c9d", optional = true }
 indicatif = "0.18.4"
 
 [dev-dependencies]

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -26,7 +26,7 @@ noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "56", features = ["arrow"] }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "5fc6a6fc26c4300402d9283d69d9d521e96abc60" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c3f611769b05b007e315eed310fcab2c47b636cb", optional = true }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "8554b5de4689cf5bcee15d6252759ff198b19f4f", optional = true }
 indicatif = "0.18.4"
 
 [dev-dependencies]

--- a/datafusion/bio-function-vep/README.md
+++ b/datafusion/bio-function-vep/README.md
@@ -60,12 +60,45 @@ SELECT * FROM annotate_vep(
 | `extended_probes` | Interval-overlap fallback for shifted indels | No |
 | `reference_fasta_path` | Indexed FASTA for HGVS genomic shifting | No |
 | `partitioned` | Use per-chromosome partitioned cache | No |
-| `refseq` | Use RefSeq cache/transcripts and emit RefSeq CSQ fields (`REFSEQ_MATCH`, `REFSEQ_OFFSET`, `GIVEN_REF`, `USED_REF`, `BAM_EDIT`) | No |
-| `merged` | Use VEP `--merged` Ensembl+RefSeq cache and emit RefSeq/source CSQ fields | No |
 | `gencode_basic` | Restrict consequences to transcripts with `gencode_basic` attribute | No |
 | `gencode_primary` | Restrict consequences to transcripts with `gencode_primary` attribute | No |
 | `all_refseq` | Keep all RefSeq cache transcripts, including CCDS/EST-style rows | No |
 | `exclude_predicted` | Exclude predicted RefSeq transcripts (`XM_` / `XR_`) | No |
+
+`refseq` and `merged` are not accepted as `options_json` source selectors.
+Cache source mode is read from Arrow schema metadata
+`bio.vep.cache_source_type = ensembl | merged | refseq`, written by the cache
+exporter on variation, transcript, exon, translation, regulatory, and motif
+tables.
+
+### Cache Source Modes and Transcript Filtering
+
+Transcript filtering follows Ensembl VEP release/115 source-mode behavior. The
+cache source mode is authoritative at the table schema level, mirroring VEP's
+cache-dir `source_type()` resolution for `ensembl`, `refseq`, and `merged`
+sources:
+https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/CacheDir.pm#L491-L510
+
+VEP's shared transcript filter first requires a stable ID and applies
+`gencode_basic` / `gencode_primary` filters before source-specific RefSeq
+logic:
+https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm#L195-L210
+
+| Cache source metadata | Transcript filtering logic | Ensembl VEP reference |
+|-----------------------|----------------------------|-----------------------|
+| `ensembl` | Keep transcripts with a non-empty stable ID after common filters. There is no `ENST*`-only filter in VEP release/115 for Ensembl mode. | VEP returns accepted transcripts after the common filters when the RefSeq condition does not apply: https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm#L216-L230 |
+| `refseq` | With `all_refseq=false`, keep default RefSeq stable IDs matching VEP's RefSeq whitelist, including mitochondrial exceptions and display-xref fallback. With `all_refseq=true`, bypass that whitelist after common filters. | The RefSeq whitelist is guarded by `source_type eq 'refseq'`: https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm#L216-L224 |
+| `merged` | Keep non-RefSeq-source rows after common filters. For rows whose normalized source is `RefSeq`, apply the same RefSeq whitelist as RefSeq mode unless `all_refseq=true`. | VEP merged cache generation marks each row `_source_cache = Ensembl` or `_source_cache = RefSeq`: https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/Pipeline/DumpVEP/MergeVEP.pm#L102-L114, and the filter applies RefSeq logic only for merged RefSeq rows: https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/AnnotationType/Transcript.pm#L216-L224 |
+
+`exclude_predicted` matches VEP's configured transcript filter for predicted
+RefSeq accessions (`not stable_id match ^X._`):
+https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/Config.pm#L555-L558
+
+The CSQ `SOURCE` field is populated only for `merged` cache mode, matching VEP's
+merged output field set and `_source_cache` emission:
+https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/Constants.pm#L97-L98
+and
+https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1530-L1531
 
 ## Output Modes
 

--- a/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
+++ b/datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs
@@ -631,12 +631,6 @@ fn build_options_json(args: &Args) -> Result<Option<String>> {
             entries.push("\"max_af\":true".to_string());
             entries.push("\"pubmed\":true".to_string());
         }
-        if args.refseq {
-            entries.push("\"refseq\":true".to_string());
-        }
-        if args.merged {
-            entries.push("\"merged\":true".to_string());
-        }
         if args.gencode_basic {
             entries.push("\"gencode_basic\":true".to_string());
         }

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -82,6 +82,7 @@ use crate::allele::{
     MatchedVariantAllele, vcf_to_vep_allele, vcf_to_vep_input_allele, vep_norm_end, vep_norm_start,
 };
 use crate::annotation_store::{AnnotationBackend, build_store};
+use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
 use crate::config;
 #[cfg(feature = "kv-cache")]
 use crate::kv_cache::KvCacheTableProvider;
@@ -1380,16 +1381,8 @@ impl HgvsFlags {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-enum TranscriptSourceMode {
-    #[default]
-    Ensembl,
-    RefSeq,
-    Merged,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct TranscriptSelectionFlags {
-    source_mode: TranscriptSourceMode,
+    cache_source_type: CacheSourceType,
     gencode_basic: bool,
     gencode_primary: bool,
     all_refseq: bool,
@@ -1397,35 +1390,21 @@ struct TranscriptSelectionFlags {
 }
 
 impl TranscriptSelectionFlags {
-    fn from_options_json(options_json: Option<&str>) -> Result<Self> {
+    fn from_options_json(
+        cache_source_type: CacheSourceType,
+        options_json: Option<&str>,
+    ) -> Result<Self> {
         let parse = |key| {
             options_json
                 .and_then(|opts| AnnotateProvider::parse_json_bool_option(opts, key))
                 .unwrap_or(false)
         };
 
-        let refseq = parse("refseq");
-        let merged = parse("merged");
         let gencode_basic = parse("gencode_basic");
         let gencode_primary = parse("gencode_primary");
         let all_refseq = parse("all_refseq");
         let exclude_predicted = parse("exclude_predicted");
 
-        if refseq && merged {
-            return Err(DataFusionError::Execution(
-                "annotate_vep(): --refseq and --merged are mutually exclusive".to_string(),
-            ));
-        }
-        if refseq && gencode_basic {
-            return Err(DataFusionError::Execution(
-                "annotate_vep(): --refseq and --gencode_basic are mutually exclusive".to_string(),
-            ));
-        }
-        if refseq && gencode_primary {
-            return Err(DataFusionError::Execution(
-                "annotate_vep(): --refseq and --gencode_primary are mutually exclusive".to_string(),
-            ));
-        }
         if gencode_basic && gencode_primary {
             return Err(DataFusionError::Execution(
                 "annotate_vep(): --gencode_basic and --gencode_primary are mutually exclusive"
@@ -1433,27 +1412,19 @@ impl TranscriptSelectionFlags {
             ));
         }
 
-        let source_mode = if merged {
-            TranscriptSourceMode::Merged
-        } else if refseq {
-            TranscriptSourceMode::RefSeq
-        } else {
-            TranscriptSourceMode::Ensembl
-        };
-
-        if source_mode == TranscriptSourceMode::Ensembl && all_refseq {
+        if cache_source_type == CacheSourceType::Ensembl && all_refseq {
             return Err(DataFusionError::Execution(
-                "annotate_vep(): --all_refseq requires --refseq or --merged".to_string(),
+                "annotate_vep(): --all_refseq requires cache schema metadata bio.vep.cache_source_type='refseq' or 'merged'".to_string(),
             ));
         }
-        if source_mode == TranscriptSourceMode::Ensembl && exclude_predicted {
+        if cache_source_type == CacheSourceType::Ensembl && exclude_predicted {
             return Err(DataFusionError::Execution(
-                "annotate_vep(): --exclude_predicted requires --refseq or --merged".to_string(),
+                "annotate_vep(): --exclude_predicted requires cache schema metadata bio.vep.cache_source_type='refseq' or 'merged'".to_string(),
             ));
         }
 
         Ok(Self {
-            source_mode,
+            cache_source_type,
             gencode_basic,
             gencode_primary,
             all_refseq,
@@ -1462,18 +1433,18 @@ impl TranscriptSelectionFlags {
     }
 
     fn merged(self) -> bool {
-        self.source_mode == TranscriptSourceMode::Merged
+        self.cache_source_type == CacheSourceType::Merged
     }
 
     fn refseq_fields(self) -> bool {
         matches!(
-            self.source_mode,
-            TranscriptSourceMode::RefSeq | TranscriptSourceMode::Merged
+            self.cache_source_type,
+            CacheSourceType::RefSeq | CacheSourceType::Merged
         )
     }
 
     fn source_field(self) -> bool {
-        self.source_mode == TranscriptSourceMode::Merged
+        self.cache_source_type == CacheSourceType::Merged
     }
 }
 
@@ -1576,8 +1547,8 @@ impl CsqPlaceholderLayout {
     ) -> Self {
         let fields = crate::golden_benchmark::csq_field_names_for_mode_with_pick(
             everything,
-            transcript_selection.source_mode == TranscriptSourceMode::RefSeq,
-            transcript_selection.source_mode == TranscriptSourceMode::Merged,
+            transcript_selection.cache_source_type == CacheSourceType::RefSeq,
+            transcript_selection.cache_source_type == CacheSourceType::Merged,
             include_pick,
         )
         .into_iter()
@@ -2900,6 +2871,7 @@ pub struct AnnotateProvider {
     vcf_table: String,
     cache_source: String,
     backend: AnnotationBackend,
+    cache_source_type: CacheSourceType,
     options_json: Option<String>,
     transcript_selection: TranscriptSelectionFlags,
     pick_flags: PickFlags,
@@ -2909,16 +2881,19 @@ pub struct AnnotateProvider {
 }
 
 impl AnnotateProvider {
-    pub fn new(
+    pub(crate) fn new(
         session: Arc<SessionContext>,
         vcf_table: String,
         cache_source: String,
         backend: AnnotationBackend,
+        cache_source_type: CacheSourceType,
         options_json: Option<String>,
         vcf_schema: Schema,
     ) -> Result<Self> {
-        let transcript_selection =
-            TranscriptSelectionFlags::from_options_json(options_json.as_deref())?;
+        let transcript_selection = TranscriptSelectionFlags::from_options_json(
+            cache_source_type,
+            options_json.as_deref(),
+        )?;
         let pick_flags = PickFlags::from_options_json(options_json.as_deref())?;
         let include_pick_output = pick_flags.include_pick_output();
         let annotation_column_defs =
@@ -2955,6 +2930,7 @@ impl AnnotateProvider {
             vcf_table,
             cache_source,
             backend,
+            cache_source_type,
             options_json,
             transcript_selection,
             pick_flags,
@@ -4343,6 +4319,7 @@ impl AnnotateProvider {
             translations_sift_table: translations_sift_table.map(|s| s.to_string()),
             flags,
             hgvs_flags,
+            cache_source_type: self.cache_source_type,
             transcript_selection,
             pick_flags,
             allowed_failed,
@@ -6336,12 +6313,30 @@ fn is_ensembl_transcript(tx: &TranscriptFeature) -> bool {
     tx.source.as_deref() == Some("Ensembl") || tx.transcript_id.starts_with("ENST")
 }
 
+fn is_ensembl_transcript_id(id: &str) -> bool {
+    id.starts_with("ENST")
+}
+
+fn row_source_is_refseq(tx: &TranscriptFeature) -> bool {
+    tx.source_cache
+        .as_deref()
+        .or(tx.source.as_deref())
+        .and_then(normalize_source_label)
+        .as_deref()
+        == Some("RefSeq")
+}
+
+fn is_standard_refseq_accession(id: &str) -> bool {
+    let bytes = id.as_bytes();
+    bytes.len() >= 4
+        && bytes[0].is_ascii_uppercase()
+        && bytes[1].is_ascii_uppercase()
+        && bytes[2] == b'_'
+        && bytes[3].is_ascii_digit()
+}
+
 fn is_refseq_transcript(tx: &TranscriptFeature) -> bool {
-    tx.source.as_deref() == Some("RefSeq")
-        || matches!(
-            tx.transcript_id.as_bytes().get(..2),
-            Some(b"NM") | Some(b"NR") | Some(b"XM") | Some(b"XR")
-        )
+    row_source_is_refseq(tx) || is_standard_refseq_accession(&tx.transcript_id)
 }
 
 fn is_refseq_offset_transcript(tx: &TranscriptFeature) -> bool {
@@ -6407,12 +6402,7 @@ fn is_mitochondrial_chrom(chrom: &str) -> bool {
 
 fn is_default_refseq_transcript_id(tx: &TranscriptFeature) -> bool {
     let id = tx.transcript_id.as_str();
-    let starts_with_refseq_accession = id.len() >= 4
-        && id.as_bytes()[0].is_ascii_uppercase()
-        && id.as_bytes()[1].is_ascii_uppercase()
-        && id.as_bytes()[2] == b'_'
-        && id.as_bytes()[3].is_ascii_digit();
-    if starts_with_refseq_accession {
+    if is_standard_refseq_accession(id) {
         return true;
     }
 
@@ -6430,14 +6420,9 @@ fn is_default_refseq_transcript_id(tx: &TranscriptFeature) -> bool {
     }
 
     tx.display_xref_id.as_deref().is_some_and(|display_id| {
-        let is_refseq_accession = display_id.len() >= 4
-            && display_id.as_bytes()[0].is_ascii_uppercase()
-            && display_id.as_bytes()[1].is_ascii_uppercase()
-            && display_id.as_bytes()[2] == b'_'
-            && display_id.as_bytes()[3].is_ascii_digit();
         let is_mt_display_id =
             display_id.len() == 4 && display_id.chars().all(|ch| ch.is_ascii_digit());
-        is_refseq_accession || is_mt_display_id
+        is_standard_refseq_accession(display_id) || is_mt_display_id
     })
 }
 
@@ -6459,17 +6444,16 @@ fn passes_transcript_selection(
         return false;
     }
 
-    match selection.source_mode {
-        TranscriptSourceMode::Ensembl => is_ensembl_transcript(tx),
-        TranscriptSourceMode::RefSeq => {
-            is_refseq_transcript(tx)
-                && (selection.all_refseq || is_default_refseq_transcript_id(tx))
-        }
-        TranscriptSourceMode::Merged => {
-            if is_refseq_transcript(tx) {
+    match selection.cache_source_type {
+        CacheSourceType::Ensembl => is_ensembl_transcript_id(&tx.transcript_id),
+        CacheSourceType::RefSeq => selection.all_refseq || is_default_refseq_transcript_id(tx),
+        CacheSourceType::Merged => {
+            if is_ensembl_transcript_id(&tx.transcript_id) {
+                true
+            } else if row_source_is_refseq(tx) {
                 selection.all_refseq || is_default_refseq_transcript_id(tx)
             } else {
-                is_ensembl_transcript(tx)
+                false
             }
         }
     }
@@ -6781,6 +6765,7 @@ fn hydrate_refseq_translation_cds_from_reference<R>(
     translations: &mut [TranslationFeature],
     translateable_seq_by_tx: &HashMap<String, String>,
     input_variant_intervals: &HashMap<String, Vec<(i64, i64)>>,
+    cache_source_type: CacheSourceType,
 ) -> Result<HashSet<String>>
 where
     R: BufRead + Seek,
@@ -6805,7 +6790,7 @@ where
         if !translation_ids.contains(tx.transcript_id.as_str()) {
             continue;
         }
-        if !is_refseq_transcript_for_hydration(tx) {
+        if !is_refseq_transcript_for_hydration(tx, cache_source_type) {
             continue;
         }
         // VEP keeps transcript-local sequence state on the Transcript object.
@@ -6896,6 +6881,7 @@ fn hydrate_transcript_cdna_from_reference<R>(
     exons: &[ExonFeature],
     indel_intervals: &HashMap<String, Vec<(i64, i64)>>,
     all_intervals: &HashMap<String, Vec<(i64, i64)>>,
+    cache_source_type: CacheSourceType,
 ) -> Result<()>
 where
     R: BufRead + Seek,
@@ -6917,7 +6903,7 @@ where
         };
 
         let should_infer_implicit_refseq_deletions = tx.spliced_seq.is_some()
-            && is_refseq_transcript_for_hydration(tx)
+            && is_refseq_transcript_for_hydration(tx, cache_source_type)
             && tx.bam_edit_status.as_deref() == Some("ok")
             && tx.refseq_edits.is_empty()
             && tx.cdna_mapper_segments.is_empty();
@@ -7071,8 +7057,40 @@ fn apply_translateable_seq_overrides(
     }
 }
 
-fn is_refseq_transcript_for_hydration(tx: &TranscriptFeature) -> bool {
-    is_refseq_transcript(tx)
+fn validate_partitioned_cache_source(
+    cache: &PartitionedParquetCache,
+    context_type: &str,
+    chrom: &str,
+    role: &str,
+    expected: CacheSourceType,
+) -> Result<()> {
+    let Some(path) = cache.context_path(context_type, chrom) else {
+        return Ok(());
+    };
+    let actual = CacheSourceType::from_parquet_file(&path).map_err(|err| {
+        DataFusionError::Plan(format!(
+            "annotate_vep(): {role} table '{}' has invalid cache source metadata: {err}",
+            path.display()
+        ))
+    })?;
+    if actual != expected {
+        return Err(DataFusionError::Plan(format!(
+            "annotate_vep(): {role} table '{}' has {CACHE_SOURCE_METADATA_KEY}='{}' but variation cache has {CACHE_SOURCE_METADATA_KEY}='{}'",
+            path.display(),
+            actual.as_str(),
+            expected.as_str()
+        )));
+    }
+    Ok(())
+}
+
+fn is_refseq_transcript_for_hydration(
+    tx: &TranscriptFeature,
+    cache_source_type: CacheSourceType,
+) -> bool {
+    row_source_is_refseq(tx)
+        || is_standard_refseq_accession(&tx.transcript_id)
+        || cache_source_type == CacheSourceType::RefSeq && is_default_refseq_transcript_id(tx)
 }
 
 fn read_reference_sequence<R>(
@@ -7430,10 +7448,11 @@ impl Debug for AnnotateProvider {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "AnnotateProvider {{ vcf: {}, cache_source: {}, backend: {} }}",
+            "AnnotateProvider {{ vcf: {}, cache_source: {}, backend: {}, cache_source_type: {} }}",
             self.vcf_table,
             self.cache_source,
-            self.backend.as_str()
+            self.backend.as_str(),
+            self.cache_source_type.as_str()
         )
     }
 }
@@ -7452,6 +7471,7 @@ struct ContigAnnotationConfig {
     translations_sift_table: Option<String>,
     flags: VepFlags,
     hgvs_flags: HgvsFlags,
+    cache_source_type: CacheSourceType,
     transcript_selection: TranscriptSelectionFlags,
     allowed_failed: i64,
     reference_fasta_path: Option<String>,
@@ -7864,6 +7884,7 @@ fn hydrate_window(
     hgvs_reader: &mut Option<FastaReader>,
     hydrated_cds_tx_ids: &mut HashSet<String>,
     window_batches: &[RecordBatch],
+    cache_source_type: CacheSourceType,
 ) -> Result<()> {
     let Some(reader) = hgvs_reader.as_mut() else {
         return Ok(());
@@ -7880,6 +7901,7 @@ fn hydrate_window(
         translations,
         translateable_seq_by_tx,
         &input_intervals,
+        cache_source_type,
     )?;
     // Merge newly hydrated IDs into cumulative set.
     let first_window = hydrated_cds_tx_ids.is_empty();
@@ -7895,6 +7917,7 @@ fn hydrate_window(
         exons,
         &indel_intervals,
         &input_intervals,
+        cache_source_type,
     )?;
 
     if first_window && profiling_enabled() {
@@ -8532,6 +8555,7 @@ impl Stream for ContigAnnotationStream {
                             config.vcf_table.clone(),
                             String::new(),
                             AnnotationBackend::Parquet,
+                            config.cache_source_type,
                             config.options_json.clone(),
                             vcf_only_schema,
                         ) {
@@ -8758,6 +8782,7 @@ impl Stream for ContigAnnotationStream {
                             &mut ann.hgvs_reader,
                             &mut ann.hydrated_cds_tx_ids,
                             &window_batches,
+                            ann.config.cache_source_type,
                         ) {
                             let fut = make_cleanup_future(
                                 Arc::clone(&ann.session),
@@ -8931,16 +8956,37 @@ async fn prepare_contig_context(
         ephemeral_tables.push(var_table.clone());
         var_table
     };
+    validate_partitioned_cache_source(
+        &cache,
+        "variation",
+        &chrom,
+        "variation",
+        config.cache_source_type,
+    )?;
 
     let tx_table =
         crate::partitioned_cache::register_chrom_parquet(&session, &cache, "transcript", &chrom)
             .await?;
     if let Some(ref t) = tx_table {
+        validate_partitioned_cache_source(
+            &cache,
+            "transcript",
+            &chrom,
+            "transcript",
+            config.cache_source_type,
+        )?;
         ephemeral_tables.push(t.clone());
     }
     let ex_table =
         crate::partitioned_cache::register_chrom_parquet(&session, &cache, "exon", &chrom).await?;
     if let Some(ref t) = ex_table {
+        validate_partitioned_cache_source(
+            &cache,
+            "exon",
+            &chrom,
+            "exon",
+            config.cache_source_type,
+        )?;
         ephemeral_tables.push(t.clone());
     }
     let tl_table = crate::partitioned_cache::register_chrom_parquet(
@@ -8951,17 +8997,38 @@ async fn prepare_contig_context(
     )
     .await?;
     if let Some(ref t) = tl_table {
+        validate_partitioned_cache_source(
+            &cache,
+            "translation_core",
+            &chrom,
+            "translation_core",
+            config.cache_source_type,
+        )?;
         ephemeral_tables.push(t.clone());
     }
     let rg_table =
         crate::partitioned_cache::register_chrom_parquet(&session, &cache, "regulatory", &chrom)
             .await?;
     if let Some(ref t) = rg_table {
+        validate_partitioned_cache_source(
+            &cache,
+            "regulatory",
+            &chrom,
+            "regulatory",
+            config.cache_source_type,
+        )?;
         ephemeral_tables.push(t.clone());
     }
     let mt_table =
         crate::partitioned_cache::register_chrom_parquet(&session, &cache, "motif", &chrom).await?;
     if let Some(ref t) = mt_table {
+        validate_partitioned_cache_source(
+            &cache,
+            "motif",
+            &chrom,
+            "motif",
+            config.cache_source_type,
+        )?;
         ephemeral_tables.push(t.clone());
     }
 
@@ -9004,6 +9071,7 @@ async fn prepare_contig_context(
         config.vcf_table.clone(),
         String::new(),
         AnnotationBackend::Parquet,
+        config.cache_source_type,
         config.options_json.clone(),
         vcf_only_schema,
     )?;
@@ -9178,6 +9246,13 @@ impl TableProvider for AnnotateProvider {
                         "partitioned cache: no variation parquet for sample chrom".to_string(),
                     )
                 })?;
+                validate_partitioned_cache_source(
+                    cache,
+                    "variation",
+                    sample_chrom,
+                    "variation",
+                    self.cache_source_type,
+                )?;
                 let cache_schema = self
                     .session
                     .table(&sample_table)
@@ -10257,35 +10332,29 @@ mod tests {
 
     #[test]
     fn test_transcript_selection_flags_reject_invalid_combinations() {
-        let err =
-            TranscriptSelectionFlags::from_options_json(Some("{\"refseq\":true,\"merged\":true}"))
-                .expect_err("refseq+merged should be rejected")
-                .to_string();
-        assert!(err.contains("--refseq and --merged"));
-
-        let err = TranscriptSelectionFlags::from_options_json(Some(
-            "{\"refseq\":true,\"gencode_basic\":true}",
-        ))
-        .expect_err("refseq+gencode_basic should be rejected")
-        .to_string();
-        assert!(err.contains("--refseq and --gencode_basic"));
-
-        let err = TranscriptSelectionFlags::from_options_json(Some(
-            "{\"gencode_basic\":true,\"gencode_primary\":true}",
-        ))
+        let err = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Ensembl,
+            Some("{\"gencode_basic\":true,\"gencode_primary\":true}"),
+        )
         .expect_err("gencode_basic+gencode_primary should be rejected")
         .to_string();
         assert!(err.contains("--gencode_basic and --gencode_primary"));
 
-        let err = TranscriptSelectionFlags::from_options_json(Some("{\"all_refseq\":true}"))
-            .expect_err("all_refseq without refseq/merged should be rejected")
-            .to_string();
-        assert!(err.contains("--all_refseq requires --refseq or --merged"));
+        let err = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Ensembl,
+            Some("{\"all_refseq\":true}"),
+        )
+        .expect_err("all_refseq without RefSeq-capable metadata should be rejected")
+        .to_string();
+        assert!(err.contains("--all_refseq requires cache schema metadata"));
 
-        let err = TranscriptSelectionFlags::from_options_json(Some("{\"exclude_predicted\":true}"))
-            .expect_err("exclude_predicted without refseq/merged should be rejected")
-            .to_string();
-        assert!(err.contains("--exclude_predicted requires --refseq or --merged"));
+        let err = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Ensembl,
+            Some("{\"exclude_predicted\":true}"),
+        )
+        .expect_err("exclude_predicted without RefSeq-capable metadata should be rejected")
+        .to_string();
+        assert!(err.contains("--exclude_predicted requires cache schema metadata"));
     }
 
     #[test]
@@ -10295,7 +10364,7 @@ mod tests {
             (
                 false,
                 TranscriptSelectionFlags {
-                    source_mode: TranscriptSourceMode::RefSeq,
+                    cache_source_type: CacheSourceType::RefSeq,
                     ..Default::default()
                 },
                 78,
@@ -10303,7 +10372,7 @@ mod tests {
             (
                 false,
                 TranscriptSelectionFlags {
-                    source_mode: TranscriptSourceMode::Merged,
+                    cache_source_type: CacheSourceType::Merged,
                     ..Default::default()
                 },
                 79,
@@ -10312,7 +10381,7 @@ mod tests {
             (
                 true,
                 TranscriptSelectionFlags {
-                    source_mode: TranscriptSourceMode::RefSeq,
+                    cache_source_type: CacheSourceType::RefSeq,
                     ..Default::default()
                 },
                 85,
@@ -10320,7 +10389,7 @@ mod tests {
             (
                 true,
                 TranscriptSelectionFlags {
-                    source_mode: TranscriptSourceMode::Merged,
+                    cache_source_type: CacheSourceType::Merged,
                     ..Default::default()
                 },
                 86,
@@ -10359,7 +10428,7 @@ mod tests {
         };
 
         let refseq_selection = TranscriptSelectionFlags {
-            source_mode: TranscriptSourceMode::RefSeq,
+            cache_source_type: CacheSourceType::RefSeq,
             ..Default::default()
         };
         let refseq_layout = CsqPlaceholderLayout::for_mode(false, refseq_selection, false);
@@ -10384,7 +10453,7 @@ mod tests {
         assert_eq!(refseq_values[refseq_index("MAX_AF_POPS")], "gnomADg_AFR");
 
         let merged_selection = TranscriptSelectionFlags {
-            source_mode: TranscriptSourceMode::Merged,
+            cache_source_type: CacheSourceType::Merged,
             ..Default::default()
         };
         let merged_layout = CsqPlaceholderLayout::for_mode(true, merged_selection, false);
@@ -10775,29 +10844,50 @@ mod tests {
     fn test_passes_transcript_selection_matches_vep_refseq_filters() {
         let ensembl_tx = make_selection_tx("ENST00000311111", Some("Ensembl"));
         let nm_tx = make_selection_tx("NM_000001", Some("RefSeq"));
+        let nr_tx = make_selection_tx("NR_123456.1", Some("RefSeq"));
+        let xm_tx = make_selection_tx("XM_011520402.2", Some("RefSeq"));
+        let xr_tx = make_selection_tx("XR_001734695.1", Some("RefSeq"));
         let mut ccds_tx = make_selection_tx("CCDS1234.1", Some("RefSeq"));
         ccds_tx.display_xref_id = Some("CCDS1234".to_string());
-        let xm_tx = make_selection_tx("XM_123456", Some("RefSeq"));
+        let mut mt_numeric_tx = make_selection_tx("4540", Some("RefSeq"));
+        mt_numeric_tx.chrom = "MT".to_string();
+        let mut mt_gene_tx = make_selection_tx("COX3", Some("RefSeq"));
+        mt_gene_tx.chrom = "MT".to_string();
+        let mut mt_rna_tx = make_selection_tx("rna-TRNK", Some("RefSeq"));
+        mt_rna_tx.chrom = "MT".to_string();
+        let mut non_refseq_mt_gene_tx = make_selection_tx("COX3", Some("Ensembl"));
+        non_refseq_mt_gene_tx.chrom = "MT".to_string();
         let mut gencode_tx = make_selection_tx("ENST00000322222", Some("Ensembl"));
         gencode_tx.is_gencode_basic = true;
         gencode_tx.is_gencode_primary = true;
 
-        let default_selection = TranscriptSelectionFlags::from_options_json(None).unwrap();
+        let default_selection =
+            TranscriptSelectionFlags::from_options_json(CacheSourceType::Ensembl, None).unwrap();
         assert!(passes_transcript_selection(&ensembl_tx, default_selection));
         assert!(!passes_transcript_selection(&nm_tx, default_selection));
 
         let refseq_selection =
-            TranscriptSelectionFlags::from_options_json(Some("{\"refseq\":true}")).unwrap();
+            TranscriptSelectionFlags::from_options_json(CacheSourceType::RefSeq, None).unwrap();
         assert!(!passes_transcript_selection(&ensembl_tx, refseq_selection));
         assert!(passes_transcript_selection(&nm_tx, refseq_selection));
+        assert!(passes_transcript_selection(&nr_tx, refseq_selection));
+        assert!(passes_transcript_selection(&xm_tx, refseq_selection));
+        assert!(passes_transcript_selection(&xr_tx, refseq_selection));
+        assert!(passes_transcript_selection(
+            &mt_numeric_tx,
+            refseq_selection
+        ));
+        assert!(passes_transcript_selection(&mt_gene_tx, refseq_selection));
+        assert!(passes_transcript_selection(&mt_rna_tx, refseq_selection));
         assert!(
             !passes_transcript_selection(&ccds_tx, refseq_selection),
             "CCDS rows should be excluded unless all_refseq is enabled"
         );
 
-        let all_refseq_selection = TranscriptSelectionFlags::from_options_json(Some(
-            "{\"merged\":true,\"all_refseq\":true}",
-        ))
+        let all_refseq_selection = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Merged,
+            Some("{\"all_refseq\":true}"),
+        )
         .unwrap();
         assert!(passes_transcript_selection(
             &ensembl_tx,
@@ -10805,18 +10895,30 @@ mod tests {
         ));
         assert!(passes_transcript_selection(&nm_tx, all_refseq_selection));
         assert!(passes_transcript_selection(&ccds_tx, all_refseq_selection));
+        assert!(passes_transcript_selection(
+            &mt_gene_tx,
+            all_refseq_selection
+        ));
+        assert!(
+            !passes_transcript_selection(&non_refseq_mt_gene_tx, all_refseq_selection),
+            "merged mode should not accept mitochondrial gene-like IDs without RefSeq row source"
+        );
 
-        let exclude_predicted_selection = TranscriptSelectionFlags::from_options_json(Some(
-            "{\"merged\":true,\"all_refseq\":true,\"exclude_predicted\":true}",
-        ))
+        let exclude_predicted_selection = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Merged,
+            Some("{\"all_refseq\":true,\"exclude_predicted\":true}"),
+        )
         .unwrap();
         assert!(
             !passes_transcript_selection(&xm_tx, exclude_predicted_selection),
             "XM_/XR_ transcripts should be filtered by exclude_predicted"
         );
 
-        let gencode_basic_selection =
-            TranscriptSelectionFlags::from_options_json(Some("{\"gencode_basic\":true}")).unwrap();
+        let gencode_basic_selection = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Ensembl,
+            Some("{\"gencode_basic\":true}"),
+        )
+        .unwrap();
         assert!(passes_transcript_selection(
             &gencode_tx,
             gencode_basic_selection
@@ -10826,9 +10928,10 @@ mod tests {
             gencode_basic_selection
         ));
 
-        let gencode_primary_selection = TranscriptSelectionFlags::from_options_json(Some(
-            "{\"merged\":true,\"gencode_primary\":true}",
-        ))
+        let gencode_primary_selection = TranscriptSelectionFlags::from_options_json(
+            CacheSourceType::Merged,
+            Some("{\"gencode_primary\":true}"),
+        )
         .unwrap();
         assert!(passes_transcript_selection(
             &gencode_tx,
@@ -10837,6 +10940,38 @@ mod tests {
         assert!(!passes_transcript_selection(
             &nm_tx,
             gencode_primary_selection
+        ));
+    }
+
+    #[test]
+    fn test_refseq_hydration_accepts_standard_and_mitochondrial_ids() {
+        let nm_tx = make_selection_tx("NM_000546.6", None);
+        let mut mt_numeric_tx = make_selection_tx("4540", None);
+        mt_numeric_tx.chrom = "MT".to_string();
+        let mut mt_gene_tx = make_selection_tx("COX3", Some("RefSeq"));
+        mt_gene_tx.chrom = "MT".to_string();
+        let mut mt_rna_tx = make_selection_tx("rna-TRNK", None);
+        mt_rna_tx.chrom = "MT".to_string();
+
+        assert!(is_refseq_transcript_for_hydration(
+            &nm_tx,
+            CacheSourceType::Ensembl
+        ));
+        assert!(is_refseq_transcript_for_hydration(
+            &mt_numeric_tx,
+            CacheSourceType::RefSeq
+        ));
+        assert!(is_refseq_transcript_for_hydration(
+            &mt_gene_tx,
+            CacheSourceType::Merged
+        ));
+        assert!(is_refseq_transcript_for_hydration(
+            &mt_rna_tx,
+            CacheSourceType::RefSeq
+        ));
+        assert!(!is_refseq_transcript_for_hydration(
+            &mt_rna_tx,
+            CacheSourceType::Ensembl
         ));
     }
 

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -6445,7 +6445,12 @@ fn passes_transcript_selection(
     }
 
     match selection.cache_source_type {
-        CacheSourceType::Ensembl => is_ensembl_transcript_id(&tx.transcript_id),
+        CacheSourceType::Ensembl => {
+            // Match VEP source-mode behavior: Ensembl mode keeps Ensembl stable
+            // transcript IDs and intentionally excludes source-labeled non-ENST
+            // rows such as LRG transcripts.
+            is_ensembl_transcript_id(&tx.transcript_id)
+        }
         CacheSourceType::RefSeq => selection.all_refseq || is_default_refseq_transcript_id(tx),
         CacheSourceType::Merged => {
             if is_ensembl_transcript_id(&tx.transcript_id) {
@@ -7067,6 +7072,8 @@ fn validate_partitioned_cache_source(
     let Some(path) = cache.context_path(context_type, chrom) else {
         return Ok(());
     };
+    // This validates the co-located shard used for the current chromosome.
+    // Mixed metadata across other shards is caught when those shards are read.
     let actual = CacheSourceType::from_parquet_file(&path).map_err(|err| {
         DataFusionError::Plan(format!(
             "annotate_vep(): {role} table '{}' has invalid cache source metadata: {err}",

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -6309,14 +6309,6 @@ fn parse_transcript_raw_metadata(raw_object_json: &str) -> TranscriptRawMetadata
     }
 }
 
-fn is_ensembl_transcript(tx: &TranscriptFeature) -> bool {
-    tx.source.as_deref() == Some("Ensembl") || tx.transcript_id.starts_with("ENST")
-}
-
-fn is_ensembl_transcript_id(id: &str) -> bool {
-    id.starts_with("ENST")
-}
-
 fn row_source_is_refseq(tx: &TranscriptFeature) -> bool {
     tx.source_cache
         .as_deref()
@@ -6333,10 +6325,6 @@ fn is_standard_refseq_accession(id: &str) -> bool {
         && bytes[1].is_ascii_uppercase()
         && bytes[2] == b'_'
         && bytes[3].is_ascii_digit()
-}
-
-fn is_refseq_transcript(tx: &TranscriptFeature) -> bool {
-    row_source_is_refseq(tx) || is_standard_refseq_accession(&tx.transcript_id)
 }
 
 fn is_refseq_offset_transcript(tx: &TranscriptFeature) -> bool {
@@ -6444,21 +6432,18 @@ fn passes_transcript_selection(
         return false;
     }
 
+    // Ensembl VEP release/115 only applies the RefSeq stable-id whitelist when
+    // source_type is RefSeq, or when source_type is merged and the row came
+    // from the RefSeq cache. Other source rows pass once the common filters
+    // above have accepted their stable ID.
     match selection.cache_source_type {
-        CacheSourceType::Ensembl => {
-            // Match VEP source-mode behavior: Ensembl mode keeps Ensembl stable
-            // transcript IDs and intentionally excludes source-labeled non-ENST
-            // rows such as LRG transcripts.
-            is_ensembl_transcript_id(&tx.transcript_id)
-        }
+        CacheSourceType::Ensembl => true,
         CacheSourceType::RefSeq => selection.all_refseq || is_default_refseq_transcript_id(tx),
         CacheSourceType::Merged => {
-            if is_ensembl_transcript_id(&tx.transcript_id) {
-                true
-            } else if row_source_is_refseq(tx) {
+            if row_source_is_refseq(tx) {
                 selection.all_refseq || is_default_refseq_transcript_id(tx)
             } else {
-                false
+                true
             }
         }
     }
@@ -10850,6 +10835,7 @@ mod tests {
     #[test]
     fn test_passes_transcript_selection_matches_vep_refseq_filters() {
         let ensembl_tx = make_selection_tx("ENST00000311111", Some("Ensembl"));
+        let lrg_tx = make_selection_tx("LRG_485", Some("Ensembl"));
         let nm_tx = make_selection_tx("NM_000001", Some("RefSeq"));
         let nr_tx = make_selection_tx("NR_123456.1", Some("RefSeq"));
         let xm_tx = make_selection_tx("XM_011520402.2", Some("RefSeq"));
@@ -10871,7 +10857,10 @@ mod tests {
         let default_selection =
             TranscriptSelectionFlags::from_options_json(CacheSourceType::Ensembl, None).unwrap();
         assert!(passes_transcript_selection(&ensembl_tx, default_selection));
-        assert!(!passes_transcript_selection(&nm_tx, default_selection));
+        assert!(
+            passes_transcript_selection(&lrg_tx, default_selection),
+            "VEP Ensembl mode does not require ENST-prefixed stable IDs"
+        );
 
         let refseq_selection =
             TranscriptSelectionFlags::from_options_json(CacheSourceType::RefSeq, None).unwrap();
@@ -10891,6 +10880,21 @@ mod tests {
             "CCDS rows should be excluded unless all_refseq is enabled"
         );
 
+        let merged_selection =
+            TranscriptSelectionFlags::from_options_json(CacheSourceType::Merged, None).unwrap();
+        assert!(passes_transcript_selection(&ensembl_tx, merged_selection));
+        assert!(passes_transcript_selection(&lrg_tx, merged_selection));
+        assert!(passes_transcript_selection(&nm_tx, merged_selection));
+        assert!(passes_transcript_selection(&mt_gene_tx, merged_selection));
+        assert!(
+            passes_transcript_selection(&non_refseq_mt_gene_tx, merged_selection),
+            "VEP merged mode applies RefSeq filtering only to RefSeq-sourced rows"
+        );
+        assert!(
+            !passes_transcript_selection(&ccds_tx, merged_selection),
+            "merged RefSeq rows should still use the default RefSeq whitelist"
+        );
+
         let all_refseq_selection = TranscriptSelectionFlags::from_options_json(
             CacheSourceType::Merged,
             Some("{\"all_refseq\":true}"),
@@ -10900,6 +10904,7 @@ mod tests {
             &ensembl_tx,
             all_refseq_selection
         ));
+        assert!(passes_transcript_selection(&lrg_tx, all_refseq_selection));
         assert!(passes_transcript_selection(&nm_tx, all_refseq_selection));
         assert!(passes_transcript_selection(&ccds_tx, all_refseq_selection));
         assert!(passes_transcript_selection(
@@ -10907,8 +10912,8 @@ mod tests {
             all_refseq_selection
         ));
         assert!(
-            !passes_transcript_selection(&non_refseq_mt_gene_tx, all_refseq_selection),
-            "merged mode should not accept mitochondrial gene-like IDs without RefSeq row source"
+            passes_transcript_selection(&non_refseq_mt_gene_tx, all_refseq_selection),
+            "VEP merged mode applies RefSeq filtering only to RefSeq-sourced rows"
         );
 
         let exclude_predicted_selection = TranscriptSelectionFlags::from_options_json(

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -18,6 +18,10 @@ use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
 
 /// Table function implementing
 /// `annotate_vep(vcf_table, cache_source, backend [, options_json])`.
+///
+/// Cache source mode is read from Arrow schema metadata on a parquet file under
+/// `{cache_source}/variation`. That directory must be readable even when the
+/// annotation backend itself is `fjall`.
 pub struct AnnotateFunction {
     session: Arc<SessionContext>,
     /// Catalog list captured at registration time to avoid acquiring

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -10,9 +10,11 @@ use datafusion::common::{DataFusionError, Result, ScalarValue};
 use datafusion::datasource::TableProvider;
 use datafusion::logical_expr::Expr;
 use datafusion::prelude::SessionContext;
+use serde_json::Value;
 
 use crate::annotate_provider::AnnotateProvider;
 use crate::annotation_store::AnnotationBackend;
+use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
 
 /// Table function implementing
 /// `annotate_vep(vcf_table, cache_source, backend [, options_json])`.
@@ -74,6 +76,8 @@ impl TableFunctionImpl for AnnotateFunction {
         } else {
             None
         };
+        reject_options_json_source_selectors(options_json.as_deref())?;
+        let cache_source_type = CacheSourceType::from_partitioned_cache_source(&cache_source)?;
 
         let vcf_schema = resolve_schema_from_catalog(
             &*self.catalog_list,
@@ -87,6 +91,7 @@ impl TableFunctionImpl for AnnotateFunction {
             vcf_table,
             cache_source,
             backend,
+            cache_source_type,
             options_json,
             vcf_schema,
         )?))
@@ -171,8 +176,32 @@ fn resolve_table_sync(
         .ok_or_else(|| DataFusionError::Plan(format!("Table '{table_name}' not found")))
 }
 
+fn options_json_has_key(options_json: Option<&str>, key: &str) -> Result<bool> {
+    let Some(raw) = options_json else {
+        return Ok(false);
+    };
+    let value: Value = serde_json::from_str(raw).map_err(|err| {
+        DataFusionError::Plan(format!(
+            "annotate_vep() options_json must be valid JSON: {err}"
+        ))
+    })?;
+    Ok(value.as_object().is_some_and(|obj| obj.contains_key(key)))
+}
+
+fn reject_options_json_source_selectors(options_json: Option<&str>) -> Result<()> {
+    for key in ["merged", "refseq"] {
+        if options_json_has_key(options_json, key)? {
+            return Err(DataFusionError::Plan(format!(
+                "annotate_vep(): options_json key '{key}' is unsupported; register/export cache tables with schema metadata {CACHE_SOURCE_METADATA_KEY}='{key}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
     use crate::create_vep_session;
     #[cfg(feature = "kv-cache")]
     use crate::kv_cache::{VepKvStore, position_entry::serialize_position_entry};
@@ -184,6 +213,7 @@ mod tests {
     use datafusion::datasource::MemTable;
     use parquet::arrow::ArrowWriter;
     use std::collections::BTreeSet;
+    use std::collections::HashMap;
     use std::fs::File;
     use std::sync::Arc;
     use tempfile::TempDir;
@@ -191,7 +221,22 @@ mod tests {
     /// Write record batches into the partitioned cache layout under
     /// `{tmpdir}/{table_type}/{chrom}.parquet`, grouping rows by the "chrom"
     /// column in each batch.
-    fn write_partitioned_cache(tmpdir: &TempDir, table_type: &str, batches: &[RecordBatch]) {
+    fn batch_with_cache_source(batch: &RecordBatch, source: CacheSourceType) -> RecordBatch {
+        let mut metadata = batch.schema().metadata().clone();
+        metadata.insert(
+            CACHE_SOURCE_METADATA_KEY.to_string(),
+            source.as_str().to_string(),
+        );
+        let schema = Arc::new(batch.schema().as_ref().clone().with_metadata(metadata));
+        RecordBatch::try_new(schema, batch.columns().to_vec()).expect("metadata-only batch schema")
+    }
+
+    fn write_partitioned_cache_with_source(
+        tmpdir: &TempDir,
+        table_type: &str,
+        batches: &[RecordBatch],
+        source: CacheSourceType,
+    ) {
         let type_dir = tmpdir.path().join(table_type);
         std::fs::create_dir_all(&type_dir).expect("create type dir");
 
@@ -200,6 +245,7 @@ mod tests {
             std::collections::HashMap::new();
 
         for batch in batches {
+            let batch = batch_with_cache_source(batch, source);
             let schema = batch.schema();
             let chrom_idx = schema
                 .index_of("chrom")
@@ -251,21 +297,103 @@ mod tests {
         }
     }
 
+    fn write_partitioned_cache_without_source_metadata(
+        tmpdir: &TempDir,
+        table_type: &str,
+        batches: &[RecordBatch],
+    ) {
+        let type_dir = tmpdir.path().join(table_type);
+        std::fs::create_dir_all(&type_dir).expect("create type dir");
+
+        let mut chrom_batches: HashMap<String, Vec<RecordBatch>> = HashMap::new();
+        for batch in batches {
+            let schema = batch.schema();
+            let chrom_idx = schema
+                .index_of("chrom")
+                .expect("batch must have a 'chrom' column");
+            let chrom_arr = batch
+                .column(chrom_idx)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("chrom column must be StringArray");
+            let unique_chroms: BTreeSet<String> = (0..chrom_arr.len())
+                .map(|i| chrom_arr.value(i).to_string())
+                .collect();
+            for chrom in unique_chroms {
+                let indices: Vec<u32> = (0..chrom_arr.len())
+                    .filter(|&i| chrom_arr.value(i) == chrom)
+                    .map(|i| i as u32)
+                    .collect();
+                let indices_arr = datafusion::arrow::array::UInt32Array::from(indices);
+                let filtered_columns: Vec<Arc<dyn Array>> = (0..batch.num_columns())
+                    .map(|c| {
+                        datafusion::arrow::compute::take(
+                            batch.column(c).as_ref(),
+                            &indices_arr,
+                            None,
+                        )
+                        .expect("take should succeed")
+                    })
+                    .collect();
+                let filtered_batch =
+                    RecordBatch::try_new(schema.clone(), filtered_columns).expect("filtered batch");
+                chrom_batches.entry(chrom).or_default().push(filtered_batch);
+            }
+        }
+
+        for (chrom, batches) in &chrom_batches {
+            let path = type_dir.join(format!("{chrom}.parquet"));
+            let file = File::create(&path).expect("create parquet file");
+            let mut writer = ArrowWriter::try_new(file, batches[0].schema(), None)
+                .expect("create parquet writer");
+            for b in batches {
+                writer.write(b).expect("write parquet batch");
+            }
+            writer.close().expect("close parquet writer");
+        }
+    }
+
     /// Convenience: write a single RecordBatch to the partitioned cache.
     fn write_batch_to_cache(tmpdir: &TempDir, table_type: &str, batch: &RecordBatch) {
-        write_partitioned_cache(tmpdir, table_type, &[batch.clone()]);
+        write_batch_to_cache_with_source(tmpdir, table_type, batch, CacheSourceType::Ensembl);
+    }
+
+    fn write_batch_to_cache_with_source(
+        tmpdir: &TempDir,
+        table_type: &str,
+        batch: &RecordBatch,
+        source: CacheSourceType,
+    ) {
+        write_partitioned_cache_with_source(tmpdir, table_type, &[batch.clone()], source);
     }
 
     /// Write a RecordBatch directly into a specific chrom parquet file,
     /// for tables that do not have a "chrom" column (e.g. exons, translations).
     fn write_batch_to_chrom(tmpdir: &TempDir, table_type: &str, chrom: &str, batch: &RecordBatch) {
+        write_batch_to_chrom_with_source(
+            tmpdir,
+            table_type,
+            chrom,
+            batch,
+            CacheSourceType::Ensembl,
+        );
+    }
+
+    fn write_batch_to_chrom_with_source(
+        tmpdir: &TempDir,
+        table_type: &str,
+        chrom: &str,
+        batch: &RecordBatch,
+        source: CacheSourceType,
+    ) {
         let type_dir = tmpdir.path().join(table_type);
         std::fs::create_dir_all(&type_dir).expect("create type dir");
         let path = type_dir.join(format!("{chrom}.parquet"));
         let file = File::create(&path).expect("create parquet file");
+        let batch = batch_with_cache_source(batch, source);
         let mut writer =
             ArrowWriter::try_new(file, batch.schema(), None).expect("create parquet writer");
-        writer.write(batch).expect("write parquet batch");
+        writer.write(&batch).expect("write parquet batch");
         writer.close().expect("close parquet writer");
     }
 
@@ -3462,14 +3590,14 @@ mod tests {
         let ctx = create_vep_session();
         ctx.register_table("vcf_refseq", Arc::new(refseq_vcf_table()))
             .expect("register refseq vcf table");
-        let tmpdir = TempDir::new().expect("create tmpdir");
-        write_batch_to_cache(&tmpdir, "variation", &refseq_cache_batch());
-        write_batch_to_cache(&tmpdir, "transcript", &refseq_transcripts_batch());
-        write_batch_to_chrom(&tmpdir, "exon", "1", &refseq_exons_batch());
-        let cache_path = tmpdir.path().display().to_string();
+        let ensembl_tmpdir = TempDir::new().expect("create ensembl tmpdir");
+        write_batch_to_cache(&ensembl_tmpdir, "variation", &refseq_cache_batch());
+        write_batch_to_cache(&ensembl_tmpdir, "transcript", &refseq_transcripts_batch());
+        write_batch_to_chrom(&ensembl_tmpdir, "exon", "1", &refseq_exons_batch());
+        let ensembl_cache_path = ensembl_tmpdir.path().display().to_string();
 
         let default_sql = format!(
-            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{cache_path}', 'parquet', '{{\"partitioned\":true}}')"
+            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{ensembl_cache_path}', 'parquet', '{{\"partitioned\":true}}')"
         );
         let default_batches = ctx
             .sql(&default_sql)
@@ -3490,8 +3618,29 @@ mod tests {
         assert_eq!(default_entry.len(), 74);
         assert_eq!(default_entry[1], "intergenic_variant");
 
+        let refseq_tmpdir = TempDir::new().expect("create refseq tmpdir");
+        write_batch_to_cache_with_source(
+            &refseq_tmpdir,
+            "variation",
+            &refseq_cache_batch(),
+            CacheSourceType::RefSeq,
+        );
+        write_batch_to_cache_with_source(
+            &refseq_tmpdir,
+            "transcript",
+            &refseq_transcripts_batch(),
+            CacheSourceType::RefSeq,
+        );
+        write_batch_to_chrom_with_source(
+            &refseq_tmpdir,
+            "exon",
+            "1",
+            &refseq_exons_batch(),
+            CacheSourceType::RefSeq,
+        );
+        let refseq_cache_path = refseq_tmpdir.path().display().to_string();
         let refseq_sql = format!(
-            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{cache_path}', 'parquet', '{{\"partitioned\":true,\"refseq\":true}}')"
+            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{refseq_cache_path}', 'parquet', '{{\"partitioned\":true}}')"
         );
         let refseq_batches = ctx
             .sql(&refseq_sql)
@@ -3516,8 +3665,29 @@ mod tests {
         assert_eq!(refseq_entry[31], "A");
         assert_eq!(refseq_entry[32], "OK");
 
+        let merged_tmpdir = TempDir::new().expect("create merged tmpdir");
+        write_batch_to_cache_with_source(
+            &merged_tmpdir,
+            "variation",
+            &refseq_cache_batch(),
+            CacheSourceType::Merged,
+        );
+        write_batch_to_cache_with_source(
+            &merged_tmpdir,
+            "transcript",
+            &refseq_transcripts_batch(),
+            CacheSourceType::Merged,
+        );
+        write_batch_to_chrom_with_source(
+            &merged_tmpdir,
+            "exon",
+            "1",
+            &refseq_exons_batch(),
+            CacheSourceType::Merged,
+        );
+        let merged_cache_path = merged_tmpdir.path().display().to_string();
         let merged_sql = format!(
-            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{cache_path}', 'parquet', '{{\"partitioned\":true,\"merged\":true}}')"
+            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{merged_cache_path}', 'parquet', '{{\"partitioned\":true}}')"
         );
         let merged_batches = ctx
             .sql(&merged_sql)
@@ -3549,14 +3719,14 @@ mod tests {
         let ctx = create_vep_session();
         ctx.register_table("vcf_refseq_schema", Arc::new(refseq_vcf_table()))
             .expect("register refseq vcf table");
-        let tmpdir = TempDir::new().expect("create tmpdir");
-        write_batch_to_cache(&tmpdir, "variation", &refseq_cache_batch());
-        write_batch_to_cache(&tmpdir, "transcript", &refseq_transcripts_batch());
-        write_batch_to_chrom(&tmpdir, "exon", "1", &refseq_exons_batch());
-        let cache_path = tmpdir.path().display().to_string();
+        let ensembl_tmpdir = TempDir::new().expect("create ensembl tmpdir");
+        write_batch_to_cache(&ensembl_tmpdir, "variation", &refseq_cache_batch());
+        write_batch_to_cache(&ensembl_tmpdir, "transcript", &refseq_transcripts_batch());
+        write_batch_to_chrom(&ensembl_tmpdir, "exon", "1", &refseq_exons_batch());
+        let ensembl_cache_path = ensembl_tmpdir.path().display().to_string();
 
         let default_sql = format!(
-            "SELECT * FROM annotate_vep('vcf_refseq_schema', '{cache_path}', 'parquet', '{{\"partitioned\":true}}')"
+            "SELECT * FROM annotate_vep('vcf_refseq_schema', '{ensembl_cache_path}', 'parquet', '{{\"partitioned\":true}}')"
         );
         let default_batches = ctx
             .sql(&default_sql)
@@ -3580,8 +3750,29 @@ mod tests {
             );
         }
 
+        let refseq_tmpdir = TempDir::new().expect("create refseq tmpdir");
+        write_batch_to_cache_with_source(
+            &refseq_tmpdir,
+            "variation",
+            &refseq_cache_batch(),
+            CacheSourceType::RefSeq,
+        );
+        write_batch_to_cache_with_source(
+            &refseq_tmpdir,
+            "transcript",
+            &refseq_transcripts_batch(),
+            CacheSourceType::RefSeq,
+        );
+        write_batch_to_chrom_with_source(
+            &refseq_tmpdir,
+            "exon",
+            "1",
+            &refseq_exons_batch(),
+            CacheSourceType::RefSeq,
+        );
+        let refseq_cache_path = refseq_tmpdir.path().display().to_string();
         let refseq_sql = format!(
-            "SELECT * FROM annotate_vep('vcf_refseq_schema', '{cache_path}', 'parquet', '{{\"partitioned\":true,\"refseq\":true}}')"
+            "SELECT * FROM annotate_vep('vcf_refseq_schema', '{refseq_cache_path}', 'parquet', '{{\"partitioned\":true}}')"
         );
         let refseq_batches = ctx
             .sql(&refseq_sql)
@@ -3612,8 +3803,29 @@ mod tests {
             "refseq-only schema should not expose SOURCE"
         );
 
+        let merged_tmpdir = TempDir::new().expect("create merged tmpdir");
+        write_batch_to_cache_with_source(
+            &merged_tmpdir,
+            "variation",
+            &refseq_cache_batch(),
+            CacheSourceType::Merged,
+        );
+        write_batch_to_cache_with_source(
+            &merged_tmpdir,
+            "transcript",
+            &refseq_transcripts_batch(),
+            CacheSourceType::Merged,
+        );
+        write_batch_to_chrom_with_source(
+            &merged_tmpdir,
+            "exon",
+            "1",
+            &refseq_exons_batch(),
+            CacheSourceType::Merged,
+        );
+        let merged_cache_path = merged_tmpdir.path().display().to_string();
         let merged_sql = format!(
-            "SELECT * FROM annotate_vep('vcf_refseq_schema', '{cache_path}', 'parquet', '{{\"partitioned\":true,\"merged\":true}}')"
+            "SELECT * FROM annotate_vep('vcf_refseq_schema', '{merged_cache_path}', 'parquet', '{{\"partitioned\":true}}')"
         );
         let merged_batches = ctx
             .sql(&merged_sql)
@@ -3679,7 +3891,12 @@ mod tests {
     async fn test_annotate_vep_merged_typed_columns_handle_rows_without_transcript_assignments() {
         let backend = "parquet";
         let tmpdir = TempDir::new().expect("create temp dir");
-        write_batch_to_cache(&tmpdir, "variation", &cache_batch());
+        write_batch_to_cache_with_source(
+            &tmpdir,
+            "variation",
+            &cache_batch(),
+            CacheSourceType::Merged,
+        );
 
         let ctx = create_vep_session();
         ctx.register_table("vcf_data", Arc::new(vcf_table()))
@@ -3687,7 +3904,7 @@ mod tests {
 
         let cache_path = tmpdir.path().to_str().expect("utf8 path");
         let sql = format!(
-            "SELECT * FROM annotate_vep('vcf_data', '{cache_path}', '{backend}', '{{\"partitioned\":true,\"merged\":true}}')"
+            "SELECT * FROM annotate_vep('vcf_data', '{cache_path}', '{backend}', '{{\"partitioned\":true}}')"
         );
         let batches = ctx
             .sql(&sql)
@@ -3737,6 +3954,105 @@ mod tests {
             .to_string();
 
         assert!(err.contains("annotate_vep() backend must be one of"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_rejects_options_json_source_selectors() {
+        for (key, expected_source) in [("merged", "merged"), ("refseq", "refseq")] {
+            for value in ["true", "false"] {
+                let ctx = create_vep_session();
+                ctx.register_table("vcf_data", Arc::new(vcf_table()))
+                    .expect("register vcf table");
+
+                let tmpdir = TempDir::new().expect("create temp dir");
+                write_batch_to_cache(&tmpdir, "variation", &cache_batch());
+                let cache_path = tmpdir.path().to_string_lossy();
+
+                let sql = format!(
+                    "SELECT * FROM annotate_vep('vcf_data', '{cache_path}', 'parquet', '{{\"partitioned\":true,\"{key}\":{value}}}')"
+                );
+                let err = ctx
+                    .sql(&sql)
+                    .await
+                    .expect_err("legacy source selector should fail during planning")
+                    .to_string();
+
+                assert!(
+                    err.contains(&format!(
+                        "annotate_vep(): options_json key '{key}' is unsupported"
+                    )),
+                    "unexpected error for {key}={value}: {err}"
+                );
+                assert!(
+                    err.contains(&format!("bio.vep.cache_source_type='{expected_source}'")),
+                    "error should point to schema metadata for {key}={value}: {err}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_ignores_options_json_cache_source_type_and_requires_metadata() {
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_data", Arc::new(vcf_table()))
+            .expect("register vcf table");
+
+        let tmpdir = TempDir::new().expect("create temp dir");
+        write_partitioned_cache_without_source_metadata(&tmpdir, "variation", &[cache_batch()]);
+        let cache_path = tmpdir.path().to_string_lossy();
+
+        let sql = format!(
+            "SELECT * FROM annotate_vep('vcf_data', '{cache_path}', 'parquet', '{{\"partitioned\":true,\"cache_source_type\":\"refseq\"}}')"
+        );
+        let err = ctx
+            .sql(&sql)
+            .await
+            .expect_err("options_json cache_source_type must not replace schema metadata")
+            .to_string();
+
+        assert!(err.contains("missing bio.vep.cache_source_type"), "{err}");
+        assert!(
+            err.contains("expected one of ensembl, merged, refseq"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_annotate_vep_rejects_mismatched_cache_source_metadata() {
+        let ctx = create_vep_session();
+        ctx.register_table("vcf_refseq", Arc::new(refseq_vcf_table()))
+            .expect("register refseq vcf table");
+
+        let tmpdir = TempDir::new().expect("create tmpdir");
+        write_batch_to_cache_with_source(
+            &tmpdir,
+            "variation",
+            &refseq_cache_batch(),
+            CacheSourceType::RefSeq,
+        );
+        write_batch_to_cache_with_source(
+            &tmpdir,
+            "transcript",
+            &refseq_transcripts_batch(),
+            CacheSourceType::Ensembl,
+        );
+        let cache_path = tmpdir.path().display().to_string();
+
+        let sql = format!(
+            "SELECT \"CSQ\" FROM annotate_vep('vcf_refseq', '{cache_path}', 'parquet', '{{\"partitioned\":true}}')"
+        );
+        let err = ctx
+            .sql(&sql)
+            .await
+            .expect("query should parse")
+            .collect()
+            .await
+            .expect_err("mismatched cache source metadata should fail")
+            .to_string();
+
+        assert!(err.contains("transcript table"), "{err}");
+        assert!(err.contains("bio.vep.cache_source_type='ensembl'"), "{err}");
+        assert!(err.contains("bio.vep.cache_source_type='refseq'"), "{err}");
     }
 
     /// VCF table with 10 rows on the same contig for LIMIT tests.

--- a/datafusion/bio-function-vep/src/annotate_table_function.rs
+++ b/datafusion/bio-function-vep/src/annotate_table_function.rs
@@ -3620,7 +3620,9 @@ mod tests {
             .next()
             .expect("default CSQ entry");
         assert_eq!(default_entry.len(), 74);
-        assert_eq!(default_entry[1], "intergenic_variant");
+        assert_eq!(default_entry[1], "non_coding_transcript_exon_variant");
+        assert_eq!(default_entry[5], "Transcript");
+        assert_eq!(default_entry[6], "NM_000001");
 
         let refseq_tmpdir = TempDir::new().expect("create refseq tmpdir");
         write_batch_to_cache_with_source(

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -455,85 +455,19 @@ impl CacheBuilder {
                     })?;
                 }
 
-                use parquet::file::properties::WriterProperties;
-                use parquet::file::reader::FileReader;
-                use parquet::file::serialized_reader::SerializedFileReader;
-                use parquet::file::writer::SerializedFileWriter;
-
-                let first_reader = SerializedFileReader::try_from(
-                    File::open(&part_files[0].1)
-                        .map_err(|e| DataFusionError::Execution(format!("open part file: {e}")))?,
-                )
-                .map_err(|e| DataFusionError::Execution(format!("read part parquet: {e}")))?;
-                let parquet_schema = first_reader.metadata().file_metadata().schema().clone();
-                let props = WriterProperties::builder()
-                    .set_compression(parquet::basic::Compression::ZSTD(
-                        parquet::basic::ZstdLevel::try_new(self.zstd_level).unwrap_or_default(),
-                    ))
-                    .build();
-                drop(first_reader);
-
-                let out_file = File::create(output_file).map_err(|e| {
-                    DataFusionError::Execution(format!("create merged parquet: {e}"))
-                })?;
-                let mut merged_writer =
-                    SerializedFileWriter::new(out_file, Arc::new(parquet_schema), Arc::new(props))
-                        .map_err(|e| {
-                            DataFusionError::Execution(format!("create parquet writer: {e}"))
-                        })?;
-
-                use parquet::column::writer::ColumnCloseResult;
-                use parquet::format::{ColumnIndex, OffsetIndex};
-
-                for (_, part_file, part_rows) in &part_files {
-                    let src_file = File::open(part_file)
-                        .map_err(|e| DataFusionError::Execution(format!("open part file: {e}")))?;
-                    let reader = SerializedFileReader::try_from(src_file).map_err(|e| {
-                        DataFusionError::Execution(format!("read part parquet: {e}"))
-                    })?;
-
-                    let meta = reader.metadata();
-                    for rg_idx in 0..meta.num_row_groups() {
-                        let rg_meta = meta.row_group(rg_idx);
-                        let mut rg_writer = merged_writer.next_row_group().map_err(|e| {
-                            DataFusionError::Execution(format!("create row group: {e}"))
-                        })?;
-
-                        // Re-open the file for each row group so append_column
-                        // can read column data via ChunkReader.
-                        let chunk_reader = File::open(part_file)
-                            .map_err(|e| DataFusionError::Execution(format!("open part: {e}")))?;
-
-                        for col_idx in 0..rg_meta.num_columns() {
-                            let col_meta = rg_meta.column(col_idx).clone();
-                            let close_result = ColumnCloseResult {
-                                bytes_written: col_meta.compressed_size() as u64,
-                                rows_written: rg_meta.num_rows() as u64,
-                                metadata: col_meta,
-                                bloom_filter: None,
-                                column_index: None,
-                                offset_index: None,
-                            };
-
-                            rg_writer
-                                .append_column(&chunk_reader, close_result)
-                                .map_err(|e| {
-                                    DataFusionError::Execution(format!("append column chunk: {e}"))
-                                })?;
-                        }
-
-                        rg_writer.close().map_err(|e| {
-                            DataFusionError::Execution(format!("close row group: {e}"))
-                        })?;
-                    }
-
-                    chrom_rows += part_rows;
-                    total_parquet_rows += part_rows;
+                let part_paths: Vec<String> = part_files
+                    .iter()
+                    .map(|(_, part_file, _)| part_file.clone())
+                    .collect();
+                let merged_rows =
+                    merge_parquet_row_groups(&part_paths, output_file, Some(self.zstd_level))?;
+                if merged_rows != parallel_rows {
+                    return Err(DataFusionError::Execution(format!(
+                        "merged parquet row count mismatch for {output_file}: copied {merged_rows}, expected {parallel_rows}"
+                    )));
                 }
-
-                merged_writer.close().map_err(|e| {
-                    DataFusionError::Execution(format!("close merged parquet: {e}"))
-                })?;
+                chrom_rows += merged_rows;
+                total_parquet_rows += merged_rows;
 
                 if let Some(ref cb) = self.on_progress {
                     cb("variation", "parquet", chrom_rows, total_parquet_rows, 0);
@@ -1986,6 +1920,93 @@ fn writer_properties(
     builder.build()
 }
 
+fn merge_parquet_row_groups(
+    part_files: &[String],
+    output_file: &str,
+    zstd_level: Option<i32>,
+) -> Result<usize> {
+    use parquet::column::writer::ColumnCloseResult;
+    use parquet::file::properties::WriterProperties;
+    use parquet::file::reader::FileReader;
+    use parquet::file::serialized_reader::SerializedFileReader;
+    use parquet::file::writer::SerializedFileWriter;
+
+    let first_part = part_files.first().ok_or_else(|| {
+        DataFusionError::Execution("merge parquet row groups: no part files provided".to_string())
+    })?;
+    let first_reader = SerializedFileReader::try_from(
+        File::open(first_part)
+            .map_err(|e| DataFusionError::Execution(format!("open part file: {e}")))?,
+    )
+    .map_err(|e| DataFusionError::Execution(format!("read part parquet: {e}")))?;
+    let first_file_metadata = first_reader.metadata().file_metadata();
+    let parquet_schema = first_file_metadata.schema().clone();
+    let key_value_metadata = first_file_metadata.key_value_metadata().cloned();
+    drop(first_reader);
+
+    let mut props = WriterProperties::builder();
+    if let Some(level) = zstd_level {
+        props = props.set_compression(parquet::basic::Compression::ZSTD(
+            parquet::basic::ZstdLevel::try_new(level).unwrap_or_default(),
+        ));
+    }
+    let props = props.set_key_value_metadata(key_value_metadata).build();
+
+    let out_file = File::create(output_file)
+        .map_err(|e| DataFusionError::Execution(format!("create merged parquet: {e}")))?;
+    let mut merged_writer =
+        SerializedFileWriter::new(out_file, Arc::new(parquet_schema), Arc::new(props))
+            .map_err(|e| DataFusionError::Execution(format!("create parquet writer: {e}")))?;
+
+    let mut total_rows = 0usize;
+    for part_file in part_files {
+        let src_file = File::open(part_file)
+            .map_err(|e| DataFusionError::Execution(format!("open part file: {e}")))?;
+        let reader = SerializedFileReader::try_from(src_file)
+            .map_err(|e| DataFusionError::Execution(format!("read part parquet: {e}")))?;
+
+        let meta = reader.metadata();
+        for rg_idx in 0..meta.num_row_groups() {
+            let rg_meta = meta.row_group(rg_idx);
+            let mut rg_writer = merged_writer
+                .next_row_group()
+                .map_err(|e| DataFusionError::Execution(format!("create row group: {e}")))?;
+
+            // Re-open the file for each row group so append_column can read
+            // column data via ChunkReader.
+            let chunk_reader = File::open(part_file)
+                .map_err(|e| DataFusionError::Execution(format!("open part: {e}")))?;
+
+            for col_idx in 0..rg_meta.num_columns() {
+                let col_meta = rg_meta.column(col_idx).clone();
+                let close_result = ColumnCloseResult {
+                    bytes_written: col_meta.compressed_size() as u64,
+                    rows_written: rg_meta.num_rows() as u64,
+                    metadata: col_meta,
+                    bloom_filter: None,
+                    column_index: None,
+                    offset_index: None,
+                };
+
+                rg_writer
+                    .append_column(&chunk_reader, close_result)
+                    .map_err(|e| DataFusionError::Execution(format!("append column chunk: {e}")))?;
+            }
+
+            rg_writer
+                .close()
+                .map_err(|e| DataFusionError::Execution(format!("close row group: {e}")))?;
+            total_rows += rg_meta.num_rows() as usize;
+        }
+    }
+
+    merged_writer
+        .close()
+        .map_err(|e| DataFusionError::Execution(format!("close merged parquet: {e}")))?;
+
+    Ok(total_rows)
+}
+
 fn project_batch(batch: &RecordBatch, target_schema: &SchemaRef) -> Result<RecordBatch> {
     let source_schema = batch.schema();
     let mut columns = Vec::with_capacity(target_schema.fields().len());
@@ -2230,6 +2251,7 @@ fn string_value(col: &dyn Array, row: usize) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
     use datafusion::arrow::array::{Int64Array, StringArray};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use std::collections::HashMap;
@@ -2255,8 +2277,19 @@ mod tests {
         alleles: Vec<&str>,
         names: Vec<&str>,
     ) -> RecordBatch {
+        make_batch_with_schema(variation_schema(), chroms, starts, ends, alleles, names)
+    }
+
+    fn make_batch_with_schema(
+        schema: SchemaRef,
+        chroms: Vec<&str>,
+        starts: Vec<i64>,
+        ends: Vec<i64>,
+        alleles: Vec<&str>,
+        names: Vec<&str>,
+    ) -> RecordBatch {
         RecordBatch::try_new(
-            variation_schema(),
+            schema,
             vec![
                 Arc::new(StringArray::from(chroms)),
                 Arc::new(Int64Array::from(starts)),
@@ -4011,6 +4044,51 @@ mod tests {
             all_starts,
             vec![100, 200, 300, 400, 500, 600, 700, 800, 900],
             "merged data should preserve order and values"
+        );
+    }
+
+    #[test]
+    fn test_zero_copy_merge_preserves_arrow_schema_metadata() {
+        use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path();
+
+        let mut schema_metadata = HashMap::new();
+        schema_metadata.insert(
+            CACHE_SOURCE_METADATA_KEY.to_string(),
+            CacheSourceType::RefSeq.as_str().to_string(),
+        );
+        let schema = Arc::new(
+            variation_schema()
+                .as_ref()
+                .clone()
+                .with_metadata(schema_metadata),
+        );
+        let batch = make_batch_with_schema(
+            schema,
+            vec!["1", "1"],
+            vec![100, 200],
+            vec![100, 200],
+            vec!["A/G", "C/T"],
+            vec!["rs1", "rs2"],
+        );
+        let part_path = format!("{}/part_0.parquet", dir_path.display());
+        write_parquet(&part_path, &[batch]);
+
+        let merged_path = format!("{}/merged.parquet", dir_path.display());
+        merge_parquet_row_groups(&[part_path], &merged_path, None).unwrap();
+
+        let merged_file = File::open(&merged_path).unwrap();
+        let arrow_metadata =
+            ArrowReaderMetadata::load(&merged_file, ArrowReaderOptions::default()).unwrap();
+        assert_eq!(
+            arrow_metadata
+                .schema()
+                .metadata()
+                .get(CACHE_SOURCE_METADATA_KEY)
+                .map(String::as_str),
+            Some(CacheSourceType::RefSeq.as_str())
         );
     }
 

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -27,8 +27,9 @@ use futures::StreamExt;
 use log::info;
 
 use datafusion_bio_format_ensembl_cache::{
-    EnsemblCacheOptions, EnsemblCacheTableProvider, EnsemblEntityKind, VEP_CACHE_REGION_SIZE_BP,
-    build_export_query, build_export_query_multi_chrom,
+    CacheSourceType as BioFormatsCacheSourceType, EnsemblCacheOptions, EnsemblCacheTableProvider,
+    EnsemblEntityKind, VEP_CACHE_REGION_SIZE_BP, build_export_query,
+    build_export_query_multi_chrom,
 };
 
 use crate::annotate_provider::read_compact_predictions;
@@ -79,7 +80,7 @@ fn build_translation_dedup_query_with_where_clause(table_name: &str, where_claus
     format!(
         "SELECT * FROM (\
             SELECT *, ROW_NUMBER() OVER (\
-                PARTITION BY transcript_id \
+                PARTITION BY chrom, transcript_id \
                 ORDER BY {source_pref}, cdna_coding_start NULLS LAST, source_file\
             ) AS _rn \
             FROM {table_name}{where_clause}\
@@ -104,6 +105,7 @@ pub struct CacheBuilder {
     overwrite: bool,
     zstd_level: i32,
     dict_size_kb: u32,
+    cache_source_type: BioFormatsCacheSourceType,
     on_progress: Option<Arc<OnProgress>>,
 }
 
@@ -117,6 +119,7 @@ impl CacheBuilder {
             overwrite: false,
             zstd_level: 3,
             dict_size_kb: 112,
+            cache_source_type: BioFormatsCacheSourceType::Ensembl,
             on_progress: None,
         }
     }
@@ -143,6 +146,11 @@ impl CacheBuilder {
 
     pub fn with_dict_size_kb(mut self, size: u32) -> Self {
         self.dict_size_kb = size;
+        self
+    }
+
+    pub fn with_cache_source_type(mut self, cache_source_type: BioFormatsCacheSourceType) -> Self {
+        self.cache_source_type = cache_source_type;
         self
     }
 
@@ -273,7 +281,13 @@ impl CacheBuilder {
         }
 
         // Discover chromosomes from schema metadata
-        let init_ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+        let init_ctx = make_ctx_and_register(
+            &self.cache_root,
+            kind,
+            table_name,
+            self.partitions,
+            self.cache_source_type,
+        )?;
         let provider_schema = {
             let table = init_ctx.table(table_name).await?;
             table.schema().inner().clone()
@@ -324,7 +338,13 @@ impl CacheBuilder {
         let mut other_total_rows = 0usize;
 
         for (chrom, output_file, is_other) in &chrom_batches {
-            let ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+            let ctx = make_ctx_and_register(
+                &self.cache_root,
+                kind,
+                table_name,
+                self.partitions,
+                self.cache_source_type,
+            )?;
             let query = build_export_query(kind, table_name, Some(chrom), None);
 
             let df = ctx.sql(&query).await?;
@@ -1059,7 +1079,13 @@ impl CacheBuilder {
         }
 
         // Discover chroms
-        let init_ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+        let init_ctx = make_ctx_and_register(
+            &self.cache_root,
+            kind,
+            table_name,
+            self.partitions,
+            self.cache_source_type,
+        )?;
         let provider_schema = {
             let table = init_ctx.table(table_name).await?;
             table.schema().inner().clone()
@@ -1126,7 +1152,13 @@ impl CacheBuilder {
         kind: EnsemblEntityKind,
         table_name: &str,
     ) -> Result<(Option<(String, usize)>, Option<(String, usize)>)> {
-        let ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+        let ctx = make_ctx_and_register(
+            &self.cache_root,
+            kind,
+            table_name,
+            self.partitions,
+            self.cache_source_type,
+        )?;
 
         let dedup_query = build_translation_dedup_query_with_where_clause(
             table_name,
@@ -1154,7 +1186,10 @@ impl CacheBuilder {
         split_ctx.register_table("_tl_deduped", Arc::new(mem_table))?;
 
         // translation_core
-        let core_schema = datafusion_bio_format_ensembl_cache::translation_core_schema(false);
+        let core_schema = datafusion_bio_format_ensembl_cache::translation_core_schema(
+            false,
+            self.cache_source_type,
+        );
         let core_select = core_schema
             .fields()
             .iter()
@@ -1192,7 +1227,10 @@ impl CacheBuilder {
         })?;
 
         // translation_sift
-        let sift_schema = datafusion_bio_format_ensembl_cache::translation_sift_schema(false);
+        let sift_schema = datafusion_bio_format_ensembl_cache::translation_sift_schema(
+            false,
+            self.cache_source_type,
+        );
         let sift_select = sift_schema
             .fields()
             .iter()
@@ -1260,7 +1298,13 @@ impl CacheBuilder {
         kind: EnsemblEntityKind,
         table_name: &str,
     ) -> Result<(Option<(String, usize)>, Option<(String, usize)>)> {
-        let ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+        let ctx = make_ctx_and_register(
+            &self.cache_root,
+            kind,
+            table_name,
+            self.partitions,
+            self.cache_source_type,
+        )?;
         let in_list = other_chroms
             .iter()
             .map(|c| format!("'{c}'"))
@@ -1291,7 +1335,10 @@ impl CacheBuilder {
         );
         split_ctx.register_table("_tl_deduped", Arc::new(mem_table))?;
 
-        let core_schema = datafusion_bio_format_ensembl_cache::translation_core_schema(false);
+        let core_schema = datafusion_bio_format_ensembl_cache::translation_core_schema(
+            false,
+            self.cache_source_type,
+        );
         let core_select = core_schema
             .fields()
             .iter()
@@ -1313,7 +1360,10 @@ impl CacheBuilder {
             DataFusionError::Execution(format!("Failed to close parquet writer: {e}"))
         })?;
 
-        let sift_schema = datafusion_bio_format_ensembl_cache::translation_sift_schema(false);
+        let sift_schema = datafusion_bio_format_ensembl_cache::translation_sift_schema(
+            false,
+            self.cache_source_type,
+        );
         let sift_select = sift_schema
             .fields()
             .iter()
@@ -1533,7 +1583,13 @@ impl CacheBuilder {
         let needs_rn_drop = matches!(kind, EnsemblEntityKind::Exon);
 
         // Discover chroms + get schema (needed for transcript HGNC propagation).
-        let init_ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+        let init_ctx = make_ctx_and_register(
+            &self.cache_root,
+            kind,
+            table_name,
+            self.partitions,
+            self.cache_source_type,
+        )?;
         let provider_schema: SchemaRef = {
             let table = init_ctx.table(table_name).await?;
             Arc::new(table.schema().as_arrow().clone())
@@ -1561,7 +1617,13 @@ impl CacheBuilder {
         };
 
         for chrom in &main_chroms {
-            let ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+            let ctx = make_ctx_and_register(
+                &self.cache_root,
+                kind,
+                table_name,
+                self.partitions,
+                self.cache_source_type,
+            )?;
             let query = build_export_query(kind, table_name, Some(chrom), tx_schema);
             let output_file = format!("{}/{subdir}/chr{chrom}.parquet", self.output_dir);
 
@@ -1607,7 +1669,13 @@ impl CacheBuilder {
 
         // Process remaining contigs as "other.parquet"
         if !other_chroms.is_empty() {
-            let ctx = make_ctx_and_register(&self.cache_root, kind, table_name, self.partitions)?;
+            let ctx = make_ctx_and_register(
+                &self.cache_root,
+                kind,
+                table_name,
+                self.partitions,
+                self.cache_source_type,
+            )?;
             let other_refs: Vec<&str> = other_chroms.iter().map(|s| s.as_str()).collect();
             let query = build_export_query_multi_chrom(kind, table_name, &other_refs, tx_schema);
             let output_file = format!("{}/{subdir}/other.parquet", self.output_dir);
@@ -2016,10 +2084,12 @@ fn make_ctx_and_register(
     kind: EnsemblEntityKind,
     table_name: &str,
     partitions: usize,
+    cache_source_type: BioFormatsCacheSourceType,
 ) -> Result<SessionContext> {
     let config = SessionConfig::new().with_target_partitions(partitions);
     let ctx = SessionContext::new_with_config(config);
-    let mut options = EnsemblCacheOptions::new(cache_root);
+    let mut options =
+        EnsemblCacheOptions::new(cache_root).with_cache_source_type(cache_source_type);
     options.target_partitions = Some(partitions);
     let provider = EnsemblCacheTableProvider::for_entity(kind, options)?;
     ctx.register_table(table_name, provider)?;
@@ -2427,7 +2497,7 @@ mod tests {
             Some(&schema),
         );
         assert!(q.contains("ROW_NUMBER()"));
-        assert!(q.contains("PARTITION BY stable_id"));
+        assert!(q.contains("PARTITION BY chrom, stable_id"));
         assert!(q.contains("WHERE _rn = 1"));
         assert!(q.contains("ORDER BY chrom, start"));
         assert!(q.contains("WHERE chrom = 'X'"));
@@ -2469,7 +2539,7 @@ mod tests {
     #[test]
     fn test_build_query_exon_dedup() {
         let q = build_export_query(EnsemblEntityKind::Exon, "exon", None, None);
-        assert!(q.contains("PARTITION BY transcript_id, exon_number"));
+        assert!(q.contains("PARTITION BY chrom, transcript_id, exon_number"));
         assert!(q.contains("ORDER BY transcript_id, start"));
     }
 
@@ -2500,7 +2570,7 @@ mod tests {
         assert!(q.contains("WHERE chrom IN ('1', '2')"));
         assert!(q.contains("ROW_NUMBER()"));
         assert!(q.contains("WHERE _rn = 1"));
-        assert!(q.contains("PARTITION BY stable_id"));
+        assert!(q.contains("PARTITION BY chrom, stable_id"));
         // HGNC propagation is a runtime concern (see
         // apply_buffer_local_hgnc_propagation) — must not be embedded in the
         // cache-level export query.
@@ -2513,7 +2583,7 @@ mod tests {
     #[test]
     fn test_build_translation_dedup_query_prefers_transcript_start_region() {
         let q = build_translation_dedup_query_with_where_clause("tl", " WHERE chrom = '2'");
-        assert!(q.contains("PARTITION BY transcript_id"));
+        assert!(q.contains("PARTITION BY chrom, transcript_id"));
         assert!(q.contains("source_file LIKE CONCAT('%/'"));
         assert!(q.contains("cdna_coding_start NULLS LAST"));
         assert!(q.contains("WHERE chrom = '2'"));
@@ -2522,7 +2592,7 @@ mod tests {
     #[test]
     fn test_build_translation_dedup_query_multi_chrom_prefers_transcript_start_region() {
         let q = build_translation_dedup_query_with_where_clause("tl", " WHERE chrom IN ('2', 'X')");
-        assert!(q.contains("PARTITION BY transcript_id"));
+        assert!(q.contains("PARTITION BY chrom, transcript_id"));
         assert!(q.contains("source_file LIKE CONCAT('%/'"));
         assert!(q.contains("WHERE chrom IN ('2', 'X')"));
     }
@@ -3017,9 +3087,14 @@ mod tests {
         }
 
         let partitions = 8;
-        let ctx =
-            make_ctx_and_register(cache_root, EnsemblEntityKind::Variation, "var", partitions)
-                .unwrap();
+        let ctx = make_ctx_and_register(
+            cache_root,
+            EnsemblEntityKind::Variation,
+            "var",
+            partitions,
+            BioFormatsCacheSourceType::Ensembl,
+        )
+        .unwrap();
 
         let query = "SELECT * FROM var WHERE chrom = '1' ORDER BY chrom, start";
         let df = ctx.sql(query).await.unwrap();
@@ -3242,8 +3317,14 @@ mod tests {
         if !std::path::Path::new(cache_root).exists() {
             return;
         }
-        let ctx =
-            make_ctx_and_register(cache_root, EnsemblEntityKind::Variation, "var", 1).unwrap();
+        let ctx = make_ctx_and_register(
+            cache_root,
+            EnsemblEntityKind::Variation,
+            "var",
+            1,
+            BioFormatsCacheSourceType::Ensembl,
+        )
+        .unwrap();
         let table = ctx.table("var").await.unwrap();
         let schema = table.schema().inner().clone();
         let chroms = chroms_from_schema(&schema);
@@ -3308,9 +3389,14 @@ mod tests {
         // Run with 1 partition (sequential) and 8 partitions (parallel)
         // on a small chromosome to compare row counts.
         for partitions in [1, 8] {
-            let ctx =
-                make_ctx_and_register(cache_root, EnsemblEntityKind::Variation, "var", partitions)
-                    .unwrap();
+            let ctx = make_ctx_and_register(
+                cache_root,
+                EnsemblEntityKind::Variation,
+                "var",
+                partitions,
+                BioFormatsCacheSourceType::Ensembl,
+            )
+            .unwrap();
 
             let query = "SELECT COUNT(*) as cnt FROM var WHERE chrom = '22'";
             let batches = ctx.sql(query).await.unwrap().collect().await.unwrap();
@@ -3335,8 +3421,14 @@ mod tests {
             return;
         }
 
-        let ctx =
-            make_ctx_and_register(cache_root, EnsemblEntityKind::Variation, "var", 8).unwrap();
+        let ctx = make_ctx_and_register(
+            cache_root,
+            EnsemblEntityKind::Variation,
+            "var",
+            8,
+            BioFormatsCacheSourceType::Ensembl,
+        )
+        .unwrap();
 
         let query = "SELECT * FROM var WHERE chrom = '22' ORDER BY chrom, start";
         let df = ctx.sql(query).await.unwrap();
@@ -3376,8 +3468,14 @@ mod tests {
         std::fs::create_dir_all(&var_dir).unwrap();
 
         // Step 1: Write chr22 parquet
-        let ctx =
-            make_ctx_and_register(cache_root, EnsemblEntityKind::Variation, "var", 1).unwrap();
+        let ctx = make_ctx_and_register(
+            cache_root,
+            EnsemblEntityKind::Variation,
+            "var",
+            1,
+            BioFormatsCacheSourceType::Ensembl,
+        )
+        .unwrap();
         let query = "SELECT * FROM var WHERE chrom = '22' ORDER BY chrom, start";
         let df = ctx.sql(query).await.unwrap();
         let mut stream = df.execute_stream().await.unwrap();

--- a/datafusion/bio-function-vep/src/cache_source.rs
+++ b/datafusion/bio-function-vep/src/cache_source.rs
@@ -1,0 +1,168 @@
+//! VEP cache source-mode metadata helpers.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use datafusion::arrow::datatypes::Schema;
+use datafusion::common::{DataFusionError, Result};
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+
+pub(crate) const CACHE_SOURCE_METADATA_KEY: &str = "bio.vep.cache_source_type";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum CacheSourceType {
+    #[default]
+    Ensembl,
+    Merged,
+    RefSeq,
+}
+
+impl CacheSourceType {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ensembl => "ensembl",
+            Self::Merged => "merged",
+            Self::RefSeq => "refseq",
+        }
+    }
+
+    pub(crate) fn from_schema(schema: &Schema) -> Result<Self> {
+        let raw = schema.metadata().get(CACHE_SOURCE_METADATA_KEY).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "annotate_vep(): cache table schema is missing {CACHE_SOURCE_METADATA_KEY}; expected one of ensembl, merged, refseq"
+            ))
+        })?;
+        raw.parse()
+    }
+
+    pub(crate) fn from_partitioned_cache_source(cache_source: &str) -> Result<Self> {
+        let parquet = first_variation_parquet(cache_source)?;
+        Self::from_parquet_file(&parquet)
+    }
+
+    pub(crate) fn from_parquet_file(parquet: &Path) -> Result<Self> {
+        let file = File::open(parquet).map_err(|err| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): failed to open cache parquet '{}': {err}",
+                parquet.display()
+            ))
+        })?;
+        let metadata =
+            ArrowReaderMetadata::load(&file, ArrowReaderOptions::default()).map_err(|err| {
+                DataFusionError::Execution(format!(
+                    "annotate_vep(): failed to read Arrow schema metadata from cache parquet '{}': {err}",
+                    parquet.display()
+                ))
+            })?;
+        Self::from_schema(metadata.schema().as_ref())
+    }
+}
+
+impl FromStr for CacheSourceType {
+    type Err = DataFusionError;
+
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw {
+            "ensembl" => Ok(Self::Ensembl),
+            "merged" => Ok(Self::Merged),
+            "refseq" => Ok(Self::RefSeq),
+            other => Err(DataFusionError::Plan(format!(
+                "annotate_vep(): unsupported {CACHE_SOURCE_METADATA_KEY} '{other}'; expected one of ensembl, merged, refseq"
+            ))),
+        }
+    }
+}
+
+fn first_variation_parquet(cache_source: &str) -> Result<PathBuf> {
+    let variation_dir = Path::new(cache_source).join("variation");
+    if !variation_dir.is_dir() {
+        return Err(DataFusionError::Plan(format!(
+            "annotate_vep(): cache source '{}' must contain a variation/ directory with parquet files carrying {CACHE_SOURCE_METADATA_KEY}",
+            cache_source
+        )));
+    }
+
+    let mut dirs = vec![variation_dir];
+    let mut parquet_files = Vec::new();
+    while let Some(dir) = dirs.pop() {
+        let entries = std::fs::read_dir(&dir).map_err(|err| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): failed to read cache variation directory '{}': {err}",
+                dir.display()
+            ))
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|err| {
+                DataFusionError::Execution(format!(
+                    "annotate_vep(): failed to read cache variation directory '{}': {err}",
+                    dir.display()
+                ))
+            })?;
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "parquet") {
+                parquet_files.push(path);
+            }
+        }
+        dirs.sort();
+    }
+    parquet_files.sort();
+    parquet_files.into_iter().next().ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "annotate_vep(): cache source '{}' variation/ directory contains no parquet files carrying {CACHE_SOURCE_METADATA_KEY}",
+            cache_source
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use datafusion::arrow::datatypes::{DataType, Field};
+
+    use super::*;
+
+    fn schema_with_source(value: &str) -> Schema {
+        let mut metadata = HashMap::new();
+        metadata.insert(CACHE_SOURCE_METADATA_KEY.to_string(), value.to_string());
+        Schema::new(vec![Field::new("chrom", DataType::Utf8, false)]).with_metadata(metadata)
+    }
+
+    #[test]
+    fn parses_supported_cache_source_metadata() {
+        assert_eq!(
+            CacheSourceType::from_schema(&schema_with_source("ensembl")).unwrap(),
+            CacheSourceType::Ensembl
+        );
+        assert_eq!(
+            CacheSourceType::from_schema(&schema_with_source("merged")).unwrap(),
+            CacheSourceType::Merged
+        );
+        assert_eq!(
+            CacheSourceType::from_schema(&schema_with_source("refseq")).unwrap(),
+            CacheSourceType::RefSeq
+        );
+    }
+
+    #[test]
+    fn rejects_missing_invalid_and_case_variant_source_metadata() {
+        let missing = Schema::new(vec![Field::new("chrom", DataType::Utf8, false)]);
+        let err = CacheSourceType::from_schema(&missing)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("missing bio.vep.cache_source_type"));
+
+        let err = CacheSourceType::from_schema(&schema_with_source("RefSeq"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("unsupported bio.vep.cache_source_type 'RefSeq'"));
+
+        let err = CacheSourceType::from_schema(&schema_with_source("other"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("expected one of ensembl, merged, refseq"));
+    }
+}

--- a/datafusion/bio-function-vep/src/cache_source.rs
+++ b/datafusion/bio-function-vep/src/cache_source.rs
@@ -106,7 +106,6 @@ fn first_variation_parquet(cache_source: &str) -> Result<PathBuf> {
                 parquet_files.push(path);
             }
         }
-        dirs.sort();
     }
     parquet_files.sort();
     parquet_files.into_iter().next().ok_or_else(|| {

--- a/datafusion/bio-function-vep/src/lib.rs
+++ b/datafusion/bio-function-vep/src/lib.rs
@@ -43,6 +43,7 @@ pub mod annotate_table_function;
 pub mod annotation_store;
 #[cfg(feature = "cache-builder")]
 pub mod cache_builder;
+pub(crate) mod cache_source;
 pub mod config;
 pub mod coordinate;
 pub mod golden_benchmark;

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -3040,25 +3040,6 @@ fn is_non_coding_biotype(biotype: &str) -> bool {
     )
 }
 
-/// Returns true for transcript IDs that VEP annotates against.
-/// When `merged` is true (VEP `--merged` mode), both Ensembl and RefSeq
-/// transcripts are accepted.  Default (non-merged) accepts only ENST.
-///
-/// Traceability:
-/// - Ensembl VEP `AnnotationSourceAdaptor::get_all_TranscriptVariations()`
-///   <https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/AnnotationSourceAdaptor.pm#L173-L220>
-pub fn is_vep_transcript(id: &str, merged: bool) -> bool {
-    if merged {
-        id.starts_with("ENST")
-            || id.starts_with("NM_")
-            || id.starts_with("NR_")
-            || id.starts_with("XM_")
-            || id.starts_with("XR_")
-    } else {
-        id.starts_with("ENST")
-    }
-}
-
 /// Strip only `protein_altering_variant` when specific children are present.
 /// Used at the cross-transcript collapse level.
 ///

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -6,13 +6,15 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use datafusion::common::Result;
+use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::TableProvider;
 use datafusion::prelude::SessionContext;
 use datafusion_bio_format_vcf::serializer::batch_to_vcf_lines;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use datafusion_bio_format_vcf::{VcfCompressionType, VcfLocalWriter};
 use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::cache_source::CacheSourceType;
 
 /// Callback invoked after each batch is written to VCF.
 /// Arguments: (rows_in_batch, total_rows_written_so_far, total_input_rows).
@@ -201,12 +203,6 @@ impl AnnotateVcfConfig {
         if self.hgvsp_use_prediction {
             opts.insert("hgvsp_use_prediction".into(), serde_json::Value::Bool(true));
         }
-        if self.refseq {
-            opts.insert("refseq".into(), serde_json::Value::Bool(true));
-        }
-        if self.merged {
-            opts.insert("merged".into(), serde_json::Value::Bool(true));
-        }
         if self.gencode_basic {
             opts.insert("gencode_basic".into(), serde_json::Value::Bool(true));
         }
@@ -240,11 +236,14 @@ impl AnnotateVcfConfig {
     }
 }
 
-fn csq_header_description(config: &AnnotateVcfConfig) -> String {
+fn csq_header_description(
+    config: &AnnotateVcfConfig,
+    cache_source_type: CacheSourceType,
+) -> String {
     let field_names = crate::golden_benchmark::csq_field_names_for_mode_with_pick(
         config.everything,
-        config.refseq,
-        config.merged,
+        cache_source_type == CacheSourceType::RefSeq,
+        cache_source_type == CacheSourceType::Merged,
         config.include_pick_output(),
     );
     let format_list = field_names.join("|");
@@ -272,6 +271,13 @@ pub async fn annotate_to_vcf(
     output_vcf: &str,
     config: &AnnotateVcfConfig,
 ) -> Result<usize> {
+    if config.refseq || config.merged {
+        return Err(DataFusionError::Plan(
+            "annotate_to_vcf(): refseq and merged config fields are unsupported; cache source mode must come from cache schema metadata bio.vep.cache_source_type".to_string(),
+        ));
+    }
+    let cache_source_type = CacheSourceType::from_partitioned_cache_source(cache_source)?;
+
     // 1. Create session and register VCF table.
     let session_config = datafusion::prelude::SessionConfig::new().with_target_partitions(1);
     let ctx = SessionContext::new_with_config(session_config);
@@ -426,7 +432,7 @@ pub async fn annotate_to_vcf(
                 }
                 arrow_field.with_metadata(merged_metadata)
             } else if name == "CSQ" {
-                let description = csq_header_description(config);
+                let description = csq_header_description(config, cache_source_type);
                 let mut meta = std::collections::HashMap::new();
                 meta.insert("bio.vcf.field.field_type".to_string(), "INFO".to_string());
                 meta.insert("bio.vcf.field.description".to_string(), description);
@@ -528,6 +534,19 @@ mod tests {
     }
 
     #[test]
+    fn test_to_options_json_does_not_emit_source_selectors() {
+        let config = AnnotateVcfConfig {
+            refseq: true,
+            merged: true,
+            ..Default::default()
+        };
+
+        let json = config.to_options_json();
+        assert!(!json.contains("\"refseq\""));
+        assert!(!json.contains("\"merged\""));
+    }
+
+    #[test]
     fn test_csq_header_description_matches_vep_pick_layout() {
         let config = AnnotateVcfConfig {
             everything: true,
@@ -535,7 +554,7 @@ mod tests {
             ..Default::default()
         };
 
-        let description = csq_header_description(&config);
+        let description = csq_header_description(&config, CacheSourceType::Ensembl);
         assert!(description.starts_with("Consequence annotations from annotate_vep. Format: "));
         assert!(description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
     }
@@ -548,7 +567,7 @@ mod tests {
             ..Default::default()
         };
 
-        let description = csq_header_description(&config);
+        let description = csq_header_description(&config, CacheSourceType::Ensembl);
         assert!(!description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
     }
 }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -261,6 +261,10 @@ fn csq_header_description(
 /// are NOT written to the VCF — only core VCF columns, original INFO/FORMAT
 /// fields, and the `csq` annotation are included.
 ///
+/// Cache source mode is read from Arrow schema metadata on a parquet file under
+/// `{cache_source}/variation`. That directory must be readable even when
+/// `backend` selects a non-parquet annotation store such as `fjall`.
+///
 /// # Returns
 ///
 /// The number of rows written.

--- a/datafusion/bio-function-vep/tests/arrow_roundtrip_golden.rs
+++ b/datafusion/bio-function-vep/tests/arrow_roundtrip_golden.rs
@@ -21,6 +21,8 @@ use datafusion::arrow::compute::concat_batches;
 use datafusion::prelude::*;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
+mod common;
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 fn is_lfs_pointer(path: &std::path::Path) -> bool {
@@ -251,7 +253,8 @@ async fn test_arrow_typed_columns_vs_golden_vep115() {
         return;
     }
 
-    let cache_str = cache_path.to_str().unwrap();
+    let cache_with_metadata = common::cache_with_source_metadata(&cache_path, "ensembl");
+    let cache_str = cache_with_metadata.path().to_str().unwrap();
     let ref_fasta_str = ref_fasta.to_str().unwrap();
 
     // ── 1. Annotate via annotate_vep() → typed Arrow columns ─────────

--- a/datafusion/bio-function-vep/tests/common/mod.rs
+++ b/datafusion/bio-function-vep/tests/common/mod.rs
@@ -1,0 +1,67 @@
+use std::fs::File;
+use std::path::Path;
+use std::sync::Arc;
+
+use datafusion::arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+const CACHE_SOURCE_METADATA_KEY: &str = "bio.vep.cache_source_type";
+
+pub fn cache_with_source_metadata(cache_dir: &Path, source: &str) -> tempfile::TempDir {
+    let tempdir = tempfile::TempDir::new().expect("create metadata cache tempdir");
+    copy_cache_with_metadata(cache_dir, tempdir.path(), source)
+        .expect("copy golden cache with source metadata");
+    tempdir
+}
+
+fn copy_cache_with_metadata(
+    source_dir: &Path,
+    target_dir: &Path,
+    source: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::create_dir_all(target_dir)?;
+    for entry in std::fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let target_path = target_dir.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_cache_with_metadata(&source_path, &target_path, source)?;
+        } else if source_path
+            .extension()
+            .is_some_and(|extension| extension == "parquet")
+        {
+            rewrite_parquet_with_metadata(&source_path, &target_path, source)?;
+        } else {
+            std::fs::copy(&source_path, &target_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn rewrite_parquet_with_metadata(
+    source_path: &Path,
+    target_path: &Path,
+    source: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source_file = File::open(source_path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(source_file)?;
+    let mut schema = builder.schema().as_ref().clone();
+    let mut metadata = schema.metadata().clone();
+    metadata.insert(CACHE_SOURCE_METADATA_KEY.to_string(), source.to_string());
+    schema = schema.with_metadata(metadata);
+    let schema = Arc::new(schema);
+
+    if let Some(parent) = target_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let target_file = File::create(target_path)?;
+    let mut writer = ArrowWriter::try_new(target_file, schema.clone(), None)?;
+    for batch in builder.build()? {
+        let batch = batch?;
+        let batch = RecordBatch::try_new(schema.clone(), batch.columns().to_vec())?;
+        writer.write(&batch)?;
+    }
+    writer.close()?;
+    Ok(())
+}

--- a/datafusion/bio-function-vep/tests/vcf_passthrough.rs
+++ b/datafusion/bio-function-vep/tests/vcf_passthrough.rs
@@ -12,6 +12,8 @@ use datafusion::prelude::*;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use datafusion_bio_function_vep::register_vep_functions;
 
+mod common;
+
 /// Resolve a path relative to the workspace root (two levels up from CARGO_MANIFEST_DIR).
 /// Check if a file is a Git LFS pointer (not actual content).
 fn is_lfs_pointer(path: &std::path::Path) -> bool {
@@ -38,7 +40,11 @@ fn count_non_null_strings(array: &dyn Array) -> usize {
 
 async fn build_test_query(
     sql_select: &str,
-) -> Option<(datafusion::prelude::DataFrame, Vec<String>)> {
+) -> Option<(
+    datafusion::prelude::DataFrame,
+    Vec<String>,
+    tempfile::TempDir,
+)> {
     let input_vcf = workspace_path("vep-benchmark/data/golden/input_1000.vcf");
     if !input_vcf.exists() || is_lfs_pointer(&input_vcf) {
         eprintln!(
@@ -49,7 +55,8 @@ async fn build_test_query(
     }
     let input_vcf = input_vcf.to_str().unwrap();
     let cache_path = workspace_path("vep-benchmark/data/golden/cache");
-    let cache_path = cache_path.to_str().unwrap();
+    let cache_with_metadata = common::cache_with_source_metadata(&cache_path, "ensembl");
+    let cache_path = cache_with_metadata.path().to_str().unwrap();
 
     let input_str = input_vcf.to_string();
     let vcf_provider = tokio::task::spawn_blocking(move || {
@@ -76,12 +83,13 @@ async fn build_test_query(
          \"reference_fasta_path\":\"{ref_fasta}\"}}')"
     );
     let df = ctx.sql(&sql).await.unwrap();
-    Some((df, input_field_names))
+    Some((df, input_field_names, cache_with_metadata))
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_vcf_columns_pass_through_annotation() {
-    let Some((df, input_field_names)) = build_test_query("SELECT *").await else {
+    let Some((df, input_field_names, _cache_with_metadata)) = build_test_query("SELECT *").await
+    else {
         return;
     };
     let output_schema = df.schema().clone();
@@ -134,7 +142,9 @@ async fn test_vcf_columns_pass_through_annotation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_projection_including_csq_preserves_values() {
-    let Some((df, _)) = build_test_query("SELECT chrom, start, \"CSQ\"").await else {
+    let Some((df, _, _cache_with_metadata)) =
+        build_test_query("SELECT chrom, start, \"CSQ\"").await
+    else {
         return;
     };
 
@@ -157,7 +167,7 @@ async fn test_projection_including_csq_preserves_values() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_projection_omitting_csq_skips_column() {
-    let Some((df, _)) = build_test_query("SELECT chrom, start").await else {
+    let Some((df, _, _cache_with_metadata)) = build_test_query("SELECT chrom, start").await else {
         return;
     };
 

--- a/datafusion/bio-function-vep/tests/vcf_roundtrip_golden.rs
+++ b/datafusion/bio-function-vep/tests/vcf_roundtrip_golden.rs
@@ -14,6 +14,8 @@ use datafusion::prelude::*;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use datafusion_bio_function_vep::vcf_sink;
 
+mod common;
+
 /// Check if a file is a Git LFS pointer (not actual content).
 fn is_lfs_pointer(path: &std::path::Path) -> bool {
     std::fs::read_to_string(path)
@@ -44,7 +46,8 @@ async fn test_roundtrip_golden_all_column_values() {
     }
     let input_vcf = input_vcf.to_str().unwrap();
     let golden_vcf = golden_vcf.to_str().unwrap();
-    let cache_path = cache_path.to_str().unwrap();
+    let cache_with_metadata = common::cache_with_source_metadata(&cache_path, "ensembl");
+    let cache_path = cache_with_metadata.path().to_str().unwrap();
     let ref_fasta = ref_fasta.to_str().unwrap();
 
     // ── Step 1: Annotate and write to VCF ──────────────────────────

--- a/datafusion/bio-function-vep/tests/vcf_roundtrip_golden_fjall.rs
+++ b/datafusion/bio-function-vep/tests/vcf_roundtrip_golden_fjall.rs
@@ -13,6 +13,8 @@ use datafusion::prelude::*;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use datafusion_bio_function_vep::vcf_sink;
 
+mod common;
+
 /// Check if a file is a Git LFS pointer (not actual content).
 fn is_lfs_pointer(path: &std::path::Path) -> bool {
     std::fs::read_to_string(path)
@@ -212,7 +214,6 @@ async fn test_roundtrip_golden_fjall_all_column_values() {
     let input_vcf = workspace_path("vep-benchmark/data/golden/input_1000.vcf");
     let golden_vcf = workspace_path("vep-benchmark/data/golden/golden_1000_vep115.vcf");
     let parquet_cache = workspace_path("vep-benchmark/data/golden/cache");
-    let fjall_cache = workspace_path("vep-benchmark/data/golden/fjall_cache");
     let ref_fasta = workspace_path("vep-benchmark/data/golden/reference_chr1.fa");
 
     if !input_vcf.exists() || !golden_vcf.exists() || is_lfs_pointer(&input_vcf) {
@@ -220,7 +221,12 @@ async fn test_roundtrip_golden_fjall_all_column_values() {
         return;
     }
 
-    // Ensure fjall caches exist (generated from parquet on first run).
+    let parquet_cache_with_metadata = common::cache_with_source_metadata(&parquet_cache, "ensembl");
+    let parquet_cache = parquet_cache_with_metadata.path();
+
+    // Ensure fjall caches exist (generated from metadata-bearing parquet).
+    let fjall_tempdir = tempfile::TempDir::new().unwrap();
+    let fjall_cache = fjall_tempdir.path().join("fjall_cache");
     std::fs::create_dir_all(&fjall_cache).ok();
     let var_fjall = fjall_cache.join("variation.fjall");
     let sift_fjall = fjall_cache.join("translation_sift.fjall");
@@ -236,7 +242,7 @@ async fn test_roundtrip_golden_fjall_all_column_values() {
             .unwrap(),
         sift_fjall.to_str().unwrap(),
     );
-    ensure_context_symlinks(&fjall_cache, &parquet_cache);
+    ensure_context_symlinks(&fjall_cache, parquet_cache);
 
     let input_vcf = input_vcf.to_str().unwrap();
     let golden_vcf = golden_vcf.to_str().unwrap();

--- a/openspec/changes/add-vep-cache-source-mode/design.md
+++ b/openspec/changes/add-vep-cache-source-mode/design.md
@@ -1,0 +1,229 @@
+# VEP Cache Source Mode Design
+
+## Context
+
+`bio-function-vep` already supports Ensembl transcript annotation and a partial
+merged-cache mode via `options_json` key `merged`. RefSeq-only caches need
+different behavior: VEP accepts RefSeq stable IDs, preserves odd mitochondrial
+RefSeq transcript names, applies RefSeq hydration logic, and does not populate
+CSQ `SOURCE` merely because the cache is RefSeq-only.
+
+The companion `datafusion-bio-formats` change writes cache source mode into
+Arrow schema metadata from an explicit provider/export option:
+
+```
+bio.vep.cache_source_type = ensembl | merged | refseq
+```
+
+This repo consumes that metadata. It must not infer cache source mode from
+paths, table names, or option booleans.
+
+Research update:
+- `datafusion-bio-formats` commit
+  `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3` adds
+  `CacheSourceType`, exports `VEP_CACHE_SOURCE_TYPE_METADATA_KEY`, requires
+  `EnsemblCacheOptions.cache_source_type`, and writes
+  `bio.vep.cache_source_type` on variation, transcript, exon, translation,
+  translation split, regulatory, and motif schemas.
+- Ensembl VEP release/115 derives cache source type from `--merged`/`--refseq`
+  flags, rejects `homo_sapiens_refseq` and `homo_sapiens_merged` as species
+  names, filters RefSeq transcripts only for RefSeq caches or merged-cache rows
+  whose `_source_cache` is `RefSeq`, and exposes CSQ `SOURCE` through the
+  merged flag field set only.
+
+## Goals / Non-Goals
+
+Goals:
+- Require explicit source-mode metadata for VEP cache tables.
+- Remove `merged` boolean compatibility from `options_json`.
+- Match Ensembl VEP transcript inclusion behavior for Ensembl, merged, and
+  RefSeq caches.
+- Keep CSQ `SOURCE` output merged-only.
+- Keep the change local to `bio-function-vep` semantics and tests.
+
+Non-goals:
+- Registering or exporting native cache tables. That belongs to
+  `datafusion-bio-formats`.
+- Inferring source mode from directory names such as `homo_sapiens_refseq`.
+- Adding a new `annotate_vep()` positional argument for source mode.
+- Reworking cache storage backends or parquet layout.
+
+## Source Mode Contract
+
+Add a small internal enum:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheSourceType {
+    Ensembl,
+    Merged,
+    RefSeq,
+}
+```
+
+Parsing is strict:
+
+```rust
+impl CacheSourceType {
+    pub const METADATA_KEY: &'static str = "bio.vep.cache_source_type";
+
+    pub fn parse(raw: &str) -> Result<Self> {
+        match raw {
+            "ensembl" => Ok(Self::Ensembl),
+            "merged" => Ok(Self::Merged),
+            "refseq" => Ok(Self::RefSeq),
+            other => Err(DataFusionError::Plan(format!(
+                "annotate_vep(): unsupported bio.vep.cache_source_type '{other}'; expected one of ensembl, merged, refseq"
+            ))),
+        }
+    }
+
+    pub fn from_schema(schema: &Schema) -> Result<Self> {
+        let raw = schema.metadata().get(Self::METADATA_KEY).ok_or_else(|| {
+            DataFusionError::Plan(
+                "annotate_vep(): cache table schema is missing bio.vep.cache_source_type; expected one of ensembl, merged, refseq".to_string(),
+            )
+        })?;
+        Self::parse(raw)
+    }
+}
+```
+
+The helper can live in a new
+`datafusion/bio-function-vep/src/cache_source.rs` module to avoid adding more
+state to already-large `annotate_provider.rs`.
+
+## Validation Boundary
+
+Validate source mode at table-function planning time where possible:
+
+1. `AnnotateFunction::call()` rejects `options_json` containing top-level
+   source selector keys `merged` or `refseq` before creating the provider.
+2. For the current partitioned-cache path API, `AnnotateFunction::call()`
+   synchronously reads the Arrow schema metadata from the first
+   `variation/*.parquet` file under `cache_source`. This is required because
+   `AnnotateProvider::schema()` must already know whether RefSeq and `SOURCE`
+   output fields are present during planning.
+3. It stores `CacheSourceType` on `AnnotateProvider`.
+
+Context tables resolved later by `AnnotateProvider` should either:
+- carry the same `bio.vep.cache_source_type`, or
+- return a clear error if they are VEP cache tables and the metadata is missing
+  or inconsistent.
+
+The variation table source mode is authoritative for provider output schema.
+Transcript and other context table metadata must match it. If any context table
+metadata differs, return an error naming both values.
+
+## Transcript Filtering
+
+Replace boolean source-mode selection in `TranscriptSelectionFlags` and retire
+the unused `transcript_consequence::is_vep_transcript(id, merged)` helper or
+replace it with source-aware helper functions that operate on
+`TranscriptFeature`.
+
+Rules:
+
+| Source mode | Accepted rows |
+|---|---|
+| `Ensembl` | `stable_id` starts with `ENST` |
+| `RefSeq` | RefSeq stable IDs and RefSeq mitochondrial cache names |
+| `Merged` | `ENST` rows plus rows whose normalized row source is `RefSeq` and match RefSeq rules |
+
+RefSeq stable ID rules should match Ensembl VEP:
+- standard RefSeq IDs: `^[A-Z]{2}_\d+`
+- mitochondrial exceptions: `^\d{4}$|^(rna-)?[A-Z0-9]{3,}$`
+
+For merged mode, RefSeq ID and mitochondrial exceptions should be accepted only
+for rows whose source normalizes to `RefSeq`, so a non-RefSeq row with a
+gene-like ID is not accidentally included. This matches Ensembl VEP
+`AnnotationType::Transcript::filter_transcript()`, which applies the RefSeq
+whitelist for `source_type eq 'refseq'` or for `source_type eq 'merged'` rows
+whose `_source_cache` is `RefSeq`.
+
+## CSQ SOURCE Output
+
+Replace boolean `merged` output gating:
+
+```rust
+let source_val = if merged { source } else { "" };
+```
+
+with:
+
+```rust
+let source_val = if source_type == CacheSourceType::Merged {
+    source
+} else {
+    ""
+};
+```
+
+This preserves VEP's merged-cache-only `SOURCE` behavior and avoids incorrectly
+emitting `RefSeq` for RefSeq-only caches.
+
+## RefSeq Hydration
+
+Update `is_refseq_transcript_for_hydration()` so it accepts:
+- normalized row source `RefSeq`
+- standard RefSeq stable IDs (`NM_`, `NR_`, `XM_`, `XR_`)
+- RefSeq mitochondrial exceptions when source mode is `RefSeq` or row source is
+  normalized to `RefSeq`
+
+This keeps edited transcript and CDS reconstruction paths available for
+RefSeq-only caches.
+
+## Options JSON Migration
+
+`options_json` remains for existing non-source settings such as:
+- `failed`
+- `reference_fasta_path`
+- `transcripts_table`
+- `exons_table`
+- `distance`
+- `extended_probes`
+- `partitioned`
+
+But source mode is not read from `options_json`. If `merged` appears in
+`options_json`, return:
+
+```
+annotate_vep(): options_json key 'merged' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='merged'
+```
+
+If `refseq` appears in `options_json`, return:
+
+```
+annotate_vep(): options_json key 'refseq' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='refseq'
+```
+
+If `cache_source_type` appears in `options_json`, ignore it as an authority and
+continue requiring schema metadata. Tests should cover this to prevent a quiet
+fallback.
+
+## Cache Builder / Dependency Update
+
+The optional `cache-builder` feature currently depends on
+`datafusion-bio-format-ensembl-cache` and uses split translation schema helpers.
+After updating that dependency to
+`ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`, callers must pass an explicit
+`CacheSourceType` into `EnsemblCacheOptions` and split translation schema
+constructors. `CacheBuilder` should therefore require or store an explicit
+source type instead of guessing from cache paths.
+
+## Testing Strategy
+
+Unit tests:
+- parse `ensembl`, `merged`, `refseq`; reject missing/invalid metadata
+- reject `{"merged": true}` and `{"merged": false}`
+- source-specific transcript inclusion for `ENST`, `NM_`, `NR_`, `XM_`, `XR_`,
+  `4540`, `COX3`, and `rna-TRNK`
+- SOURCE output is populated only in merged mode
+- hydration eligibility includes RefSeq mitochondrial IDs
+
+Integration tests:
+- in-memory MemTable schemas with metadata for each source mode
+- gated real-cache tests using an environment variable such as
+  `DF_BIO_FUNCTION_REFSEQ_CACHE=/Users/mwiewior/workspace/data_vepyr/homo_sapiens_refseq/115_GRCh38`
+  after the companion format repo can export/register that cache with explicit
+  source metadata

--- a/openspec/changes/add-vep-cache-source-mode/design.md
+++ b/openspec/changes/add-vep-cache-source-mode/design.md
@@ -126,20 +126,21 @@ Rules:
 
 | Source mode | Accepted rows |
 |---|---|
-| `Ensembl` | `stable_id` starts with `ENST` |
+| `Ensembl` | any non-empty `stable_id` after common filters |
 | `RefSeq` | RefSeq stable IDs and RefSeq mitochondrial cache names |
-| `Merged` | `ENST` rows plus rows whose normalized row source is `RefSeq` and match RefSeq rules |
+| `Merged` | non-RefSeq-source rows after common filters, plus rows whose normalized row source is `RefSeq` and match RefSeq rules |
 
 RefSeq stable ID rules should match Ensembl VEP:
 - standard RefSeq IDs: `^[A-Z]{2}_\d+`
 - mitochondrial exceptions: `^\d{4}$|^(rna-)?[A-Z0-9]{3,}$`
 
-For merged mode, RefSeq ID and mitochondrial exceptions should be accepted only
-for rows whose source normalizes to `RefSeq`, so a non-RefSeq row with a
-gene-like ID is not accidentally included. This matches Ensembl VEP
+For merged mode, RefSeq ID and mitochondrial exceptions should be applied only
+for rows whose source normalizes to `RefSeq`. Other merged rows pass after the
+common stable-id and gencode filters. This matches Ensembl VEP
 `AnnotationType::Transcript::filter_transcript()`, which applies the RefSeq
 whitelist for `source_type eq 'refseq'` or for `source_type eq 'merged'` rows
-whose `_source_cache` is `RefSeq`.
+whose `_source_cache` is `RefSeq`; it does not impose an `ENST`-only rule on
+Ensembl-mode or merged Ensembl-source rows.
 
 ## CSQ SOURCE Output
 
@@ -216,8 +217,8 @@ source type instead of guessing from cache paths.
 Unit tests:
 - parse `ensembl`, `merged`, `refseq`; reject missing/invalid metadata
 - reject `{"merged": true}` and `{"merged": false}`
-- source-specific transcript inclusion for `ENST`, `NM_`, `NR_`, `XM_`, `XR_`,
-  `4540`, `COX3`, and `rna-TRNK`
+- source-specific transcript inclusion for non-`ENST` Ensembl-side stable IDs,
+  `NM_`, `NR_`, `XM_`, `XR_`, `4540`, `COX3`, and `rna-TRNK`
 - SOURCE output is populated only in merged mode
 - hydration eligibility includes RefSeq mitochondrial IDs
 

--- a/openspec/changes/add-vep-cache-source-mode/implementation-plan.md
+++ b/openspec/changes/add-vep-cache-source-mode/implementation-plan.md
@@ -1,0 +1,518 @@
+# Add VEP Cache Source Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `annotate_vep()` consume explicit VEP cache source mode metadata (`bio.vep.cache_source_type = ensembl | merged | refseq`), remove source selection from `options_json`, and match Ensembl VEP behavior for Ensembl, merged, and RefSeq caches.
+
+**Architecture:** Add a small internal cache-source module, resolve source mode from the variation parquet schema during table-function planning, carry `CacheSourceType` through `AnnotateProvider`, validate all cache table schemas against the same mode, and make transcript filtering, RefSeq hydration, and CSQ field selection source-mode aware.
+
+**Tech Stack:** Rust, Apache Arrow/DataFusion, Parquet, `datafusion-bio-function-vep`, optional `datafusion-bio-format-ensembl-cache` dependency pinned to BioFormats commit `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`.
+
+---
+
+## Evidence Checked
+
+- `datafusion-bio-formats` commit `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3` adds `CacheSourceType`, exports `VEP_CACHE_SOURCE_TYPE_METADATA_KEY`, requires `EnsemblCacheOptions.cache_source_type`, and writes `bio.vep.cache_source_type` on all VEP cache schemas.
+- Ensembl VEP `release/115` derives cache source mode from `--merged` and `--refseq`, rejects source mode embedded in species names, applies RefSeq filtering only for RefSeq caches or merged rows whose `_source_cache` is `RefSeq`, and exposes CSQ `SOURCE` only through the merged field set.
+- Current `bio-function-vep` builds the output schema in `AnnotateProvider::new(...)`, so source mode must be known before provider construction. For the current partitioned-cache path API, this means reading the Arrow schema metadata from a `variation/*.parquet` file during `AnnotateFunction::call()`.
+- Current `options_json` handling still reads source selectors (`merged`, `refseq`) in several places. Those reads must be removed or converted into explicit errors.
+
+## Files To Change
+
+- `datafusion/bio-function-vep/Cargo.toml`
+- `datafusion/bio-function-vep/src/lib.rs`
+- `datafusion/bio-function-vep/src/cache_source.rs` (new)
+- `datafusion/bio-function-vep/src/annotate_table_function.rs`
+- `datafusion/bio-function-vep/src/annotate_provider.rs`
+- `datafusion/bio-function-vep/src/transcript_consequence.rs`
+- `datafusion/bio-function-vep/src/cache_builder.rs`
+- `datafusion/bio-function-vep/src/vcf_sink.rs`
+- `datafusion/bio-function-vep/examples/annotate_vep_golden_bench.rs`
+- Existing tests in `datafusion/bio-function-vep/src/annotate_table_function.rs` and any source-specific unit tests close to the changed helpers.
+
+## Implementation Steps
+
+### 1. Add the Cache Source Contract
+
+- [ ] 1.1 Create `datafusion/bio-function-vep/src/cache_source.rs`.
+- [ ] 1.2 Add a local enum instead of depending on the optional BioFormats crate from normal function code:
+
+```rust
+use std::fs::File;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use arrow::datatypes::Schema;
+use datafusion::common::{DataFusionError, Result};
+use parquet::arrow::arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions};
+
+pub(crate) const CACHE_SOURCE_METADATA_KEY: &str = "bio.vep.cache_source_type";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CacheSourceType {
+    Ensembl,
+    Merged,
+    RefSeq,
+}
+
+impl CacheSourceType {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Ensembl => "ensembl",
+            Self::Merged => "merged",
+            Self::RefSeq => "refseq",
+        }
+    }
+
+    pub(crate) fn from_schema(schema: &Schema) -> Result<Self> {
+        let raw = schema.metadata().get(CACHE_SOURCE_METADATA_KEY).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "annotate_vep(): cache table schema is missing {CACHE_SOURCE_METADATA_KEY}; expected one of ensembl, merged, refseq"
+            ))
+        })?;
+        raw.parse()
+    }
+
+    pub(crate) fn from_partitioned_cache_source(cache_source: &str) -> Result<Self> {
+        let parquet = first_variation_parquet(cache_source)?;
+        let file = File::open(&parquet).map_err(|err| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): failed to open cache variation parquet '{}': {err}",
+                parquet.display()
+            ))
+        })?;
+        let metadata = ArrowReaderMetadata::load(&file, ArrowReaderOptions::default()).map_err(|err| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): failed to read Arrow schema metadata from cache variation parquet '{}': {err}",
+                parquet.display()
+            ))
+        })?;
+        Self::from_schema(metadata.schema().as_ref())
+    }
+}
+
+impl FromStr for CacheSourceType {
+    type Err = DataFusionError;
+
+    fn from_str(raw: &str) -> Result<Self> {
+        match raw {
+            "ensembl" => Ok(Self::Ensembl),
+            "merged" => Ok(Self::Merged),
+            "refseq" => Ok(Self::RefSeq),
+            other => Err(DataFusionError::Plan(format!(
+                "annotate_vep(): unsupported {CACHE_SOURCE_METADATA_KEY} '{other}'; expected one of ensembl, merged, refseq"
+            ))),
+        }
+    }
+}
+```
+
+- [ ] 1.3 Implement `first_variation_parquet(cache_source: &str) -> Result<PathBuf>` using the existing partitioned layout convention. It should search under `<cache_source>/variation` recursively enough for the existing layout and return the first `.parquet` file in deterministic sorted order.
+- [ ] 1.4 Add `pub(crate) mod cache_source;` to `datafusion/bio-function-vep/src/lib.rs`.
+- [ ] 1.5 Add unit tests for accepted values, missing metadata, invalid values, and case sensitivity.
+
+Implementation note: keep this enum local because `datafusion-bio-format-ensembl-cache` is optional behind `cache-builder`; normal `annotate_vep()` builds should not gain a required dependency on that crate.
+
+### 2. Reject Legacy Source Selectors at Table-Function Planning
+
+- [ ] 2.1 In `annotate_table_function.rs`, add a helper that inspects only top-level JSON object keys:
+
+```rust
+fn options_json_has_key(options_json: Option<&str>, key: &str) -> Result<bool> {
+    let Some(raw) = options_json else {
+        return Ok(false);
+    };
+    let Some(value) = parse_options_json_value(raw)? else {
+        return Ok(false);
+    };
+    Ok(value.as_object().is_some_and(|obj| obj.contains_key(key)))
+}
+
+fn reject_options_json_source_selectors(options_json: Option<&str>) -> Result<()> {
+    for key in ["merged", "refseq"] {
+        if options_json_has_key(options_json, key)? {
+            return Err(DataFusionError::Plan(format!(
+                "annotate_vep(): options_json key '{key}' is unsupported; register/export cache tables with schema metadata {CACHE_SOURCE_METADATA_KEY}='{key}'"
+            )));
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] 2.2 If the existing JSON parsing helper is private to another module, either move the selector rejection helper there or parse with `serde_json::from_str::<serde_json::Value>()` locally and preserve existing invalid JSON error style.
+- [ ] 2.3 In `AnnotateFunction::call()`, call `reject_options_json_source_selectors(options_json.as_deref())?` immediately after extracting `options_json`.
+- [ ] 2.4 Still ignore `options_json.cache_source_type` as an authority. Missing schema metadata must remain an error even if that option exists.
+- [ ] 2.5 Add tests for `{"merged":true}`, `{"merged":false}`, `{"refseq":true}`, and `{"refseq":false}`.
+
+The exact error strings expected by tests:
+
+```text
+annotate_vep(): options_json key 'merged' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='merged'
+annotate_vep(): options_json key 'refseq' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='refseq'
+```
+
+### 3. Resolve Source Mode Before Provider Construction
+
+- [ ] 3.1 In `AnnotateFunction::call()`, after validating `options_json` and before `AnnotateProvider::new(...)`, read the mode:
+
+```rust
+let cache_source_type = CacheSourceType::from_partitioned_cache_source(&cache_source)?;
+```
+
+- [ ] 3.2 Pass the mode into provider construction:
+
+```rust
+let provider = AnnotateProvider::new(
+    session,
+    vcf_table,
+    cache_source,
+    backend,
+    cache_source_type,
+    options_json,
+    vcf_schema,
+)?;
+```
+
+- [ ] 3.3 Update every `AnnotateProvider::new(...)` call site, including temporary providers created inside context setup.
+- [ ] 3.4 Add missing-metadata and invalid-metadata tests that fail before execution because `schema()` must already know the source-mode-specific CSQ fields.
+- [ ] 3.5 Add a test where `options_json` contains `{"cache_source_type":"refseq"}` but parquet metadata is missing; it must still fail for missing metadata.
+
+### 4. Store Source Mode on `AnnotateProvider`
+
+- [ ] 4.1 In `annotate_provider.rs`, import `crate::cache_source::CacheSourceType`.
+- [ ] 4.2 Add `cache_source_type: CacheSourceType` to `AnnotateProvider`.
+- [ ] 4.3 Change `TranscriptSelectionFlags` to carry source mode:
+
+```rust
+struct TranscriptSelectionFlags {
+    cache_source_type: CacheSourceType,
+    gencode_basic: bool,
+    gencode_primary: bool,
+    all_refseq: bool,
+    exclude_predicted: bool,
+}
+```
+
+- [ ] 4.4 Change construction from `TranscriptSelectionFlags::from_options_json(options_json)` to:
+
+```rust
+let transcript_selection =
+    TranscriptSelectionFlags::from_options_json(cache_source_type, options_json)?;
+```
+
+- [ ] 4.5 Remove `TranscriptSourceMode`. Use `CacheSourceType` everywhere instead.
+- [ ] 4.6 Update `Debug` output to include `cache_source_type`.
+- [ ] 4.7 Add `cache_source_type: CacheSourceType` to `ContigAnnotationConfig` and pass it through `hydrate_window(...)`, lookup construction, and any temporary provider setup.
+
+### 5. Remove Source-Mode Reads from `options_json`
+
+- [ ] 5.1 Remove all source-mode reads like:
+
+```rust
+parse_json_bool_option(opts, "merged")
+parse_json_bool_option(opts, "refseq")
+```
+
+- [ ] 5.2 Keep non-source options unchanged: `failed`, `reference_fasta_path`, `transcripts_table`, `exons_table`, `distance`, `extended_probes`, `partitioned`, `all_refseq`, `exclude_predicted`, `gencode_basic`, `gencode_primary`, and backend options.
+- [ ] 5.3 Update `TranscriptSelectionFlags::from_options_json(...)` so `all_refseq` and `exclude_predicted` are only meaningful for RefSeq-capable modes:
+
+```rust
+match cache_source_type {
+    CacheSourceType::Ensembl if all_refseq || exclude_predicted => {
+        return Err(DataFusionError::Plan(
+            "annotate_vep(): all_refseq/exclude_predicted require cache schema metadata bio.vep.cache_source_type='refseq' or 'merged'".to_string(),
+        ));
+    }
+    _ => {}
+}
+```
+
+- [ ] 5.4 Run the source search at the end of the implementation and confirm no source mode is read from `options_json`:
+
+```bash
+rg 'parse_json_bool_option\(opts, "(merged|refseq)"|"\\"merged\\""|"\\"refseq\\""' \
+  datafusion/bio-function-vep/src \
+  datafusion/bio-function-vep/examples
+```
+
+Any remaining hits must be tests asserting rejection, fixture JSON, or user-facing error strings.
+
+### 6. Validate All Cache Table Metadata
+
+- [ ] 6.1 Add an async helper on `AnnotateProvider`:
+
+```rust
+async fn validate_registered_cache_source(&self, table: &str, role: &str) -> Result<()> {
+    let df = self.session.table(table).await?;
+    let schema = df.schema();
+    let actual = CacheSourceType::from_schema(schema.as_arrow().as_ref())?;
+    if actual != self.cache_source_type {
+        return Err(DataFusionError::Plan(format!(
+            "annotate_vep(): {role} table '{table}' has {CACHE_SOURCE_METADATA_KEY}='{}' but variation cache has {CACHE_SOURCE_METADATA_KEY}='{}'",
+            actual.as_str(),
+            self.cache_source_type.as_str(),
+        )));
+    }
+    Ok(())
+}
+```
+
+- [ ] 6.2 If `DFSchemaRef::as_arrow()` returns a borrowed schema rather than `SchemaRef` in the local DataFusion version, adjust the `.as_ref()` part to match the current API.
+- [ ] 6.3 Call this helper after registering or resolving each cache table used for a scan:
+  - variation table for the current contig
+  - transcript table
+  - exon table
+  - translation table
+  - split translation tables
+  - regulatory table
+  - motif table
+- [ ] 6.4 Missing metadata should be an error for these VEP cache tables. Do not silently skip missing metadata for backward compatibility.
+- [ ] 6.5 Add mismatch tests where variation metadata is `refseq` and transcript metadata is `ensembl`, and where transcript metadata is missing.
+
+### 7. Make Transcript Filtering Match Ensembl VEP
+
+- [ ] 7.1 Replace `TranscriptSelectionFlags::source_mode` logic with `cache_source_type`.
+- [ ] 7.2 Keep the existing prefilters for failed, gencode, `all_refseq`, and `exclude_predicted`, but base source-mode inclusion on `CacheSourceType`.
+- [ ] 7.3 Add source helpers near the existing transcript filtering helpers:
+
+```rust
+fn is_ensembl_transcript_id(id: &str) -> bool {
+    id.starts_with("ENST")
+}
+
+fn is_standard_refseq_accession(id: &str) -> bool {
+    let bytes = id.as_bytes();
+    bytes.len() >= 4 && bytes[0].is_ascii_uppercase() && bytes[1].is_ascii_uppercase() && bytes[2] == b'_' && bytes[3].is_ascii_digit()
+}
+
+fn is_mitochondrial_refseq_exception(tx: &TranscriptFeature) -> bool {
+    is_mitochondrial_contig(&tx.seq_region_name)
+        && (is_mitochondrial_refseq_name(&tx.transcript_id)
+            || tx
+                .display_xref
+                .as_deref()
+                .is_some_and(is_mitochondrial_refseq_name))
+}
+
+fn is_default_refseq_transcript_id(tx: &TranscriptFeature) -> bool {
+    is_standard_refseq_accession(&tx.transcript_id)
+        || is_mitochondrial_refseq_exception(tx)
+        || tx
+            .display_xref
+            .as_deref()
+            .is_some_and(is_standard_refseq_accession)
+}
+```
+
+- [ ] 7.4 Implement merged-row source detection using the normalized row source already present in the provider. Prefer `_source_cache`/`source_cache` when available; fall back to the exported source label only if that is the existing row field:
+
+```rust
+fn row_source_is_refseq(tx: &TranscriptFeature) -> bool {
+    normalize_source_label(tx.source_cache.as_deref().or(tx.source.as_deref()))
+        .is_some_and(|source| source == "RefSeq")
+}
+```
+
+- [ ] 7.5 Update `passes_transcript_selection(...)` to this shape:
+
+```rust
+match selection.cache_source_type {
+    CacheSourceType::Ensembl => is_ensembl_transcript_id(&tx.transcript_id),
+    CacheSourceType::RefSeq => {
+        selection.all_refseq || is_default_refseq_transcript_id(tx)
+    }
+    CacheSourceType::Merged => {
+        if is_ensembl_transcript_id(&tx.transcript_id) {
+            true
+        } else if row_source_is_refseq(tx) {
+            selection.all_refseq || is_default_refseq_transcript_id(tx)
+        } else {
+            false
+        }
+    }
+}
+```
+
+- [ ] 7.6 Keep `exclude_predicted` as an earlier RefSeq-only filter for `XM_`/`XR_`.
+- [ ] 7.7 Retire `transcript_consequence::is_vep_transcript(id, merged)` if it remains unused. If tests or future call sites need it, replace it with a `TranscriptFeature` plus `CacheSourceType` signature.
+- [ ] 7.8 Add unit tests for Ensembl, RefSeq, merged, numeric MT IDs, `COX3`, `rna-TRNK`, and a non-RefSeq merged row whose ID would otherwise match the MT exception pattern.
+
+### 8. Drive CSQ Fields from Source Mode
+
+- [ ] 8.1 Update annotation-column selection so RefSeq-specific fields appear for `CacheSourceType::RefSeq` and `CacheSourceType::Merged`.
+- [ ] 8.2 Ensure the CSQ `SOURCE` field appears only for `CacheSourceType::Merged`.
+- [ ] 8.3 Replace boolean gates like:
+
+```rust
+let source_val = if merged { source } else { "" };
+```
+
+with:
+
+```rust
+let source_val = if self.cache_source_type == CacheSourceType::Merged {
+    source
+} else {
+    ""
+};
+```
+
+- [ ] 8.4 Update `CsqPlaceholderLayout::for_mode(...)` and benchmark field comparison setup to derive `refseq_fields` and `source_field` from `CacheSourceType`:
+
+```rust
+let refseq_fields = matches!(cache_source_type, CacheSourceType::RefSeq | CacheSourceType::Merged);
+let source_field = cache_source_type == CacheSourceType::Merged;
+```
+
+- [ ] 8.5 Add tests proving merged mode emits `SOURCE`, while RefSeq-only and Ensembl-only modes leave it absent or empty according to the established schema contract.
+
+### 9. Extend RefSeq Hydration Eligibility
+
+- [ ] 9.1 Add `cache_source_type: CacheSourceType` to:
+  - `hydrate_window(...)`
+  - `hydrate_refseq_translation_cds_from_reference(...)`
+  - `hydrate_transcript_cdna_from_reference(...)`
+  - `is_refseq_transcript_for_hydration(...)`
+- [ ] 9.2 Implement hydration eligibility as:
+
+```rust
+fn is_refseq_transcript_for_hydration(tx: &TranscriptFeature, cache_source_type: CacheSourceType) -> bool {
+    row_source_is_refseq(tx)
+        || is_standard_refseq_accession(&tx.transcript_id)
+        || matches!(cache_source_type, CacheSourceType::RefSeq)
+            && is_mitochondrial_refseq_exception(tx)
+}
+```
+
+- [ ] 9.3 For merged mode, allow MT exceptions when `row_source_is_refseq(tx)` is true.
+- [ ] 9.4 Add tests proving `4540`, `COX3`, and `rna-TRNK` are hydration-eligible in RefSeq mode and for merged RefSeq rows.
+
+### 10. Update Test Fixtures to Carry Metadata
+
+- [ ] 10.1 Add helpers in `annotate_table_function.rs` tests:
+
+```rust
+fn schema_with_cache_source(fields: Vec<Field>, source: CacheSourceType) -> Arc<Schema> {
+    let mut metadata = HashMap::new();
+    metadata.insert(CACHE_SOURCE_METADATA_KEY.to_string(), source.as_str().to_string());
+    Arc::new(Schema::new(fields).with_metadata(metadata))
+}
+
+fn batch_with_cache_source(batch: &RecordBatch, source: CacheSourceType) -> RecordBatch {
+    let schema = batch.schema();
+    let mut metadata = schema.metadata().clone();
+    metadata.insert(CACHE_SOURCE_METADATA_KEY.to_string(), source.as_str().to_string());
+    let schema = Arc::new(schema.as_ref().clone().with_metadata(metadata));
+    RecordBatch::try_new(schema, batch.columns().to_vec()).expect("metadata-only schema update")
+}
+```
+
+- [ ] 10.2 Add `write_batch_to_cache_with_source(...)` and `write_batch_to_chrom_with_source(...)`.
+- [ ] 10.3 Keep existing fixture helpers as Ensembl defaults by forwarding to the source-aware helpers with `CacheSourceType::Ensembl`.
+- [ ] 10.4 Add a dedicated helper that writes parquet without source metadata for missing-metadata tests.
+- [ ] 10.5 Update RefSeq and merged tests to use source metadata instead of `options_json` source booleans.
+
+### 11. Update Optional Cache Builder Integration
+
+- [ ] 11.1 In `datafusion/bio-function-vep/Cargo.toml`, update the optional dependency:
+
+```toml
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/DataFusion-Bio/datafusion-bio-formats.git", rev = "ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3", optional = true }
+```
+
+- [ ] 11.2 In `cache_builder.rs`, import the BioFormats enum under the `cache-builder` feature:
+
+```rust
+use datafusion_bio_format_ensembl_cache::CacheSourceType as BioFormatsCacheSourceType;
+```
+
+- [ ] 11.3 Add a source-type field to `CacheBuilder` and require it in construction, or add a builder setter that must be called before execution:
+
+```rust
+pub struct CacheBuilder {
+    cache_root: PathBuf,
+    output_dir: PathBuf,
+    cache_source_type: BioFormatsCacheSourceType,
+}
+```
+
+- [ ] 11.4 Pass it to BioFormats options:
+
+```rust
+let mut options = EnsemblCacheOptions::new(cache_root)
+    .with_cache_source_type(self.cache_source_type);
+options.target_partitions = Some(partitions);
+```
+
+- [ ] 11.5 Update split translation schema calls:
+
+```rust
+translation_core_schema(false, self.cache_source_type)
+translation_sift_schema(false, self.cache_source_type)
+```
+
+- [ ] 11.6 Update cache-builder tests and examples to pass `BioFormatsCacheSourceType::Ensembl` unless they intentionally build RefSeq or merged caches.
+
+### 12. Update VCF Sink and Golden Benchmark Options
+
+- [ ] 12.1 In `vcf_sink.rs`, stop serializing `refseq` and `merged` into `options_json`.
+- [ ] 12.2 If `AnnotateVcfConfig` still exposes `refseq` and `merged`, either:
+  - return a clear error that source mode now comes from cache schema metadata, or
+  - deprecate the fields and ignore them only after tests verify they are not serialized.
+- [ ] 12.3 Prefer an explicit error for now, because silently ignoring these fields can hide a user migration bug.
+- [ ] 12.4 In `examples/annotate_vep_golden_bench.rs`, remove only our `annotate_vep()` `options_json` source flags. Keep Docker VEP `--refseq` and `--merged` flags for expected-output generation.
+
+### 13. Verification
+
+- [ ] 13.1 Run formatting:
+
+```bash
+cargo fmt
+```
+
+- [ ] 13.2 Run focused tests:
+
+```bash
+cargo test -p datafusion-bio-function-vep cache_source
+cargo test -p datafusion-bio-function-vep is_vep_transcript
+cargo test -p datafusion-bio-function-vep test_annotate_vep_rejects_options_json_source_selectors
+cargo test -p datafusion-bio-function-vep test_annotate_vep_refseq_and_merged_modes_emit_refseq_specific_csq_fields
+```
+
+- [ ] 13.3 Run the broader package tests:
+
+```bash
+cargo test -p datafusion-bio-function-vep annotate_vep
+```
+
+- [ ] 13.4 Run cache-builder checks after updating the BioFormats dependency:
+
+```bash
+cargo test -p datafusion-bio-function-vep --features cache-builder cache_builder
+cargo clippy -p datafusion-bio-function-vep --all-targets --features cache-builder -- -D warnings
+```
+
+- [ ] 13.5 Confirm source mode is no longer read from `options_json`:
+
+```bash
+rg 'parse_json_bool_option\(opts, "(merged|refseq)"|"\\"merged\\""|"\\"refseq\\""' \
+  datafusion/bio-function-vep/src \
+  datafusion/bio-function-vep/examples
+```
+
+- [ ] 13.6 Validate the OpenSpec change:
+
+```bash
+openspec validate add-vep-cache-source-mode --strict
+```
+
+## Commit Boundary
+
+Recommended implementation commits:
+
+1. Add `cache_source.rs`, planning-time metadata read, provider source-mode field, and tests for missing/invalid metadata.
+2. Remove `options_json` source selectors and update VCF sink/golden benchmark option generation.
+3. Replace transcript filtering, CSQ field selection, and RefSeq hydration with source-mode-aware behavior.
+4. Update fixtures and integration tests for Ensembl, RefSeq, and merged modes.
+5. Update optional cache-builder dependency and API calls to BioFormats commit `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`.

--- a/openspec/changes/add-vep-cache-source-mode/implementation-plan.md
+++ b/openspec/changes/add-vep-cache-source-mode/implementation-plan.md
@@ -277,10 +277,6 @@ async fn validate_registered_cache_source(&self, table: &str, role: &str) -> Res
 - [ ] 7.3 Add source helpers near the existing transcript filtering helpers:
 
 ```rust
-fn is_ensembl_transcript_id(id: &str) -> bool {
-    id.starts_with("ENST")
-}
-
 fn is_standard_refseq_accession(id: &str) -> bool {
     let bytes = id.as_bytes();
     bytes.len() >= 4 && bytes[0].is_ascii_uppercase() && bytes[1].is_ascii_uppercase() && bytes[2] == b'_' && bytes[3].is_ascii_digit()
@@ -318,25 +314,23 @@ fn row_source_is_refseq(tx: &TranscriptFeature) -> bool {
 
 ```rust
 match selection.cache_source_type {
-    CacheSourceType::Ensembl => is_ensembl_transcript_id(&tx.transcript_id),
+    CacheSourceType::Ensembl => true,
     CacheSourceType::RefSeq => {
         selection.all_refseq || is_default_refseq_transcript_id(tx)
     }
     CacheSourceType::Merged => {
-        if is_ensembl_transcript_id(&tx.transcript_id) {
-            true
-        } else if row_source_is_refseq(tx) {
+        if row_source_is_refseq(tx) {
             selection.all_refseq || is_default_refseq_transcript_id(tx)
         } else {
-            false
+            true
         }
     }
 }
 ```
 
-- [ ] 7.6 Keep `exclude_predicted` as an earlier RefSeq-only filter for `XM_`/`XR_`.
+- [ ] 7.6 Keep `exclude_predicted` as an earlier filter for `XM_`/`XR_` in RefSeq-capable modes.
 - [ ] 7.7 Retire `transcript_consequence::is_vep_transcript(id, merged)` if it remains unused. If tests or future call sites need it, replace it with a `TranscriptFeature` plus `CacheSourceType` signature.
-- [ ] 7.8 Add unit tests for Ensembl, RefSeq, merged, numeric MT IDs, `COX3`, `rna-TRNK`, and a non-RefSeq merged row whose ID would otherwise match the MT exception pattern.
+- [ ] 7.8 Add unit tests for Ensembl, RefSeq, merged, non-`ENST` Ensembl-side IDs, numeric MT IDs, `COX3`, `rna-TRNK`, and a non-RefSeq merged row whose ID would otherwise match the MT exception pattern.
 
 ### 8. Drive CSQ Fields from Source Mode
 

--- a/openspec/changes/add-vep-cache-source-mode/proposal.md
+++ b/openspec/changes/add-vep-cache-source-mode/proposal.md
@@ -1,0 +1,51 @@
+# Add Explicit VEP Cache Source Mode
+
+## Why
+
+`annotate_vep()` currently models Ensembl-vs-merged behavior with an optional
+`merged` boolean in `options_json`. That is not expressive enough for
+RefSeq-only caches and allows ambiguous execution when a cache table does not
+declare whether it represents Ensembl, merged, or RefSeq data.
+
+The companion `datafusion-bio-formats` change will expose
+`bio.vep.cache_source_type` schema metadata from an explicit
+`cache_source_type` provider/export option. `bio-function-vep` must consume that
+metadata and apply Ensembl VEP-compatible source-specific transcript semantics.
+
+## What Changes
+
+- Add an explicit `CacheSourceType`/source-mode contract with valid values
+  `ensembl`, `merged`, and `refseq`.
+- Require cache table schema metadata `bio.vep.cache_source_type`; missing or
+  invalid values are planning/execution errors.
+- Remove unsupported `merged = true` and `refseq = true` source-selection
+  handling from `options_json`.
+- Replace boolean merged transcript filtering with source-mode-aware filtering.
+- Support RefSeq-only transcript IDs, including Ensembl VEP's mitochondrial
+  RefSeq cache exceptions.
+- Populate CSQ `SOURCE` only for merged cache mode, not RefSeq-only mode.
+- Extend RefSeq hydration helpers so RefSeq-only caches get the same transcript
+  sequence handling as merged RefSeq rows.
+
+## Impact
+
+### Affected Specs
+- **NEW**: `vep-cache-source-mode` — source-mode contract for VEP annotation
+
+### Affected Code
+- `datafusion/bio-function-vep/src/config.rs` — source-mode enum and metadata key constants if kept in config
+- `datafusion/bio-function-vep/Cargo.toml` — update optional `datafusion-bio-format-ensembl-cache` dependency to the source-metadata commit
+- `datafusion/bio-function-vep/src/cache_source.rs` — source-mode enum, schema metadata parsing, partitioned parquet metadata loading
+- `datafusion/bio-function-vep/src/annotate_table_function.rs` — validate cache source metadata before provider construction and reject source selectors in `options_json`
+- `datafusion/bio-function-vep/src/annotate_provider.rs` — store source mode, use it for transcript filtering and CSQ `SOURCE`
+- `datafusion/bio-function-vep/src/transcript_consequence.rs` — replace `is_vep_transcript(id, merged)` with source-mode-aware filtering
+- `datafusion/bio-function-vep/src/schema_contract.rs` or a new `cache_source.rs` — shared validation helpers if extraction should be isolated
+- `datafusion/bio-function-vep/src/cache_builder.rs` — pass explicit cache source type through the cache-builder path when compiled with `cache-builder`
+- `datafusion/bio-function-vep/src/vcf_sink.rs` and `examples/annotate_vep_golden_bench.rs` — stop serializing source mode into `options_json`
+- `datafusion/bio-function-vep/tests/` or existing unit modules — source-mode, RefSeq, and rejected-option tests
+
+### Breaking Changes
+
+`options_json` no longer accepts `{"merged": true}` or `{"refseq": true}` as
+source selectors. Callers must register or export cache tables with schema
+metadata such as `bio.vep.cache_source_type = "merged"`.

--- a/openspec/changes/add-vep-cache-source-mode/specs/vep-cache-source-mode/spec.md
+++ b/openspec/changes/add-vep-cache-source-mode/specs/vep-cache-source-mode/spec.md
@@ -54,10 +54,10 @@ selector.
 The system SHALL filter transcripts according to the explicit cache source mode,
 matching Ensembl VEP cache behavior for Ensembl, merged, and RefSeq caches.
 
-#### Scenario: Ensembl mode accepts only Ensembl transcripts
+#### Scenario: Ensembl mode accepts stable transcripts
 - **WHEN** cache source mode is `ensembl`
-- **THEN** transcripts with stable IDs beginning `ENST` are included
-- **AND** RefSeq-only stable IDs such as `NM_000000.1`, `NR_000000.1`, `XM_000000.1`, and `XR_000000.1` are excluded
+- **THEN** transcripts with non-empty stable IDs are included after common gencode filters
+- **AND** transcript IDs are not required to begin `ENST`
 
 #### Scenario: RefSeq mode accepts canonical RefSeq transcripts
 - **WHEN** cache source mode is `refseq`
@@ -74,6 +74,7 @@ matching Ensembl VEP cache behavior for Ensembl, merged, and RefSeq caches.
 - **THEN** Ensembl transcript rows beginning `ENST` are included
 - **AND** RefSeq rows beginning `NM_`, `NR_`, `XM_`, or `XR_` are included
 - **AND** mitochondrial RefSeq rows accepted by Ensembl VEP are included when the row source is RefSeq
+- **AND** non-RefSeq-source rows with non-empty stable IDs are included even when their IDs do not begin `ENST`
 
 ### Requirement: Source-Specific CSQ SOURCE Output
 The system SHALL populate the CSQ `SOURCE` field only for merged cache mode.

--- a/openspec/changes/add-vep-cache-source-mode/specs/vep-cache-source-mode/spec.md
+++ b/openspec/changes/add-vep-cache-source-mode/specs/vep-cache-source-mode/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Explicit Cache Source Metadata
+The system SHALL require each VEP cache table consumed by `annotate_vep()` to
+declare schema metadata key `bio.vep.cache_source_type` with value `ensembl`,
+`merged`, or `refseq`.
+
+#### Scenario: Ensembl cache metadata is accepted
+- **WHEN** `annotate_vep()` reads a transcript, variation, or context table whose schema metadata contains `bio.vep.cache_source_type = "ensembl"`
+- **THEN** the table is accepted as an Ensembl cache table
+- **AND** source-specific transcript filtering uses Ensembl semantics
+
+#### Scenario: RefSeq cache metadata is accepted
+- **WHEN** `annotate_vep()` reads a transcript table whose schema metadata contains `bio.vep.cache_source_type = "refseq"`
+- **THEN** the table is accepted as a RefSeq cache table
+- **AND** source-specific transcript filtering uses RefSeq semantics
+
+#### Scenario: Merged cache metadata is accepted
+- **WHEN** `annotate_vep()` reads a transcript table whose schema metadata contains `bio.vep.cache_source_type = "merged"`
+- **THEN** the table is accepted as a merged cache table
+- **AND** source-specific transcript filtering uses merged-cache semantics
+
+#### Scenario: Missing source metadata is rejected
+- **WHEN** `annotate_vep()` is called with a cache table that does not expose `bio.vep.cache_source_type`
+- **THEN** the system returns a clear error requiring `ensembl`, `merged`, or `refseq`
+- **AND** the system does not infer source type from table names, file paths, or cache directory names
+
+#### Scenario: Invalid source metadata is rejected
+- **WHEN** `annotate_vep()` is called with `bio.vep.cache_source_type = "foo"`
+- **THEN** the system returns a clear error listing the allowed values `ensembl`, `merged`, and `refseq`
+
+### Requirement: No Options JSON Source Selector
+The system SHALL NOT accept `merged = true`, `merged = false`, `refseq = true`,
+or `refseq = false` in `annotate_vep()` `options_json` as a source-mode
+selector.
+
+#### Scenario: Legacy merged boolean is rejected
+- **WHEN** a user calls `annotate_vep('vcf', 'cache', 'parquet', '{"merged":true}')`
+- **THEN** the system returns a clear error explaining that `merged` is unsupported
+- **AND** the error instructs the user to provide cache schema metadata `bio.vep.cache_source_type = "merged"` instead
+
+#### Scenario: Legacy refseq boolean is rejected
+- **WHEN** a user calls `annotate_vep('vcf', 'cache', 'parquet', '{"refseq":true}')`
+- **THEN** the system returns a clear error explaining that `refseq` is unsupported as an `options_json` source selector
+- **AND** the error instructs the user to provide cache schema metadata `bio.vep.cache_source_type = "refseq"` instead
+
+#### Scenario: Source mode is not read from options_json
+- **WHEN** a user calls `annotate_vep()` with `options_json` containing `cache_source_type = "refseq"`
+- **THEN** the system ignores that value as a source-mode authority
+- **AND** the system uses only schema metadata `bio.vep.cache_source_type`
+- **AND** missing schema metadata remains an error
+
+### Requirement: Source-Specific Transcript Filtering
+The system SHALL filter transcripts according to the explicit cache source mode,
+matching Ensembl VEP cache behavior for Ensembl, merged, and RefSeq caches.
+
+#### Scenario: Ensembl mode accepts only Ensembl transcripts
+- **WHEN** cache source mode is `ensembl`
+- **THEN** transcripts with stable IDs beginning `ENST` are included
+- **AND** RefSeq-only stable IDs such as `NM_000000.1`, `NR_000000.1`, `XM_000000.1`, and `XR_000000.1` are excluded
+
+#### Scenario: RefSeq mode accepts canonical RefSeq transcripts
+- **WHEN** cache source mode is `refseq`
+- **THEN** transcripts with stable IDs beginning `NM_`, `NR_`, `XM_`, and `XR_` are included
+- **AND** Ensembl-only transcript IDs beginning `ENST` are excluded
+
+#### Scenario: RefSeq mode keeps mitochondrial RefSeq names
+- **WHEN** cache source mode is `refseq`
+- **AND** a mitochondrial RefSeq transcript has an Ensembl VEP-accepted ID such as `4540`, `COX3`, or `rna-TRNK`
+- **THEN** the transcript is included
+
+#### Scenario: Merged mode accepts Ensembl and RefSeq rows
+- **WHEN** cache source mode is `merged`
+- **THEN** Ensembl transcript rows beginning `ENST` are included
+- **AND** RefSeq rows beginning `NM_`, `NR_`, `XM_`, or `XR_` are included
+- **AND** mitochondrial RefSeq rows accepted by Ensembl VEP are included when the row source is RefSeq
+
+### Requirement: Source-Specific CSQ SOURCE Output
+The system SHALL populate the CSQ `SOURCE` field only for merged cache mode.
+
+#### Scenario: Merged mode populates SOURCE
+- **WHEN** cache source mode is `merged`
+- **AND** an annotated transcript row has source label `RefSeq` or `Ensembl`
+- **THEN** the CSQ `SOURCE` field contains that row source value
+
+#### Scenario: RefSeq mode leaves SOURCE empty
+- **WHEN** cache source mode is `refseq`
+- **AND** an annotated transcript row has source label `RefSeq`
+- **THEN** the CSQ `SOURCE` field is empty
+
+#### Scenario: Ensembl mode leaves SOURCE empty
+- **WHEN** cache source mode is `ensembl`
+- **AND** an annotated transcript row has source label `Ensembl`
+- **THEN** the CSQ `SOURCE` field is empty
+
+### Requirement: RefSeq Hydration Support
+The system SHALL apply RefSeq transcript hydration logic to RefSeq cache rows
+identified by either normalized row source or RefSeq-compatible stable ID.
+
+#### Scenario: RefSeq stable IDs are hydrated
+- **WHEN** a RefSeq transcript row has stable ID beginning `NM_`, `NR_`, `XM_`, or `XR_`
+- **AND** the annotation path is configured with `reference_fasta_path`
+- **THEN** RefSeq CDS/spliced sequence hydration considers that transcript eligible
+
+#### Scenario: RefSeq mitochondrial IDs are hydrated
+- **WHEN** a RefSeq mitochondrial transcript row has stable ID such as `4540`, `COX3`, or `rna-TRNK`
+- **AND** the row source normalizes to `RefSeq` or cache source mode is `refseq`
+- **THEN** RefSeq hydration considers that transcript eligible
+
+### Requirement: Cache Source Mode Validation Tests
+The system SHALL include tests that cover accepted source modes, rejected legacy
+options, RefSeq transcript filters, and CSQ `SOURCE` behavior.
+
+#### Scenario: Unit tests cover source mode parsing
+- **WHEN** the test suite runs
+- **THEN** it verifies accepted metadata values `ensembl`, `merged`, and `refseq`
+- **AND** it verifies missing/invalid metadata produces clear errors
+
+#### Scenario: Unit tests cover RefSeq transcript IDs
+- **WHEN** the test suite runs
+- **THEN** it verifies `NM_`, `NR_`, `XM_`, `XR_`, numeric mitochondrial IDs, and `rna-*` IDs are handled according to source mode
+
+#### Scenario: Integration tests compare RefSeq behavior
+- **WHEN** a gated local RefSeq cache fixture is available
+- **THEN** the test suite compares representative chr22 and MT annotations against Ensembl VEP output

--- a/openspec/changes/add-vep-cache-source-mode/tasks.md
+++ b/openspec/changes/add-vep-cache-source-mode/tasks.md
@@ -9,108 +9,108 @@
 ## 1. Cache Source Mode Contract
 
 ### 1.1 Add source-mode helper module
-- [ ] 1.1.1 Create `datafusion/bio-function-vep/src/cache_source.rs`
-- [ ] 1.1.2 Define `CacheSourceType::{Ensembl, Merged, RefSeq}`
-- [ ] 1.1.3 Add constant `CACHE_SOURCE_METADATA_KEY = "bio.vep.cache_source_type"`
-- [ ] 1.1.4 Implement strict parser accepting only `ensembl`, `merged`, and `refseq`
-- [ ] 1.1.5 Implement `CacheSourceType::from_schema(&Schema) -> Result<CacheSourceType>`
-- [ ] 1.1.6 Add unit tests for accepted values, missing metadata, invalid metadata, and case sensitivity
+- [x] 1.1.1 Create `datafusion/bio-function-vep/src/cache_source.rs`
+- [x] 1.1.2 Define `CacheSourceType::{Ensembl, Merged, RefSeq}`
+- [x] 1.1.3 Add constant `CACHE_SOURCE_METADATA_KEY = "bio.vep.cache_source_type"`
+- [x] 1.1.4 Implement strict parser accepting only `ensembl`, `merged`, and `refseq`
+- [x] 1.1.5 Implement `CacheSourceType::from_schema(&Schema) -> Result<CacheSourceType>`
+- [x] 1.1.6 Add unit tests for accepted values, missing metadata, invalid metadata, and case sensitivity
 
 ### 1.2 Export module from crate root
-- [ ] 1.2.1 Add `pub(crate) mod cache_source;` to `datafusion/bio-function-vep/src/lib.rs`
-- [ ] 1.2.2 Use the helper from `annotate_table_function.rs`, `annotate_provider.rs`, and `transcript_consequence.rs`
-- [ ] 1.2.3 Read source mode from partitioned parquet variation schema metadata at `annotate_vep()` planning time
+- [x] 1.2.1 Add `pub(crate) mod cache_source;` to `datafusion/bio-function-vep/src/lib.rs`
+- [x] 1.2.2 Use the helper from `annotate_table_function.rs`, `annotate_provider.rs`, and `transcript_consequence.rs`
+- [x] 1.2.3 Read source mode from partitioned parquet variation schema metadata at `annotate_vep()` planning time
 
 ## 2. Table Function Validation
 
 ### 2.1 Reject unsupported legacy source-selector options
-- [ ] 2.1.1 Add an `options_json_has_key(options, key)` helper near existing JSON option parsing
-- [ ] 2.1.2 In `AnnotateFunction::call()`, reject any `options_json` containing top-level `merged` or `refseq`
-- [ ] 2.1.3 Return error text: `annotate_vep(): options_json key 'merged' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='merged'`
-- [ ] 2.1.4 Return matching error text for `refseq` pointing to `bio.vep.cache_source_type='refseq'`
-- [ ] 2.1.5 Add tests for `{"merged":true}`, `{"merged":false}`, `{"refseq":true}`, and `{"refseq":false}`
+- [x] 2.1.1 Add an `options_json_has_key(options, key)` helper near existing JSON option parsing
+- [x] 2.1.2 In `AnnotateFunction::call()`, reject any `options_json` containing top-level `merged` or `refseq`
+- [x] 2.1.3 Return error text: `annotate_vep(): options_json key 'merged' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='merged'`
+- [x] 2.1.4 Return matching error text for `refseq` pointing to `bio.vep.cache_source_type='refseq'`
+- [x] 2.1.5 Add tests for `{"merged":true}`, `{"merged":false}`, `{"refseq":true}`, and `{"refseq":false}`
 
 ### 2.2 Resolve cache source mode from schema metadata
-- [ ] 2.2.1 In `AnnotateFunction::call()`, resolve the main cache source table/provider schema
-- [ ] 2.2.2 Read `bio.vep.cache_source_type` from the main cache schema using `CacheSourceType::from_schema`
-- [ ] 2.2.3 Pass `CacheSourceType` into `AnnotateProvider::new(...)`
-- [ ] 2.2.4 Add tests proving missing metadata fails before provider execution
-- [ ] 2.2.5 Add tests proving `options_json.cache_source_type` does not replace schema metadata
+- [x] 2.2.1 In `AnnotateFunction::call()`, resolve the main cache source table/provider schema
+- [x] 2.2.2 Read `bio.vep.cache_source_type` from the main cache schema using `CacheSourceType::from_schema`
+- [x] 2.2.3 Pass `CacheSourceType` into `AnnotateProvider::new(...)`
+- [x] 2.2.4 Add tests proving missing metadata fails before provider execution
+- [x] 2.2.5 Add tests proving `options_json.cache_source_type` does not replace schema metadata
 
 ## 3. AnnotateProvider Source Mode Wiring
 
 ### 3.1 Store source mode on provider
-- [ ] 3.1.1 Add `cache_source_type: CacheSourceType` field to `AnnotateProvider`
-- [ ] 3.1.2 Update `AnnotateProvider::new(...)` signature and call sites
-- [ ] 3.1.3 Update `Debug` output to include source mode
+- [x] 3.1.1 Add `cache_source_type: CacheSourceType` field to `AnnotateProvider`
+- [x] 3.1.2 Update `AnnotateProvider::new(...)` signature and call sites
+- [x] 3.1.3 Update `Debug` output to include source mode
 
 ### 3.2 Remove boolean merged reads
-- [ ] 3.2.1 Remove `parse_json_bool_option(opts, "merged")` use from `scan_with_transcript_engine_partitioned`
-- [ ] 3.2.2 Remove `parse_json_bool_option(opts, "merged")` use from non-partitioned transcript context loading
-- [ ] 3.2.3 Remove `parse_json_bool_option(opts, "merged")` use from CSQ output construction
-- [ ] 3.2.4 Replace each removed use with `self.cache_source_type`
+- [x] 3.2.1 Remove `parse_json_bool_option(opts, "merged")` use from `scan_with_transcript_engine_partitioned`
+- [x] 3.2.2 Remove `parse_json_bool_option(opts, "merged")` use from non-partitioned transcript context loading
+- [x] 3.2.3 Remove `parse_json_bool_option(opts, "merged")` use from CSQ output construction
+- [x] 3.2.4 Replace each removed use with `self.cache_source_type`
 
 ### 3.3 Validate context source metadata
-- [ ] 3.3.1 When variation/context tables are resolved, read schema metadata
-- [ ] 3.3.2 If context table metadata exists and differs from provider `cache_source_type`, return an error naming both values
-- [ ] 3.3.3 If context table metadata is missing, return a clear error requiring `bio.vep.cache_source_type`
-- [ ] 3.3.4 Add tests for mismatched main/transcript source metadata
+- [x] 3.3.1 When variation/context tables are resolved, read schema metadata
+- [x] 3.3.2 If context table metadata exists and differs from provider `cache_source_type`, return an error naming both values
+- [x] 3.3.3 If context table metadata is missing, return a clear error requiring `bio.vep.cache_source_type`
+- [x] 3.3.4 Add tests for mismatched main/transcript source metadata
 
 ## 4. Source-Specific Transcript Filtering
 
 ### 4.1 Replace `is_vep_transcript`
-- [ ] 4.1.1 Change `is_vep_transcript(id: &str, merged: bool)` to source-mode-aware filtering
-- [ ] 4.1.2 Prefer signature `is_vep_transcript(tx: &TranscriptFeature, source_type: CacheSourceType) -> bool`
-- [ ] 4.1.3 Implement Ensembl mode: accept only IDs starting `ENST`
-- [ ] 4.1.4 Implement RefSeq mode: accept standard RefSeq IDs matching `^[A-Z]{2}_\d+`
-- [ ] 4.1.5 Implement RefSeq mitochondrial exceptions: accept `^\d{4}$` and `^(rna-)?[A-Z0-9]{3,}$`
-- [ ] 4.1.6 Implement merged mode: accept `ENST` rows plus RefSeq rows matching RefSeq rules when row source normalizes to `RefSeq`
+- [x] 4.1.1 Change `is_vep_transcript(id: &str, merged: bool)` to source-mode-aware filtering
+- [x] 4.1.2 Prefer signature `is_vep_transcript(tx: &TranscriptFeature, source_type: CacheSourceType) -> bool`
+- [x] 4.1.3 Implement Ensembl mode: accept only IDs starting `ENST`
+- [x] 4.1.4 Implement RefSeq mode: accept standard RefSeq IDs matching `^[A-Z]{2}_\d+`
+- [x] 4.1.5 Implement RefSeq mitochondrial exceptions: accept `^\d{4}$` and `^(rna-)?[A-Z0-9]{3,}$`
+- [x] 4.1.6 Implement merged mode: accept `ENST` rows plus RefSeq rows matching RefSeq rules when row source normalizes to `RefSeq`
 
 ### 4.2 Update transcript filtering call sites
-- [ ] 4.2.1 Update partitioned context loading filter to call source-mode-aware `is_vep_transcript`
-- [ ] 4.2.2 Update non-partitioned context loading filter to call source-mode-aware `is_vep_transcript`
-- [ ] 4.2.3 Keep HGNC backfill behavior for merged caches; do not apply merged-only HGNC fill to RefSeq-only mode unless existing data requires it
+- [x] 4.2.1 Update partitioned context loading filter to call source-mode-aware `is_vep_transcript`
+- [x] 4.2.2 Update non-partitioned context loading filter to call source-mode-aware `is_vep_transcript`
+- [x] 4.2.3 Keep HGNC backfill behavior for merged caches; do not apply merged-only HGNC fill to RefSeq-only mode unless existing data requires it
 
 ### 4.3 Add transcript filter tests
-- [ ] 4.3.1 Test Ensembl mode includes `ENST00000367770` and excludes `NM_000546.6`
-- [ ] 4.3.2 Test RefSeq mode includes `NM_000546.6`, `NR_123456.1`, `XM_011520402.2`, and `XR_001734695.1`
-- [ ] 4.3.3 Test RefSeq mode includes mitochondrial names `4540`, `COX3`, and `rna-TRNK`
-- [ ] 4.3.4 Test RefSeq mode excludes `ENST00000367770`
-- [ ] 4.3.5 Test merged mode includes Ensembl rows and source-normalized RefSeq rows
-- [ ] 4.3.6 Test merged mode does not include gene-like non-RefSeq rows solely because their ID matches the mitochondrial exception regex
+- [x] 4.3.1 Test Ensembl mode includes `ENST00000367770` and excludes `NM_000546.6`
+- [x] 4.3.2 Test RefSeq mode includes `NM_000546.6`, `NR_123456.1`, `XM_011520402.2`, and `XR_001734695.1`
+- [x] 4.3.3 Test RefSeq mode includes mitochondrial names `4540`, `COX3`, and `rna-TRNK`
+- [x] 4.3.4 Test RefSeq mode excludes `ENST00000367770`
+- [x] 4.3.5 Test merged mode includes Ensembl rows and source-normalized RefSeq rows
+- [x] 4.3.6 Test merged mode does not include gene-like non-RefSeq rows solely because their ID matches the mitochondrial exception regex
 
 ## 5. CSQ SOURCE Output
 
 ### 5.1 Gate SOURCE by source mode
-- [ ] 5.1.1 Replace `let source_val = if merged { source } else { "" };`
-- [ ] 5.1.2 Use `self.cache_source_type == CacheSourceType::Merged` as the only condition for emitting SOURCE
-- [ ] 5.1.3 Add unit or integration tests for SOURCE output in Ensembl, RefSeq, and merged modes
+- [x] 5.1.1 Replace `let source_val = if merged { source } else { "" };`
+- [x] 5.1.2 Use `self.cache_source_type == CacheSourceType::Merged` as the only condition for emitting SOURCE
+- [x] 5.1.3 Add unit or integration tests for SOURCE output in Ensembl, RefSeq, and merged modes
 
 ## 6. RefSeq Hydration
 
 ### 6.1 Extend hydration eligibility
-- [ ] 6.1.1 Update `is_refseq_transcript_for_hydration()` to accept `CacheSourceType`
-- [ ] 6.1.2 Keep current row-source normalization behavior for `RefSeq`
-- [ ] 6.1.3 Keep standard RefSeq ID detection for `NM_`, `NR_`, `XM_`, and `XR_`
-- [ ] 6.1.4 Add mitochondrial RefSeq ID detection when source mode is `RefSeq` or row source normalizes to `RefSeq`
+- [x] 6.1.1 Update `is_refseq_transcript_for_hydration()` to accept `CacheSourceType`
+- [x] 6.1.2 Keep current row-source normalization behavior for `RefSeq`
+- [x] 6.1.3 Keep standard RefSeq ID detection for `NM_`, `NR_`, `XM_`, and `XR_`
+- [x] 6.1.4 Add mitochondrial RefSeq ID detection when source mode is `RefSeq` or row source normalizes to `RefSeq`
 
 ### 6.2 Update hydration call sites
-- [ ] 6.2.1 Pass `self.cache_source_type` into `hydrate_refseq_translation_cds_from_reference`
-- [ ] 6.2.2 Pass source mode through any helper layers needed by `is_refseq_transcript_for_hydration`
-- [ ] 6.2.3 Add tests proving `4540`, `COX3`, and `rna-TRNK` are hydration-eligible in RefSeq mode
+- [x] 6.2.1 Pass `self.cache_source_type` into `hydrate_refseq_translation_cds_from_reference`
+- [x] 6.2.2 Pass source mode through any helper layers needed by `is_refseq_transcript_for_hydration`
+- [x] 6.2.3 Add tests proving `4540`, `COX3`, and `rna-TRNK` are hydration-eligible in RefSeq mode
 
 ## 7. Integration and Regression Tests
 
 ### 7.1 Update existing MemTable fixtures
-- [ ] 7.1.1 Add `bio.vep.cache_source_type = "ensembl"` metadata to existing annotation test schemas that represent Ensembl-only caches
-- [ ] 7.1.2 Add helper for constructing test schemas with cache source metadata
-- [ ] 7.1.3 Verify existing annotation tests pass after the explicit metadata requirement
+- [x] 7.1.1 Add `bio.vep.cache_source_type = "ensembl"` metadata to existing annotation test schemas that represent Ensembl-only caches
+- [x] 7.1.2 Add helper for constructing test schemas with cache source metadata
+- [x] 7.1.3 Verify existing annotation tests pass after the explicit metadata requirement
 
 ### 7.2 Add source-mode integration tests
 - [ ] 7.2.1 Create an in-memory RefSeq transcript table with IDs `NM_000546.6`, `NR_123456.1`, `4540`, and `rna-TRNK`
-- [ ] 7.2.2 Verify `annotate_vep()` includes RefSeq transcripts when metadata is `refseq`
-- [ ] 7.2.3 Verify `annotate_vep()` excludes RefSeq transcripts when metadata is `ensembl`
-- [ ] 7.2.4 Verify merged mode emits SOURCE and RefSeq mode leaves SOURCE empty
+- [x] 7.2.2 Verify `annotate_vep()` includes RefSeq transcripts when metadata is `refseq`
+- [x] 7.2.3 Verify `annotate_vep()` excludes RefSeq transcripts when metadata is `ensembl`
+- [x] 7.2.4 Verify merged mode emits SOURCE and RefSeq mode leaves SOURCE empty
 
 ### 7.3 Add gated real-cache validation
 - [ ] 7.3.1 Add ignored/gated test controlled by `DF_BIO_FUNCTION_REFSEQ_CACHE`
@@ -120,15 +120,15 @@
 ## 8. Verification
 
 ### 8.1 Local checks
-- [ ] 8.1.1 Run `cargo fmt`
-- [ ] 8.1.2 Run `cargo test -p datafusion-bio-function-vep cache_source`
-- [ ] 8.1.3 Run `cargo test -p datafusion-bio-function-vep is_vep_transcript`
-- [ ] 8.1.4 Run `cargo test -p datafusion-bio-function-vep annotate_vep`
-- [ ] 8.1.5 Run `cargo clippy -p datafusion-bio-function-vep --all-targets -- -D warnings`
+- [x] 8.1.1 Run `cargo fmt`
+- [x] 8.1.2 Run `cargo test -p datafusion-bio-function-vep cache_source`
+- [x] 8.1.3 Run `cargo test -p datafusion-bio-function-vep is_vep_transcript`
+- [x] 8.1.4 Run `cargo test -p datafusion-bio-function-vep annotate_vep`
+- [x] 8.1.5 Run `cargo clippy -p datafusion-bio-function-vep --all-targets -- -D warnings`
 
 ### 8.2 Cross-repo validation
-- [ ] 8.2.1 Update optional `datafusion-bio-format-ensembl-cache` dependency to `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`
+- [x] 8.2.1 Update optional `datafusion-bio-format-ensembl-cache` dependency to `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`
 - [ ] 8.2.2 Run a RefSeq chr22 smoke annotation with `cache_source_type = refseq`
 - [ ] 8.2.3 Run a merged-mode smoke annotation with `cache_source_type = merged`
-- [ ] 8.2.4 Confirm no code path reads `options_json.merged`
-- [ ] 8.2.5 Confirm no code path reads `options_json.refseq` as source mode
+- [x] 8.2.4 Confirm no code path reads `options_json.merged`
+- [x] 8.2.5 Confirm no code path reads `options_json.refseq` as source mode

--- a/openspec/changes/add-vep-cache-source-mode/tasks.md
+++ b/openspec/changes/add-vep-cache-source-mode/tasks.md
@@ -61,10 +61,10 @@
 ### 4.1 Replace `is_vep_transcript`
 - [x] 4.1.1 Change `is_vep_transcript(id: &str, merged: bool)` to source-mode-aware filtering
 - [x] 4.1.2 Prefer signature `is_vep_transcript(tx: &TranscriptFeature, source_type: CacheSourceType) -> bool`
-- [x] 4.1.3 Implement Ensembl mode: accept only IDs starting `ENST`
+- [x] 4.1.3 Implement Ensembl mode: accept non-empty stable IDs after common filters
 - [x] 4.1.4 Implement RefSeq mode: accept standard RefSeq IDs matching `^[A-Z]{2}_\d+`
 - [x] 4.1.5 Implement RefSeq mitochondrial exceptions: accept `^\d{4}$` and `^(rna-)?[A-Z0-9]{3,}$`
-- [x] 4.1.6 Implement merged mode: accept `ENST` rows plus RefSeq rows matching RefSeq rules when row source normalizes to `RefSeq`
+- [x] 4.1.6 Implement merged mode: accept non-RefSeq-source rows after common filters and apply RefSeq rules only when row source normalizes to `RefSeq`
 
 ### 4.2 Update transcript filtering call sites
 - [x] 4.2.1 Update partitioned context loading filter to call source-mode-aware `is_vep_transcript`
@@ -72,12 +72,12 @@
 - [x] 4.2.3 Keep HGNC backfill behavior for merged caches; do not apply merged-only HGNC fill to RefSeq-only mode unless existing data requires it
 
 ### 4.3 Add transcript filter tests
-- [x] 4.3.1 Test Ensembl mode includes `ENST00000367770` and excludes `NM_000546.6`
+- [x] 4.3.1 Test Ensembl mode includes `ENST00000367770` and a non-`ENST` stable ID
 - [x] 4.3.2 Test RefSeq mode includes `NM_000546.6`, `NR_123456.1`, `XM_011520402.2`, and `XR_001734695.1`
 - [x] 4.3.3 Test RefSeq mode includes mitochondrial names `4540`, `COX3`, and `rna-TRNK`
 - [x] 4.3.4 Test RefSeq mode excludes `ENST00000367770`
 - [x] 4.3.5 Test merged mode includes Ensembl rows and source-normalized RefSeq rows
-- [x] 4.3.6 Test merged mode does not include gene-like non-RefSeq rows solely because their ID matches the mitochondrial exception regex
+- [x] 4.3.6 Test merged mode includes non-RefSeq rows after common filters, including gene-like IDs that would match the mitochondrial exception regex only for RefSeq rows
 
 ## 5. CSQ SOURCE Output
 

--- a/openspec/changes/add-vep-cache-source-mode/tasks.md
+++ b/openspec/changes/add-vep-cache-source-mode/tasks.md
@@ -1,0 +1,134 @@
+# Implementation Tasks
+
+## 0. Research Inputs
+
+- [x] 0.1 Inspect `datafusion-bio-formats` commit `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`
+- [x] 0.2 Inspect Ensembl VEP release/115 source-mode, RefSeq transcript-filter, MT exception, and CSQ field behavior
+- [x] 0.3 Create detailed implementation handoff in `implementation-plan.md`
+
+## 1. Cache Source Mode Contract
+
+### 1.1 Add source-mode helper module
+- [ ] 1.1.1 Create `datafusion/bio-function-vep/src/cache_source.rs`
+- [ ] 1.1.2 Define `CacheSourceType::{Ensembl, Merged, RefSeq}`
+- [ ] 1.1.3 Add constant `CACHE_SOURCE_METADATA_KEY = "bio.vep.cache_source_type"`
+- [ ] 1.1.4 Implement strict parser accepting only `ensembl`, `merged`, and `refseq`
+- [ ] 1.1.5 Implement `CacheSourceType::from_schema(&Schema) -> Result<CacheSourceType>`
+- [ ] 1.1.6 Add unit tests for accepted values, missing metadata, invalid metadata, and case sensitivity
+
+### 1.2 Export module from crate root
+- [ ] 1.2.1 Add `pub(crate) mod cache_source;` to `datafusion/bio-function-vep/src/lib.rs`
+- [ ] 1.2.2 Use the helper from `annotate_table_function.rs`, `annotate_provider.rs`, and `transcript_consequence.rs`
+- [ ] 1.2.3 Read source mode from partitioned parquet variation schema metadata at `annotate_vep()` planning time
+
+## 2. Table Function Validation
+
+### 2.1 Reject unsupported legacy source-selector options
+- [ ] 2.1.1 Add an `options_json_has_key(options, key)` helper near existing JSON option parsing
+- [ ] 2.1.2 In `AnnotateFunction::call()`, reject any `options_json` containing top-level `merged` or `refseq`
+- [ ] 2.1.3 Return error text: `annotate_vep(): options_json key 'merged' is unsupported; register/export cache tables with schema metadata bio.vep.cache_source_type='merged'`
+- [ ] 2.1.4 Return matching error text for `refseq` pointing to `bio.vep.cache_source_type='refseq'`
+- [ ] 2.1.5 Add tests for `{"merged":true}`, `{"merged":false}`, `{"refseq":true}`, and `{"refseq":false}`
+
+### 2.2 Resolve cache source mode from schema metadata
+- [ ] 2.2.1 In `AnnotateFunction::call()`, resolve the main cache source table/provider schema
+- [ ] 2.2.2 Read `bio.vep.cache_source_type` from the main cache schema using `CacheSourceType::from_schema`
+- [ ] 2.2.3 Pass `CacheSourceType` into `AnnotateProvider::new(...)`
+- [ ] 2.2.4 Add tests proving missing metadata fails before provider execution
+- [ ] 2.2.5 Add tests proving `options_json.cache_source_type` does not replace schema metadata
+
+## 3. AnnotateProvider Source Mode Wiring
+
+### 3.1 Store source mode on provider
+- [ ] 3.1.1 Add `cache_source_type: CacheSourceType` field to `AnnotateProvider`
+- [ ] 3.1.2 Update `AnnotateProvider::new(...)` signature and call sites
+- [ ] 3.1.3 Update `Debug` output to include source mode
+
+### 3.2 Remove boolean merged reads
+- [ ] 3.2.1 Remove `parse_json_bool_option(opts, "merged")` use from `scan_with_transcript_engine_partitioned`
+- [ ] 3.2.2 Remove `parse_json_bool_option(opts, "merged")` use from non-partitioned transcript context loading
+- [ ] 3.2.3 Remove `parse_json_bool_option(opts, "merged")` use from CSQ output construction
+- [ ] 3.2.4 Replace each removed use with `self.cache_source_type`
+
+### 3.3 Validate context source metadata
+- [ ] 3.3.1 When variation/context tables are resolved, read schema metadata
+- [ ] 3.3.2 If context table metadata exists and differs from provider `cache_source_type`, return an error naming both values
+- [ ] 3.3.3 If context table metadata is missing, return a clear error requiring `bio.vep.cache_source_type`
+- [ ] 3.3.4 Add tests for mismatched main/transcript source metadata
+
+## 4. Source-Specific Transcript Filtering
+
+### 4.1 Replace `is_vep_transcript`
+- [ ] 4.1.1 Change `is_vep_transcript(id: &str, merged: bool)` to source-mode-aware filtering
+- [ ] 4.1.2 Prefer signature `is_vep_transcript(tx: &TranscriptFeature, source_type: CacheSourceType) -> bool`
+- [ ] 4.1.3 Implement Ensembl mode: accept only IDs starting `ENST`
+- [ ] 4.1.4 Implement RefSeq mode: accept standard RefSeq IDs matching `^[A-Z]{2}_\d+`
+- [ ] 4.1.5 Implement RefSeq mitochondrial exceptions: accept `^\d{4}$` and `^(rna-)?[A-Z0-9]{3,}$`
+- [ ] 4.1.6 Implement merged mode: accept `ENST` rows plus RefSeq rows matching RefSeq rules when row source normalizes to `RefSeq`
+
+### 4.2 Update transcript filtering call sites
+- [ ] 4.2.1 Update partitioned context loading filter to call source-mode-aware `is_vep_transcript`
+- [ ] 4.2.2 Update non-partitioned context loading filter to call source-mode-aware `is_vep_transcript`
+- [ ] 4.2.3 Keep HGNC backfill behavior for merged caches; do not apply merged-only HGNC fill to RefSeq-only mode unless existing data requires it
+
+### 4.3 Add transcript filter tests
+- [ ] 4.3.1 Test Ensembl mode includes `ENST00000367770` and excludes `NM_000546.6`
+- [ ] 4.3.2 Test RefSeq mode includes `NM_000546.6`, `NR_123456.1`, `XM_011520402.2`, and `XR_001734695.1`
+- [ ] 4.3.3 Test RefSeq mode includes mitochondrial names `4540`, `COX3`, and `rna-TRNK`
+- [ ] 4.3.4 Test RefSeq mode excludes `ENST00000367770`
+- [ ] 4.3.5 Test merged mode includes Ensembl rows and source-normalized RefSeq rows
+- [ ] 4.3.6 Test merged mode does not include gene-like non-RefSeq rows solely because their ID matches the mitochondrial exception regex
+
+## 5. CSQ SOURCE Output
+
+### 5.1 Gate SOURCE by source mode
+- [ ] 5.1.1 Replace `let source_val = if merged { source } else { "" };`
+- [ ] 5.1.2 Use `self.cache_source_type == CacheSourceType::Merged` as the only condition for emitting SOURCE
+- [ ] 5.1.3 Add unit or integration tests for SOURCE output in Ensembl, RefSeq, and merged modes
+
+## 6. RefSeq Hydration
+
+### 6.1 Extend hydration eligibility
+- [ ] 6.1.1 Update `is_refseq_transcript_for_hydration()` to accept `CacheSourceType`
+- [ ] 6.1.2 Keep current row-source normalization behavior for `RefSeq`
+- [ ] 6.1.3 Keep standard RefSeq ID detection for `NM_`, `NR_`, `XM_`, and `XR_`
+- [ ] 6.1.4 Add mitochondrial RefSeq ID detection when source mode is `RefSeq` or row source normalizes to `RefSeq`
+
+### 6.2 Update hydration call sites
+- [ ] 6.2.1 Pass `self.cache_source_type` into `hydrate_refseq_translation_cds_from_reference`
+- [ ] 6.2.2 Pass source mode through any helper layers needed by `is_refseq_transcript_for_hydration`
+- [ ] 6.2.3 Add tests proving `4540`, `COX3`, and `rna-TRNK` are hydration-eligible in RefSeq mode
+
+## 7. Integration and Regression Tests
+
+### 7.1 Update existing MemTable fixtures
+- [ ] 7.1.1 Add `bio.vep.cache_source_type = "ensembl"` metadata to existing annotation test schemas that represent Ensembl-only caches
+- [ ] 7.1.2 Add helper for constructing test schemas with cache source metadata
+- [ ] 7.1.3 Verify existing annotation tests pass after the explicit metadata requirement
+
+### 7.2 Add source-mode integration tests
+- [ ] 7.2.1 Create an in-memory RefSeq transcript table with IDs `NM_000546.6`, `NR_123456.1`, `4540`, and `rna-TRNK`
+- [ ] 7.2.2 Verify `annotate_vep()` includes RefSeq transcripts when metadata is `refseq`
+- [ ] 7.2.3 Verify `annotate_vep()` excludes RefSeq transcripts when metadata is `ensembl`
+- [ ] 7.2.4 Verify merged mode emits SOURCE and RefSeq mode leaves SOURCE empty
+
+### 7.3 Add gated real-cache validation
+- [ ] 7.3.1 Add ignored/gated test controlled by `DF_BIO_FUNCTION_REFSEQ_CACHE`
+- [ ] 7.3.2 Use the local RefSeq cache exported/registered with explicit source metadata
+- [ ] 7.3.3 Compare representative chr22 and MT variant outputs against Ensembl VEP
+
+## 8. Verification
+
+### 8.1 Local checks
+- [ ] 8.1.1 Run `cargo fmt`
+- [ ] 8.1.2 Run `cargo test -p datafusion-bio-function-vep cache_source`
+- [ ] 8.1.3 Run `cargo test -p datafusion-bio-function-vep is_vep_transcript`
+- [ ] 8.1.4 Run `cargo test -p datafusion-bio-function-vep annotate_vep`
+- [ ] 8.1.5 Run `cargo clippy -p datafusion-bio-function-vep --all-targets -- -D warnings`
+
+### 8.2 Cross-repo validation
+- [ ] 8.2.1 Update optional `datafusion-bio-format-ensembl-cache` dependency to `ca91f694e4db145ff0f8c1118b92a7f4c6f9aee3`
+- [ ] 8.2.2 Run a RefSeq chr22 smoke annotation with `cache_source_type = refseq`
+- [ ] 8.2.3 Run a merged-mode smoke annotation with `cache_source_type = merged`
+- [ ] 8.2.4 Confirm no code path reads `options_json.merged`
+- [ ] 8.2.5 Confirm no code path reads `options_json.refseq` as source mode


### PR DESCRIPTION
## Summary
- require VEP cache source metadata (`bio.vep.cache_source_type`) and reject legacy `options_json` source selectors
- carry explicit cache source mode through annotate_vep, VCF output, transcript filtering, RefSeq hydration, and cache-builder export paths
- add OpenSpec proposal/design/tasks and tests for metadata parsing, rejected selectors, source mismatch, RefSeq/merged CSQ fields, and RefSeq MT handling

## Verification
- cargo fmt --check
- openspec validate add-vep-cache-source-mode --strict
- cargo test -p datafusion-bio-function-vep --lib
- cargo test -p datafusion-bio-function-vep --features cache-builder cache_builder
- cargo clippy -p datafusion-bio-function-vep --all-targets --features cache-builder -- -D warnings
- git diff --check