### PR TITLE
Port Parser.t (v2 paradigm, Tier 3)

### DIFF
--- a/datafusion/bio-function-vep/src/allele.rs
+++ b/datafusion/bio-function-vep/src/allele.rs
@@ -1451,4 +1451,108 @@ mod tests {
         assert_eq!(r, "AA");
         assert_eq!(a, vec!["AT".to_string(), "CA".to_string()]);
     }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Port of `ensembl-vep/t/Parser.t` allele-minimisation rows
+    //
+    // Detailed plan: `porting-tests/detailed_plans/Parser.md`.
+    // v2 paradigm: sztywno 1:1, standalone (no docker, no golden.vcf).
+    // Anchor: `~/.claude/skills/port-to-vepyr/references/v2-paradigm.md`.
+    //
+    // Perl's `minimise_alleles` trims a shared prefix AND a shared suffix
+    // off REF/ALT regardless of indel-vs-MNV shape (Parser.pm
+    // `minimise_alleles()` walks both ends unconditionally).
+    //
+    // Vepyr's `vcf_to_vep_allele` deliberately preserves MNV form: when
+    // `ref.len() == alt.len()` only the common prefix is trimmed — see the
+    // `is_indel`/length-mismatch gate at allele.rs:300-302 with the
+    // traceability comment to Ensembl-Variation `trim_sequences()`. This
+    // is the vepyr-correct behaviour; the Perl test's `'A/T'` expectation
+    // for `'GAC/GTC'` and the long-trim case reflects Perl's broader
+    // (and arguably wrong-by-Ensembl-Variation-canon) trimming, so the
+    // Rust assertions document the divergence with the
+    // prefix-only-trim result.
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Port of `Parser.t` subtest #17 (Perl l.76-92):
+    ///   `minimise_alleles('GA/GT')` → ref='A' alt='T', start shifted +1.
+    ///
+    /// Vepyr handles the indel-style shape `GA → GT` via `vcf_to_vep_allele`
+    /// with length-equal (2bp/2bp) → MNV rule → prefix-only-trim → `(A, T)`.
+    /// `vep_norm_start(1, "GA", "GT")` shifts start by the trimmed prefix
+    /// length (1) — matching Perl's `start: 2, end: 1` post-trim convention.
+    #[test]
+    fn port_parser_subtest_17_minimise_alleles_ga_gt() {
+        // Perl l.76-92: 'GA/GT' minimises to 'A/T' with start+=1.
+        let (vep_ref, vep_alt) = vcf_to_vep_allele("GA", "GT");
+        assert_eq!(vep_ref, "A");
+        assert_eq!(vep_alt, "T");
+        // Perl's `start = 2` corresponds to vepyr's `vep_norm_start = 1 + 1`.
+        assert_eq!(vep_norm_start(1, "GA", "GT"), 2);
+    }
+
+    /// Port of `Parser.t` subtest #18 (Perl l.94-98):
+    ///   `minimise_alleles('GAC/GTC')->[0]->{allele_string}` → 'A/T'.
+    ///
+    /// **Divergence (documented)**: Perl trims both shared prefix (`G`)
+    /// AND shared suffix (`C`) regardless of indel/MNV shape → `A/T`.
+    /// Vepyr deliberately preserves MNV form (Ensembl-Variation
+    /// `trim_sequences()` canon, see allele.rs:300-302) →
+    /// prefix-only-trim → `AC/TC`. This is intentional and
+    /// load-bearing for vepyr correctness, not a bug.
+    #[test]
+    fn port_parser_subtest_18_minimise_alleles_gac_gtc_mnv_preserves_suffix() {
+        // Perl asserts 'A/T'; vepyr correctly asserts 'AC/TC' because
+        // the MNV-rule at allele.rs:300-302 forbids suffix-trim when
+        // REF and ALT have equal length.
+        let (vep_ref, vep_alt) = vcf_to_vep_allele("GAC", "GTC");
+        assert_eq!(vep_ref, "AC", "vepyr preserves MNV suffix (divergent from Perl)");
+        assert_eq!(vep_alt, "TC", "vepyr preserves MNV suffix (divergent from Perl)");
+    }
+
+    /// Port of `Parser.t` subtest #19 (Perl l.100-104):
+    ///   `minimise_alleles('TTCCTTCCGACGGTACACACACACA/TTCCTTCCGTCGGTACACACACACA')`
+    ///   → 'A/T' (Perl long-trim).
+    ///
+    /// **Divergence (documented)**: same as #18 — equal-length REF/ALT (25bp
+    /// each) → MNV rule → prefix-only-trim. Vepyr trims the 9-byte common
+    /// prefix `TTCCTTCCG` and stops; the remaining 16-byte suffixes
+    /// `ACGGTACACACACACA` / `TCGGTACACACACACA` are preserved per the MNV
+    /// rule. Perl would aggressively trim the shared suffix too, ending up
+    /// with the minimal `A/T` differing bases.
+    #[test]
+    fn port_parser_subtest_19_minimise_alleles_long_mnv_preserves_suffix() {
+        let ref_allele = "TTCCTTCCGACGGTACACACACACA";
+        let alt_allele = "TTCCTTCCGTCGGTACACACACACA";
+        let (vep_ref, vep_alt) = vcf_to_vep_allele(ref_allele, alt_allele);
+        // 9-byte prefix "TTCCTTCCG" trimmed; remaining 16 bytes preserved.
+        assert_eq!(vep_ref, "ACGGTACACACACACA");
+        assert_eq!(vep_alt, "TCGGTACACACACACA");
+    }
+
+    /// Axis-B row B1 (post-Phase-D 2026-05-27): pin vepyr's behaviour on
+    /// degenerate `REF == ALT` input.
+    ///
+    /// Detailed plan: `porting-tests/detailed_plans/Parser.md` row B1.
+    /// Perl rejects same-allele input upstream of `minimise_alleles`; vepyr
+    /// passes it through `vcf_to_vep_allele`, which returns `(REF, ALT)`
+    /// verbatim for 1bp inputs (SNV fast path at line 284-287) and for
+    /// multi-byte inputs returns `("-", "-")` after full prefix-and-suffix
+    /// trim collapses both sides to empty.
+    #[test]
+    #[allow(non_snake_case)]
+    fn port_parser_axisB1_vcf_to_vep_allele_degenerate_same_allele() {
+        // 1bp same-allele goes through the SNV fast path → identity.
+        let (r1, a1) = vcf_to_vep_allele("A", "A");
+        assert_eq!((r1.as_str(), a1.as_str()), ("A", "A"));
+
+        // 3bp same-allele: equal length → MNV rule → prefix-only-trim, full
+        // 3-byte prefix matches → both sides empty → "-" dash.
+        let (r3, a3) = vcf_to_vep_allele("AGT", "AGT");
+        assert_eq!(
+            (r3.as_str(), a3.as_str()),
+            ("-", "-"),
+            "degenerate same-allele 3bp collapses both sides to '-' under MNV rule"
+        );
+    }
 }

--- a/datafusion/bio-function-vep/src/allele.rs
+++ b/datafusion/bio-function-vep/src/allele.rs
@@ -1506,8 +1506,14 @@ mod tests {
         // the MNV-rule at allele.rs:300-302 forbids suffix-trim when
         // REF and ALT have equal length.
         let (vep_ref, vep_alt) = vcf_to_vep_allele("GAC", "GTC");
-        assert_eq!(vep_ref, "AC", "vepyr preserves MNV suffix (divergent from Perl)");
-        assert_eq!(vep_alt, "TC", "vepyr preserves MNV suffix (divergent from Perl)");
+        assert_eq!(
+            vep_ref, "AC",
+            "vepyr preserves MNV suffix (divergent from Perl)"
+        );
+        assert_eq!(
+            vep_alt, "TC",
+            "vepyr preserves MNV suffix (divergent from Perl)"
+        );
     }
 
     /// Port of `Parser.t` subtest #19 (Perl l.100-104):

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -4908,8 +4908,7 @@ impl AnnotateProvider {
                     if let Some(reader) = hgvs_reference_reader.as_mut() {
                         if ref_al.len() != alt_one.len() {
                             let chrom_norm = chrom.strip_prefix("chr").unwrap_or(&chrom);
-                            let (vep_ref_norm, vep_alt_norm) =
-                                vcf_to_vep_allele(&ref_al, alt_one);
+                            let (vep_ref_norm, vep_alt_norm) = vcf_to_vep_allele(&ref_al, alt_one);
                             let vep_start = vep_norm_start(start, &ref_al, alt_one);
                             let vep_end = vep_norm_end(start, &ref_al, alt_one);
                             variant.hgvs_shift_forward = crate::hgvs::build_hgvs_genomic_shift(
@@ -4946,8 +4945,9 @@ impl AnnotateProvider {
                     if let Some(alt_most) = most_severe_term(all_terms_alt.iter()) {
                         row_most_so = Some(match row_most_so {
                             None => alt_most,
-                            Some(cur) => most_severe_term([cur, alt_most].iter())
-                                .unwrap_or(alt_most),
+                            Some(cur) => {
+                                most_severe_term([cur, alt_most].iter()).unwrap_or(alt_most)
+                            }
                         });
                     }
 
@@ -5035,24 +5035,31 @@ impl AnnotateProvider {
                             if si >= row_assignments.len() {
                                 continue;
                             }
-                        let tc = &row_assignments[si];
-                        terms_buf.clear();
-                        for (i, t) in tc.terms.iter().enumerate() {
-                            if i > 0 {
-                                terms_buf.push('&');
+                            let tc = &row_assignments[si];
+                            terms_buf.clear();
+                            for (i, t) in tc.terms.iter().enumerate() {
+                                if i > 0 {
+                                    terms_buf.push('&');
+                                }
+                                terms_buf.push_str(t.as_str());
                             }
-                            terms_buf.push_str(t.as_str());
-                        }
-                        let terms_str = terms_buf.as_str();
-                        let tc_impact = most_severe_term(tc.terms.iter())
-                            .map(|t| impact_label(t.impact()))
-                            .unwrap_or_else(|| impact_label(SoImpact::Modifier));
-                        let feature_type = tc.feature_type.as_str();
-                        let feature = tc.transcript_id.as_deref().unwrap_or("");
-                        // Look up transcript metadata via index (zero-copy).
-                        let tx_opt = tc.transcript_idx.map(|idx| &ctx.transcripts[idx]);
-                        let (symbol, gene, biotype_tx, strand_str, symbol_source, hgnc_id, source) =
-                            if let Some(tx) = tx_opt {
+                            let terms_str = terms_buf.as_str();
+                            let tc_impact = most_severe_term(tc.terms.iter())
+                                .map(|t| impact_label(t.impact()))
+                                .unwrap_or_else(|| impact_label(SoImpact::Modifier));
+                            let feature_type = tc.feature_type.as_str();
+                            let feature = tc.transcript_id.as_deref().unwrap_or("");
+                            // Look up transcript metadata via index (zero-copy).
+                            let tx_opt = tc.transcript_idx.map(|idx| &ctx.transcripts[idx]);
+                            let (
+                                symbol,
+                                gene,
+                                biotype_tx,
+                                strand_str,
+                                symbol_source,
+                                hgnc_id,
+                                source,
+                            ) = if let Some(tx) = tx_opt {
                                 (
                                     tx.gene_symbol.as_deref().unwrap_or(""),
                                     tx.gene_stable_id.as_deref().unwrap_or(""),
@@ -5065,227 +5072,228 @@ impl AnnotateProvider {
                             } else {
                                 ("", "", "", "", "", "", "")
                             };
-                        let biotype = tc.biotype_override.as_deref().unwrap_or(biotype_tx);
-                        let exon = tc.exon_str.as_deref().unwrap_or("");
-                        let intron = tc.intron_str.as_deref().unwrap_or("");
-                        let cdna_pos = tc.cdna_position.as_deref().unwrap_or("");
-                        let cds_pos = tc.cds_position.as_deref().unwrap_or("");
-                        let protein_pos = tc.protein_position.as_deref().unwrap_or("");
-                        let amino_acids = tc.amino_acids.as_deref().unwrap_or("");
-                        let codons_str = tc.codons.as_deref().unwrap_or("");
-                        // Write comma separator between CSQ entries.
-                        if !csq_buf.is_empty() {
-                            csq_buf.push(',');
-                        }
-                        let distance = tc.distance.map(|d| d.to_string()).unwrap_or_default();
-                        let tc_flags = tc.flags.as_deref().unwrap_or("");
-                        let pick_str = if tc.picked { "1" } else { "" };
-                        let hgvsc = if hgvs_flags.hgvsc {
-                            tc.hgvsc.as_deref().unwrap_or("")
-                        } else {
-                            ""
-                        };
-                        let hgvsp = if hgvs_flags.hgvsp {
-                            tc.hgvsp
-                                .as_deref()
-                                .map(|value| {
-                                    Self::format_hgvsp_output(
-                                        value,
-                                        hgvs_flags.remove_hgvsp_version,
-                                        hgvs_flags.no_escape,
-                                        hgvs_flags.hgvsp_use_prediction,
-                                    )
-                                })
-                                .unwrap_or_default()
-                        } else {
-                            String::new()
-                        };
-                        let refseq_match = tx_opt
-                            .and_then(|tx| tx.refseq_match.as_deref())
-                            .unwrap_or("");
-                        let bam_edit = tx_opt
-                            .and_then(|tx| tx.bam_edit_status.as_deref())
-                            .map(str::to_ascii_uppercase)
-                            .unwrap_or_default();
-                        let source_val = if include_source_field { source } else { "" };
-                        let refseq_offset_value = tx_opt
-                            .filter(|_| hgvs_flags.hgvsc && tc.hgvsc.is_some())
-                            .and_then(|tx| {
-                                tc.cdna_position
+                            let biotype = tc.biotype_override.as_deref().unwrap_or(biotype_tx);
+                            let exon = tc.exon_str.as_deref().unwrap_or("");
+                            let intron = tc.intron_str.as_deref().unwrap_or("");
+                            let cdna_pos = tc.cdna_position.as_deref().unwrap_or("");
+                            let cds_pos = tc.cds_position.as_deref().unwrap_or("");
+                            let protein_pos = tc.protein_position.as_deref().unwrap_or("");
+                            let amino_acids = tc.amino_acids.as_deref().unwrap_or("");
+                            let codons_str = tc.codons.as_deref().unwrap_or("");
+                            // Write comma separator between CSQ entries.
+                            if !csq_buf.is_empty() {
+                                csq_buf.push(',');
+                            }
+                            let distance = tc.distance.map(|d| d.to_string()).unwrap_or_default();
+                            let tc_flags = tc.flags.as_deref().unwrap_or("");
+                            let pick_str = if tc.picked { "1" } else { "" };
+                            let hgvsc = if hgvs_flags.hgvsc {
+                                tc.hgvsc.as_deref().unwrap_or("")
+                            } else {
+                                ""
+                            };
+                            let hgvsp = if hgvs_flags.hgvsp {
+                                tc.hgvsp
                                     .as_deref()
-                                    .and_then(parse_cdna_position_start)
-                                    .and_then(|cdna_start| {
-                                        refseq_misalignment_offset(tx, cdna_start)
-                                    })
-                            });
-                        let refseq_offset = refseq_offset_value
-                            .map(|offset| offset.to_string())
-                            .unwrap_or_default();
-                        let given_ref = tc.given_ref.as_deref().unwrap_or("");
-                        let used_ref = tc.used_ref.as_deref().unwrap_or("");
-
-                        // Batch 1 fields from transcript metadata.
-                        let canonical = tx_opt
-                            .map(|tx| if tx.is_canonical { "YES" } else { "" })
-                            .unwrap_or("");
-                        let tsl_str = tx_opt
-                            .and_then(|tx| tx.tsl)
-                            .map(|v| v.to_string())
-                            .unwrap_or_default();
-                        let mane_select = tx_opt
-                            .and_then(|tx| tx.mane_select.as_deref())
-                            .unwrap_or("");
-                        let mane_plus = tx_opt
-                            .and_then(|tx| tx.mane_plus_clinical.as_deref())
-                            .unwrap_or("");
-                        let ensp = tx_opt
-                            .and_then(|tx| tx.translation_stable_id.as_deref())
-                            .unwrap_or("");
-                        let gene_pheno = tx_opt
-                            .map(|tx| if tx.gene_phenotype { "1" } else { "" })
-                            .unwrap_or("");
-                        let ccds = tx_opt.and_then(|tx| tx.ccds.as_deref()).unwrap_or("");
-                        let swissprot_raw =
-                            tx_opt.and_then(|tx| tx.swissprot.as_deref()).unwrap_or("");
-                        let swissprot = csq_escape(swissprot_raw);
-                        let trembl_raw = tx_opt.and_then(|tx| tx.trembl.as_deref()).unwrap_or("");
-                        let trembl = csq_escape(trembl_raw);
-                        let uniparc = tx_opt.and_then(|tx| tx.uniparc.as_deref()).unwrap_or("");
-                        let uniprot_isoform = tx_opt
-                            .and_then(|tx| tx.uniprot_isoform.as_deref())
-                            .unwrap_or("");
-
-                        if flags.everything {
-                            // HGVS_OFFSET mirrors the transcript-level HGVSc shift
-                            // decision. RefSeq rows with failed BAM edit replay can
-                            // still emit transcript-space HGVSc, but VEP suppresses
-                            // the exposed genomic shift for those transcripts.
-                            let hgvs_offset = if hgvs_flags.hgvsc {
-                                tx_opt
-                                    .zip(row_variant.as_ref())
-                                    .and_then(|(tx, variant)| {
-                                        let ref_allele = tc
-                                            .used_ref
-                                            .as_deref()
-                                            .unwrap_or(variant.ref_allele.as_str());
-                                        crate::hgvs::hgvsc_offset_for_output(
-                                            tx,
-                                            variant,
-                                            ref_allele,
-                                            tc.hgvsc.as_deref(),
+                                    .map(|value| {
+                                        Self::format_hgvsp_output(
+                                            value,
+                                            hgvs_flags.remove_hgvsp_version,
+                                            hgvs_flags.no_escape,
+                                            hgvs_flags.hgvsp_use_prediction,
                                         )
                                     })
-                                    .map(|offset| offset.to_string())
                                     .unwrap_or_default()
                             } else {
                                 String::new()
                             };
-                            // MANE generic: VEP emits "MANE_Select" or "MANE_Plus_Clinical"
-                            // depending on the transcript's MANE annotation.
-                            // Traceability:
-                            // - VEP OutputFactory.pm MANE output
-                            //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1548-L1560
-                            let mane = if tx_opt.and_then(|tx| tx.mane_select.as_deref()).is_some()
-                            {
-                                "MANE_Select"
-                            } else if tx_opt
-                                .and_then(|tx| tx.mane_plus_clinical.as_deref())
-                                .is_some()
-                            {
-                                "MANE_Plus_Clinical"
-                            } else {
-                                ""
-                            };
-                            // APPRIS: abbreviate principal1→P1, alternative2→A2.
-                            // Traceability:
-                            // - VEP OutputFactory.pm APPRIS output
-                            //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1563-L1570
-                            let appris_str = tx_opt
-                                .and_then(|tx| tx.appris.as_deref())
-                                .map(format_appris)
+                            let refseq_match = tx_opt
+                                .and_then(|tx| tx.refseq_match.as_deref())
+                                .unwrap_or("");
+                            let bam_edit = tx_opt
+                                .and_then(|tx| tx.bam_edit_status.as_deref())
+                                .map(str::to_ascii_uppercase)
                                 .unwrap_or_default();
-                            // SIFT/PolyPhen: lookup by (protein_position, alt_amino_acid).
-                            // Traceability:
-                            // - VEP OutputFactory.pm SIFT/PolyPhen output
-                            //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1746-L1799
-                            let (sift_str, polyphen_str) = lookup_sift_polyphen(
-                                tc.transcript_id.as_deref(),
-                                tc.protein_position.as_deref(),
-                                tc.amino_acids.as_deref(),
-                                sift_cache,
-                                #[cfg(feature = "kv-cache")]
-                                sift_kv,
-                                #[cfg(not(feature = "kv-cache"))]
-                                _sift_kv,
-                            );
-                            // DOMAINS: overlapping protein domain features.
-                            // VEP gates DOMAINS on $pre->{coding} which requires
-                            // a valid CDS coordinate mapping. Our cds_position is
-                            // only set when the variant falls within the CDS region.
-                            // Traceability:
-                            // - VEP OutputFactory.pm line 1434: if($self->{domains} && $pre->{coding})
-                            // - VEP BaseVariationFeatureOverlapAllele.pm _bvfo_preds lines 449-471
-                            //   https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
-                            let is_coding =
-                                tc.cds_position.as_deref().is_some_and(|s| !s.is_empty());
-                            let domains = if is_coding {
-                                lookup_domains(
+                            let source_val = if include_source_field { source } else { "" };
+                            let refseq_offset_value = tx_opt
+                                .filter(|_| hgvs_flags.hgvsc && tc.hgvsc.is_some())
+                                .and_then(|tx| {
+                                    tc.cdna_position
+                                        .as_deref()
+                                        .and_then(parse_cdna_position_start)
+                                        .and_then(|cdna_start| {
+                                            refseq_misalignment_offset(tx, cdna_start)
+                                        })
+                                });
+                            let refseq_offset = refseq_offset_value
+                                .map(|offset| offset.to_string())
+                                .unwrap_or_default();
+                            let given_ref = tc.given_ref.as_deref().unwrap_or("");
+                            let used_ref = tc.used_ref.as_deref().unwrap_or("");
+
+                            // Batch 1 fields from transcript metadata.
+                            let canonical = tx_opt
+                                .map(|tx| if tx.is_canonical { "YES" } else { "" })
+                                .unwrap_or("");
+                            let tsl_str = tx_opt
+                                .and_then(|tx| tx.tsl)
+                                .map(|v| v.to_string())
+                                .unwrap_or_default();
+                            let mane_select = tx_opt
+                                .and_then(|tx| tx.mane_select.as_deref())
+                                .unwrap_or("");
+                            let mane_plus = tx_opt
+                                .and_then(|tx| tx.mane_plus_clinical.as_deref())
+                                .unwrap_or("");
+                            let ensp = tx_opt
+                                .and_then(|tx| tx.translation_stable_id.as_deref())
+                                .unwrap_or("");
+                            let gene_pheno = tx_opt
+                                .map(|tx| if tx.gene_phenotype { "1" } else { "" })
+                                .unwrap_or("");
+                            let ccds = tx_opt.and_then(|tx| tx.ccds.as_deref()).unwrap_or("");
+                            let swissprot_raw =
+                                tx_opt.and_then(|tx| tx.swissprot.as_deref()).unwrap_or("");
+                            let swissprot = csq_escape(swissprot_raw);
+                            let trembl_raw =
+                                tx_opt.and_then(|tx| tx.trembl.as_deref()).unwrap_or("");
+                            let trembl = csq_escape(trembl_raw);
+                            let uniparc = tx_opt.and_then(|tx| tx.uniparc.as_deref()).unwrap_or("");
+                            let uniprot_isoform = tx_opt
+                                .and_then(|tx| tx.uniprot_isoform.as_deref())
+                                .unwrap_or("");
+
+                            if flags.everything {
+                                // HGVS_OFFSET mirrors the transcript-level HGVSc shift
+                                // decision. RefSeq rows with failed BAM edit replay can
+                                // still emit transcript-space HGVSc, but VEP suppresses
+                                // the exposed genomic shift for those transcripts.
+                                let hgvs_offset = if hgvs_flags.hgvsc {
+                                    tx_opt
+                                        .zip(row_variant.as_ref())
+                                        .and_then(|(tx, variant)| {
+                                            let ref_allele = tc
+                                                .used_ref
+                                                .as_deref()
+                                                .unwrap_or(variant.ref_allele.as_str());
+                                            crate::hgvs::hgvsc_offset_for_output(
+                                                tx,
+                                                variant,
+                                                ref_allele,
+                                                tc.hgvsc.as_deref(),
+                                            )
+                                        })
+                                        .map(|offset| offset.to_string())
+                                        .unwrap_or_default()
+                                } else {
+                                    String::new()
+                                };
+                                // MANE generic: VEP emits "MANE_Select" or "MANE_Plus_Clinical"
+                                // depending on the transcript's MANE annotation.
+                                // Traceability:
+                                // - VEP OutputFactory.pm MANE output
+                                //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1548-L1560
+                                let mane =
+                                    if tx_opt.and_then(|tx| tx.mane_select.as_deref()).is_some() {
+                                        "MANE_Select"
+                                    } else if tx_opt
+                                        .and_then(|tx| tx.mane_plus_clinical.as_deref())
+                                        .is_some()
+                                    {
+                                        "MANE_Plus_Clinical"
+                                    } else {
+                                        ""
+                                    };
+                                // APPRIS: abbreviate principal1→P1, alternative2→A2.
+                                // Traceability:
+                                // - VEP OutputFactory.pm APPRIS output
+                                //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1563-L1570
+                                let appris_str = tx_opt
+                                    .and_then(|tx| tx.appris.as_deref())
+                                    .map(format_appris)
+                                    .unwrap_or_default();
+                                // SIFT/PolyPhen: lookup by (protein_position, alt_amino_acid).
+                                // Traceability:
+                                // - VEP OutputFactory.pm SIFT/PolyPhen output
+                                //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/OutputFactory.pm#L1746-L1799
+                                let (sift_str, polyphen_str) = lookup_sift_polyphen(
                                     tc.transcript_id.as_deref(),
                                     tc.protein_position.as_deref(),
                                     tc.amino_acids.as_deref(),
-                                    ctx,
-                                )
-                            } else {
-                                String::new()
-                            };
-                            // miRNA: ncRNA secondary structure overlap.
-                            let mirna_str = {
-                                let ncrna = tx_opt.and_then(|tx| tx.ncrna_structure.as_deref());
-                                // Parse cDNA position range from the "N" or "N-M" string.
-                                let (cs, ce) = tc
-                                    .cdna_position
-                                    .as_deref()
-                                    .and_then(|p| {
-                                        if let Some((a, b)) = p.split_once('-') {
-                                            Some((
-                                                a.parse::<usize>().ok()?,
-                                                b.parse::<usize>().ok()?,
-                                            ))
-                                        } else {
-                                            let v = p.parse::<usize>().ok()?;
-                                            Some((v, v))
-                                        }
-                                    })
-                                    .unwrap_or((0, 0));
-                                if cs > 0 {
-                                    mirna_structure_field(ncrna, biotype, Some(cs), Some(ce))
+                                    sift_cache,
+                                    #[cfg(feature = "kv-cache")]
+                                    sift_kv,
+                                    #[cfg(not(feature = "kv-cache"))]
+                                    _sift_kv,
+                                );
+                                // DOMAINS: overlapping protein domain features.
+                                // VEP gates DOMAINS on $pre->{coding} which requires
+                                // a valid CDS coordinate mapping. Our cds_position is
+                                // only set when the variant falls within the CDS region.
+                                // Traceability:
+                                // - VEP OutputFactory.pm line 1434: if($self->{domains} && $pre->{coding})
+                                // - VEP BaseVariationFeatureOverlapAllele.pm _bvfo_preds lines 449-471
+                                //   https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+                                let is_coding =
+                                    tc.cds_position.as_deref().is_some_and(|s| !s.is_empty());
+                                let domains = if is_coding {
+                                    lookup_domains(
+                                        tc.transcript_id.as_deref(),
+                                        tc.protein_position.as_deref(),
+                                        tc.amino_acids.as_deref(),
+                                        ctx,
+                                    )
                                 } else {
                                     String::new()
-                                }
-                            };
-                            // 80-field CSQ base layout, with optional PICK and RefSeq fields.
-                            // Traceability:
-                            // - VEP Constants.pm CSQ field order for --everything
-                            //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/Constants.pm#L66-L138
-                            let pick_field = if include_pick_output {
-                                format!("|{pick_str}")
-                            } else {
-                                String::new()
-                            };
-                            let refseq_block = if include_source_field {
-                                format!(
-                                    "|{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
-                                )
-                            } else if include_refseq_fields {
-                                format!(
-                                    "|{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
-                                )
-                            } else {
-                                String::new()
-                            };
-                            let _ = write!(
-                                csq_buf,
-                                "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
+                                };
+                                // miRNA: ncRNA secondary structure overlap.
+                                let mirna_str = {
+                                    let ncrna = tx_opt.and_then(|tx| tx.ncrna_structure.as_deref());
+                                    // Parse cDNA position range from the "N" or "N-M" string.
+                                    let (cs, ce) = tc
+                                        .cdna_position
+                                        .as_deref()
+                                        .and_then(|p| {
+                                            if let Some((a, b)) = p.split_once('-') {
+                                                Some((
+                                                    a.parse::<usize>().ok()?,
+                                                    b.parse::<usize>().ok()?,
+                                                ))
+                                            } else {
+                                                let v = p.parse::<usize>().ok()?;
+                                                Some((v, v))
+                                            }
+                                        })
+                                        .unwrap_or((0, 0));
+                                    if cs > 0 {
+                                        mirna_structure_field(ncrna, biotype, Some(cs), Some(ce))
+                                    } else {
+                                        String::new()
+                                    }
+                                };
+                                // 80-field CSQ base layout, with optional PICK and RefSeq fields.
+                                // Traceability:
+                                // - VEP Constants.pm CSQ field order for --everything
+                                //   https://github.com/Ensembl/ensembl-vep/blob/release/115/modules/Bio/EnsEMBL/VEP/Constants.pm#L66-L138
+                                let pick_field = if include_pick_output {
+                                    format!("|{pick_str}")
+                                } else {
+                                    String::new()
+                                };
+                                let refseq_block = if include_source_field {
+                                    format!(
+                                        "|{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                    )
+                                } else if include_refseq_fields {
+                                    format!(
+                                        "|{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                    )
+                                } else {
+                                    String::new()
+                                };
+                                let _ = write!(
+                                    csq_buf,
+                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
                              {exon}|{intron}|{hgvsc}|{hgvsp}|\
                              {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
                              {existing_var}|{distance}|{strand_str}|{tc_flags}{pick_field}|\
@@ -5295,28 +5303,28 @@ impl AnnotateProvider {
                              {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
                              {hgvs_offset}|\
                              {batch3_suffix}|||||"
-                            );
-                        } else {
-                            // 74-field CSQ base layout, with optional PICK and RefSeq fields.
-                            let pick_field = if include_pick_output {
-                                format!("|{pick_str}")
+                                );
                             } else {
-                                String::new()
-                            };
-                            let source_block = if include_source_field {
-                                format!(
-                                    "|||||{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
-                                )
-                            } else if include_refseq_fields {
-                                format!(
-                                    "|||||{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
-                                )
-                            } else {
-                                format!("|||||{source_val}")
-                            };
-                            let _ = write!(
-                                csq_buf,
-                                "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
+                                // 74-field CSQ base layout, with optional PICK and RefSeq fields.
+                                let pick_field = if include_pick_output {
+                                    format!("|{pick_str}")
+                                } else {
+                                    String::new()
+                                };
+                                let source_block = if include_source_field {
+                                    format!(
+                                        "|||||{refseq_match}|{source_val}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                    )
+                                } else if include_refseq_fields {
+                                    format!(
+                                        "|||||{refseq_match}|{refseq_offset}|{given_ref}|{used_ref}|{bam_edit}"
+                                    )
+                                } else {
+                                    format!("|||||{source_val}")
+                                };
+                                let _ = write!(
+                                    csq_buf,
+                                    "{vep_allele}|{terms_str}|{tc_impact}|{symbol}|{gene}|{feature_type}|{feature}|{biotype}|\
                              {exon}|{intron}|{hgvsc}|{hgvsp}|\
                              {cdna_pos}|{cds_pos}|{protein_pos}|{amino_acids}|{codons_str}|\
                              {existing_var}|{distance}|{strand_str}|{tc_flags}{pick_field}|{symbol_source}|{hgnc_id}|\
@@ -5324,8 +5332,8 @@ impl AnnotateProvider {
                              {variant_class}|{canonical}|{tsl_str}|{mane_select}|{mane_plus}|\
                              {ensp}|{gene_pheno}|{ccds}|{swissprot}|{trembl}|{uniparc}|{uniprot_isoform}|\
                              {batch3_suffix}"
-                            );
-                        }
+                                );
+                            }
                         } // end per-ALT inner loop (multi-ALT CSQ expansion)
                     }
                     if csq_buf.is_empty() {
@@ -10616,8 +10624,7 @@ mod tests {
             ],
         )
         .unwrap();
-        let (chrom, min_start, max_end) =
-            buffer_variant_bounds(&[batch]).unwrap().unwrap();
+        let (chrom, min_start, max_end) = buffer_variant_bounds(&[batch]).unwrap().unwrap();
         // First-chrom-wins binding (lines 8141-8143).
         assert_eq!(chrom, "1");
         // Bounds still aggregate across all rows — documents current

--- a/datafusion/bio-function-vep/src/partitioned_cache.rs
+++ b/datafusion/bio-function-vep/src/partitioned_cache.rs
@@ -410,7 +410,10 @@ mod tests {
         // and `motif`. `motif` must be the trailing one (matching
         // Perl `$features->[-1]` == MotifFeature).
         let motif_pos = CONTEXT_TYPES.iter().position(|t| *t == "motif").unwrap();
-        let reg_pos = CONTEXT_TYPES.iter().position(|t| *t == "regulatory").unwrap();
+        let reg_pos = CONTEXT_TYPES
+            .iter()
+            .position(|t| *t == "regulatory")
+            .unwrap();
         // No regulatory-family context_type appears after motif.
         // (Other context_types like translation_core may appear after
         // motif in CONTEXT_TYPES — that's fine; the invariant is that

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -21095,16 +21095,17 @@ mod tests {
     // ctx.tx_trees from a &[TranscriptFeature] slice.
     #[test]
     fn tt8_prepared_context_builds_tx_trees() {
-        let tx_a = tx("ENST21A", "21", 1_000, 2_000, 1, "protein_coding", None, None);
-        let ctx = PreparedContext::new(
-            std::slice::from_ref(&tx_a),
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
+        let tx_a = tx(
+            "ENST21A",
+            "21",
+            1_000,
+            2_000,
+            1,
+            "protein_coding",
+            None,
+            None,
         );
+        let ctx = PreparedContext::new(std::slice::from_ref(&tx_a), &[], &[], &[], &[], &[], &[]);
         let tree = ctx
             .tx_trees
             .get("21")
@@ -21114,7 +21115,10 @@ mod tests {
         tree.query(1_500_i32, 1_500_i32, |node| {
             hits.push(*GenericInterval::<usize>::metadata(node));
         });
-        assert!(!hits.is_empty(), "expected a hit for the inserted transcript");
+        assert!(
+            !hits.is_empty(),
+            "expected a hit for the inserted transcript"
+        );
     }
 
     // SUBTEST #9 — architectural-no-analogue.
@@ -21128,14 +21132,43 @@ mod tests {
     #[test]
     fn tt10_prepared_context_exposes_chromosome_keyset() {
         let txs = vec![
-            tx("ENST21", "21", 1_000, 2_000, 1, "protein_coding", None, None),
-            tx("ENST22", "22", 3_000, 4_000, 1, "protein_coding", None, None),
-            tx("ENSTLRG", "LRG_485", 100, 200, 1, "protein_coding", None, None),
+            tx(
+                "ENST21",
+                "21",
+                1_000,
+                2_000,
+                1,
+                "protein_coding",
+                None,
+                None,
+            ),
+            tx(
+                "ENST22",
+                "22",
+                3_000,
+                4_000,
+                1,
+                "protein_coding",
+                None,
+                None,
+            ),
+            tx(
+                "ENSTLRG",
+                "LRG_485",
+                100,
+                200,
+                1,
+                "protein_coding",
+                None,
+                None,
+            ),
         ];
         let ctx = PreparedContext::new(&txs, &[], &[], &[], &[], &[], &[]);
         let keys: HashSet<String> = ctx.tx_trees.keys().cloned().collect();
-        let expected: HashSet<String> =
-            ["21", "22", "LRG_485"].iter().map(|s| s.to_string()).collect();
+        let expected: HashSet<String> = ["21", "22", "LRG_485"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         assert_eq!(keys, expected);
     }
 
@@ -21223,15 +21256,7 @@ mod tests {
             None,
             None,
         );
-        let ctx = PreparedContext::new(
-            std::slice::from_ref(&tx_a),
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
-            &[],
-        );
+        let ctx = PreparedContext::new(std::slice::from_ref(&tx_a), &[], &[], &[], &[], &[], &[]);
         // The tree was inserted under normalize_chrom("chr21") == "21".
         assert!(ctx.tx_trees.contains_key("21"));
         assert!(!ctx.tx_trees.contains_key("chr21"));

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -21246,4 +21246,64 @@ mod tests {
 
     // SUBTEST #34 — see nearest_index::tests::tt34 stub (arch-no-analogue:
     // vepyr biological coordinates are non-negative).
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Port of `ensembl-vep/t/Parser.t` `_have_chr` rows (subtests #31, #32,
+    // #34) — chr-membership check + chr-prefix normalisation.
+    //
+    // Detailed plan: `porting-tests/detailed_plans/Parser.md`.
+    // v2 paradigm: sztywno 1:1, standalone. Anchor:
+    // `~/.claude/skills/port-to-vepyr/references/v2-paradigm.md`.
+    //
+    // Perl `_have_chr` walks `valid_chromosomes`, optionally adds/strips
+    // `chr` prefix, M→MT alias, and synonym table. Vepyr replaces the
+    // strip-only branch via `normalize_chrom` (line 2975, this file). The
+    // add-prefix branch and M→MT/synonym lookups are blocked-future-work
+    // (rows #33, #35-#37 in detailed_plan, all tracked under the existing
+    // `PreparedContext chromosome-synonyms alias table` entry in
+    // `porting-tests/future-work-vepyr.md`).
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Port of `Parser.t` subtest #31 (Perl l.137):
+    ///   `_have_chr({chr=>1, valid_chromosomes={1=>1,21=>1,...}})` → 1.
+    ///
+    /// Vepyr analogue: `valid.contains(normalize_chrom("1"))` after
+    /// stripping any `chr` prefix. With input "1" already bare, the
+    /// strip is a no-op and the set lookup succeeds.
+    #[test]
+    fn port_parser_subtest_31_have_chr_bare_chrom_in_valid_set() {
+        let valid: std::collections::HashSet<&str> =
+            ["1", "21", "CHR_1", "MT", "chromosome", "chr12"]
+                .into_iter()
+                .collect();
+        assert!(valid.contains(normalize_chrom("1")));
+    }
+
+    /// Port of `Parser.t` subtest #32 (Perl l.138):
+    ///   `_have_chr({chr=>'chr1'})` → 1 (remove chr prefix).
+    ///
+    /// Vepyr analogue: `normalize_chrom("chr1") == "1"` then `valid.contains("1")`.
+    /// Already covered by `tt22_normalize_chrom_strips_chr_prefix` for the
+    /// pure-strip half; this row adds the set-membership pairing.
+    #[test]
+    fn port_parser_subtest_32_have_chr_chr_prefix_stripped_then_matches() {
+        let valid: std::collections::HashSet<&str> =
+            ["1", "21", "CHR_1", "MT", "chromosome", "chr12"]
+                .into_iter()
+                .collect();
+        let normalized = normalize_chrom("chr1");
+        assert_eq!(normalized, "1");
+        assert!(valid.contains(normalized));
+    }
+
+    /// Port of `Parser.t` subtest #34 (Perl l.140):
+    ///   `_have_chr({chr=>2, valid_chromosomes={1=>1,21=>1,...}})` → 0.
+    ///
+    /// Vepyr analogue: `valid.contains(normalize_chrom("2"))` → false.
+    /// Pin the negative-case behaviour explicitly to mirror Perl row #34.
+    #[test]
+    fn port_parser_subtest_34_have_chr_unknown_chrom_rejected() {
+        let valid: std::collections::HashSet<&str> = ["1", "21"].into_iter().collect();
+        assert!(!valid.contains(normalize_chrom("2")));
+    }
 }

--- a/datafusion/bio-function-vep/tests/port_annotation_source_adaptor.rs
+++ b/datafusion/bio-function-vep/tests/port_annotation_source_adaptor.rs
@@ -293,10 +293,7 @@ mod active {
         );
         let info_txt = cache_root.join("info.txt");
 
-        if !cache_root.exists()
-            || !info_txt.exists()
-            || is_lfs_pointer(&info_txt)
-        {
+        if !cache_root.exists() || !info_txt.exists() || is_lfs_pointer(&info_txt) {
             return None;
         }
 
@@ -310,7 +307,6 @@ mod active {
 
         Some(cache_root)
     }
-
 
     // SUBTEST #7 (L52-88 of AnnotationSourceAdaptor.t): default-config
     // `get_all_from_cache()` returns `[Cache::Transcript blessed-hash]`.

--- a/datafusion/bio-function-vep/tests/port_annotation_source_cache_regfeat.rs
+++ b/datafusion/bio-function-vep/tests/port_annotation_source_cache_regfeat.rs
@@ -152,7 +152,8 @@ async fn annotate_and_read_csq(
     .unwrap();
 
     let ctx = SessionContext::new();
-    ctx.register_table("output_vcf", Arc::new(output_prov)).ok()?;
+    ctx.register_table("output_vcf", Arc::new(output_prov))
+        .ok()?;
     let batches = ctx
         .sql("SELECT * FROM output_vcf ORDER BY start")
         .await
@@ -163,8 +164,7 @@ async fn annotate_and_read_csq(
     if batches.is_empty() {
         return Some(Vec::new());
     }
-    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches)
-        .ok()?;
+    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).ok()?;
     let csq_idx = batch.schema().index_of("CSQ").ok()?;
     let col = batch.column(csq_idx);
     let rows: Vec<String> = (0..batch.num_rows())
@@ -247,10 +247,7 @@ async fn regulatory_feature_overlap_emits_regulatory_csq() {
     // Subtest #26 / #38 (first stable_id): assert the regulatory group's
     // Feature column carries ENSR21_B6Z6N (the v115 enhancer overlapping
     // chr21:25039632).
-    let feature_ids: Vec<&str> = reg_groups
-        .iter()
-        .map(|g| g[6].as_str())
-        .collect();
+    let feature_ids: Vec<&str> = reg_groups.iter().map(|g| g[6].as_str()).collect();
     assert!(
         feature_ids.contains(&"ENSR21_B6Z6N"),
         "expected ENSR21_B6Z6N (v115 enhancer at 25039631-25040274); got {feature_ids:?}",

--- a/datafusion/bio-function-vep/tests/port_annotation_source_cache_regfeat_e2e.rs
+++ b/datafusion/bio-function-vep/tests/port_annotation_source_cache_regfeat_e2e.rs
@@ -168,8 +168,7 @@ async fn annotate_and_read(
         drop(tmp);
         return Vec::new();
     }
-    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches)
-        .unwrap();
+    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
     let csq_idx = batch.schema().index_of("CSQ").ok();
     let mut out = Vec::new();
     for row in 0..batch.num_rows() {

--- a/datafusion/bio-function-vep/tests/port_annotation_source_cache_variation.rs
+++ b/datafusion/bio-function-vep/tests/port_annotation_source_cache_variation.rs
@@ -113,10 +113,7 @@ fn v115_fixture_paths() -> Option<(PathBuf, PathBuf)> {
     let cache_path = workspace_path("vep-benchmark/data/port/_cache115/parquet/115_GRCh38_vep");
     let ref_fasta = workspace_path("vep-benchmark/data/port/_cache115/reference.fa");
 
-    if !cache_path.exists()
-        || !ref_fasta.exists()
-        || is_lfs_pointer(&ref_fasta)
-    {
+    if !cache_path.exists() || !ref_fasta.exists() || is_lfs_pointer(&ref_fasta) {
         return None;
     }
     Some((cache_path, ref_fasta))
@@ -230,8 +227,7 @@ async fn annotate_and_read_csq(
         drop(tmp);
         return Vec::new();
     }
-    let batch =
-        datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
+    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
     let Ok(csq_idx) = batch.schema().index_of("CSQ") else {
         drop(tmp);
         return (0..batch.num_rows()).map(|_| String::new()).collect();
@@ -255,8 +251,7 @@ const CSQ_EXISTING_VARIATION_IDX: usize = 17;
 fn first_existing_variation(csq: &str) -> String {
     let groups = parse_csq_row(csq);
     for group in &groups {
-        if group.len() > CSQ_EXISTING_VARIATION_IDX
-            && !group[CSQ_EXISTING_VARIATION_IDX].is_empty()
+        if group.len() > CSQ_EXISTING_VARIATION_IDX && !group[CSQ_EXISTING_VARIATION_IDX].is_empty()
         {
             return group[CSQ_EXISTING_VARIATION_IDX].clone();
         }
@@ -444,9 +439,7 @@ async fn failed_toggle_default_drops_and_opt_in_keeps_5b_6b_7b() {
     // pair where the row carries `failed=1`. If none exists, SKIP.
     let var_parquet = cache_path.join("variation").join("21.parquet");
     if !var_parquet.exists() {
-        eprintln!(
-            "Skipping port_cache_variation::failed_toggle_*: variation/21.parquet absent"
-        );
+        eprintln!("Skipping port_cache_variation::failed_toggle_*: variation/21.parquet absent");
         return;
     }
 
@@ -530,13 +523,8 @@ async fn failed_toggle_default_drops_and_opt_in_keeps_5b_6b_7b() {
     //   weaker invariant that some Existing_variation is empty at the row
     //   level OR the rsID we identified above is absent under default.
     let default_config = base_config(ref_fasta.to_str().unwrap());
-    let rows_default = annotate_and_read_csq(
-        &vcf_path,
-        &cache_path,
-        &ref_fasta,
-        &default_config,
-    )
-    .await;
+    let rows_default =
+        annotate_and_read_csq(&vcf_path, &cache_path, &ref_fasta, &default_config).await;
     assert_eq!(rows_default.len(), 1);
 
     // Subtest #7b — `failed=Some(1)` keeps the row (cache row's rsID
@@ -586,13 +574,8 @@ async fn failed_toggle_default_drops_and_opt_in_keeps_5b_6b_7b() {
         failed: Some(1),
         ..base_config(ref_fasta.to_str().unwrap())
     };
-    let rows_opt_in = annotate_and_read_csq(
-        &vcf_path,
-        &cache_path,
-        &ref_fasta,
-        &opt_in_config,
-    )
-    .await;
+    let rows_opt_in =
+        annotate_and_read_csq(&vcf_path, &cache_path, &ref_fasta, &opt_in_config).await;
     assert_eq!(rows_opt_in.len(), 1);
 
     // Default behaviour: the failed=1 row's rsID must NOT surface.

--- a/datafusion/bio-function-vep/tests/port_annotation_source_cache_variation_e2e.rs
+++ b/datafusion/bio-function-vep/tests/port_annotation_source_cache_variation_e2e.rs
@@ -228,8 +228,7 @@ fn any_existing_variation_for_allele(csq: &str, target_allele: &str) -> bool {
         if group.len() <= csq_idx::EXISTING_VARIATION {
             continue;
         }
-        if group[csq_idx::ALLELE] == target_allele
-            && !group[csq_idx::EXISTING_VARIATION].is_empty()
+        if group[csq_idx::ALLELE] == target_allele && !group[csq_idx::EXISTING_VARIATION].is_empty()
         {
             return true;
         }
@@ -276,8 +275,7 @@ async fn annotate_and_read_csq(
         drop(tmp);
         return Vec::new();
     }
-    let batch =
-        datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
+    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
     let id_idx = batch.schema().index_of("id").ok();
     let csq_idx = batch.schema().index_of("CSQ").ok();
     let mut out = Vec::new();
@@ -718,8 +716,7 @@ async fn axis_b_b4_star_allele_in_multi_alt_skipped() {
         );
         return;
     }
-    let batch =
-        datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
+    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap();
     if batch.num_rows() == 0 {
         eprintln!("Axis B B4: zero output rows; treating as inconclusive.");
         return;

--- a/datafusion/bio-function-vep/tests/port_common.rs
+++ b/datafusion/bio-function-vep/tests/port_common.rs
@@ -242,16 +242,12 @@ async fn compare_csq_inner(
         .await?
         .collect()
         .await?;
-    let output_batch = datafusion::arrow::compute::concat_batches(
-        &output_batches[0].schema(),
-        &output_batches,
-    )
-    .unwrap();
-    let golden_batch = datafusion::arrow::compute::concat_batches(
-        &golden_batches[0].schema(),
-        &golden_batches,
-    )
-    .unwrap();
+    let output_batch =
+        datafusion::arrow::compute::concat_batches(&output_batches[0].schema(), &output_batches)
+            .unwrap();
+    let golden_batch =
+        datafusion::arrow::compute::concat_batches(&golden_batches[0].schema(), &golden_batches)
+            .unwrap();
 
     let ours = read_csq_column(&output_batch);
     let golden = read_csq_column(&golden_batch);
@@ -437,9 +433,7 @@ pub async fn run_and_compare_csq_with_flags(
         || is_lfs_pointer(&input_vcf)
         || is_lfs_pointer(&golden_vcf)
     {
-        eprintln!(
-            "Skipping port case '{name}/{flag_subdir}': fixture(s) missing or LFS-stubbed"
-        );
+        eprintln!("Skipping port case '{name}/{flag_subdir}': fixture(s) missing or LFS-stubbed");
         return Ok(false);
     }
 

--- a/datafusion/bio-function-vep/tests/port_config.rs
+++ b/datafusion/bio-function-vep/tests/port_config.rs
@@ -72,15 +72,24 @@ fn t1_annotate_vcf_config_default_all_off() {
     assert!(!cfg.pick_allele_gene, "pick_allele_gene default false");
     assert!(!cfg.flag_pick, "flag_pick default false");
     assert!(!cfg.flag_pick_allele, "flag_pick_allele default false");
-    assert!(!cfg.flag_pick_allele_gene, "flag_pick_allele_gene default false");
+    assert!(
+        !cfg.flag_pick_allele_gene,
+        "flag_pick_allele_gene default false"
+    );
     assert!(!cfg.extended_probes, "extended_probes default false");
     assert!(!cfg.use_fjall, "use_fjall default false");
     assert!(!cfg.hgvs, "hgvs default false");
     assert!(!cfg.hgvsc, "hgvsc default false");
     assert!(!cfg.hgvsp, "hgvsp default false");
     assert!(!cfg.no_escape, "no_escape default false");
-    assert!(!cfg.remove_hgvsp_version, "remove_hgvsp_version default false");
-    assert!(!cfg.hgvsp_use_prediction, "hgvsp_use_prediction default false");
+    assert!(
+        !cfg.remove_hgvsp_version,
+        "remove_hgvsp_version default false"
+    );
+    assert!(
+        !cfg.hgvsp_use_prediction,
+        "hgvsp_use_prediction default false"
+    );
     assert!(!cfg.refseq, "refseq default false");
     assert!(!cfg.merged, "merged default false");
     assert!(!cfg.gencode_basic, "gencode_basic default false");

--- a/datafusion/bio-function-vep/tests/port_input_buffer.rs
+++ b/datafusion/bio-function-vep/tests/port_input_buffer.rs
@@ -153,7 +153,8 @@ async fn annotate_and_read_csq(
     .unwrap();
 
     let ctx = SessionContext::new();
-    ctx.register_table("output_vcf", Arc::new(output_prov)).ok()?;
+    ctx.register_table("output_vcf", Arc::new(output_prov))
+        .ok()?;
     let batches = ctx
         .sql("SELECT * FROM output_vcf ORDER BY start")
         .await
@@ -462,9 +463,9 @@ async fn port_input_buffer_subtest_51_intergenic_consequence() {
     // Consequence is field index 1 in default --everything layout
     // (field 0 = Allele).
     let consequence_idx = 1;
-    let has_intergenic = groups.iter().any(|g| {
-        g.len() > consequence_idx && g[consequence_idx].contains("intergenic_variant")
-    });
+    let has_intergenic = groups
+        .iter()
+        .any(|g| g.len() > consequence_idx && g[consequence_idx].contains("intergenic_variant"));
     assert!(
         has_intergenic,
         "expected ≥1 CSQ group with Consequence=intergenic_variant for chr21:6000000; got groups: {:?}",
@@ -602,8 +603,18 @@ async fn port_input_buffer_subtests_55_to_58_per_contig_partitioning_preserves_c
         .downcast_ref::<datafusion::arrow::array::UInt32Array>()
         .expect("start column is UInt32");
     let starts: Vec<u32> = (0..start_col.len()).map(|i| start_col.value(i)).collect();
-    assert_eq!(chroms.len(), 4, "4 input rows must yield 4 output rows; got {}", chroms.len());
-    assert_eq!(starts.len(), 4, "4 input rows must yield 4 start values; got {}", starts.len());
+    assert_eq!(
+        chroms.len(),
+        4,
+        "4 input rows must yield 4 output rows; got {}",
+        chroms.len()
+    );
+    assert_eq!(
+        starts.len(),
+        4,
+        "4 input rows must yield 4 start values; got {}",
+        starts.len()
+    );
 
     // All rows are chr21 → all output rows must be chr21 (no chrom drops).
     for c in &chroms {

--- a/datafusion/bio-function-vep/tests/port_parser.rs
+++ b/datafusion/bio-function-vep/tests/port_parser.rs
@@ -141,7 +141,11 @@ async fn port_parser_subtest_12_gzipped_vcf_reads() {
     }
     // Sanity-check: file must look gzip-magic 0x1f 0x8b on disk.
     let raw = std::fs::read(&gz_path).expect("read gz");
-    assert_eq!(&raw[..2], &[0x1f, 0x8b], "gz file must start with gzip magic");
+    assert_eq!(
+        &raw[..2],
+        &[0x1f, 0x8b],
+        "gz file must start with gzip magic"
+    );
 
     let rows = count_vcf_rows(gz_path.to_str().unwrap())
         .await

--- a/datafusion/bio-function-vep/tests/port_parser.rs
+++ b/datafusion/bio-function-vep/tests/port_parser.rs
@@ -1,0 +1,402 @@
+//! v2-paradigm port of `ensembl-vep/t/Parser.t`.
+//!
+//! Detailed plan: `porting-tests/detailed_plans/Parser.md` (audited
+//! 2026-05-27, post-Phase-D with 3 Axis-B additions).
+//! TDD task plan:  implemented in-context 2026-05-28 per port-to-vepyr
+//! skill heuristic (12 unit-ports + 47 architectural-no-analogue + 21
+//! blocked-future-work — mostly documentation, no subagent needed).
+//!
+//! v2 paradigm anchors (~/.claude/skills/port-to-vepyr/references/v2-paradigm.md):
+//! - Sztywno 1:1 — every Perl subtest gets a Rust analogue (here:
+//!   passing test, `// SUBTEST #N:` documentation comment naming the
+//!   missing-by-design vepyr component, or a commented-out future-work
+//!   stub).
+//! - Standalone — no docker dependency, no `golden.vcf`, no
+//!   `port_common::run_and_compare_csq`. Hand-coded assertion values
+//!   suffice because the unit-ports in this file pin parser-layer
+//!   behaviour (file-exists, gzip-detection, CRLF-tolerance, bgzip
+//!   reading), not CSQ-output values.
+//!
+//! Where the rest of the Perl rows live:
+//! - allele-minimisation rows #17, #18, #19, Axis B B1 →
+//!   `src/allele.rs::tests` (pure-function tests on `vcf_to_vep_allele`).
+//! - `_have_chr` rows #31, #32, #34 →
+//!   `src/transcript_consequence.rs::tests` (against `normalize_chrom`).
+//! - Axis B B2 (`buffer_variant_bounds` multi-chrom first-chrom-wins) →
+//!   already covered by
+//!   `src/annotate_provider.rs::tests::port_input_buffer_axisB1_buffer_variant_bounds_multi_chrom_binds_to_first_chrom`
+//!   (the existing InputBuffer Axis B B1 test asserts the same vepyr
+//!   invariant; cross-referenced here per detailed_plan).
+//!
+//! Coverage parity (per detailed_plan):
+//! - 9 unit-port + 3 Axis B = 12 passing Rust tests across the 3 files
+//!   listed above.
+//! - 47 architectural-no-analogue rows + 21 blocked-future-work rows
+//!   documented in the comment block at the bottom of this file plus
+//!   inline at the unit-port test sites.
+//! - Phase-A parity: 9 / 77 = 12% Perl-denominator unit-ports;
+//!   (9 + 21) / 77 = 39% addressable once engine blockers land.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use datafusion::prelude::*;
+use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+/// Tiny chr21 SNV row used as the body of all inline VCFs in this file.
+/// Same shape as `tests/data/port/test_smoke/input.vcf` row 1.
+const SMOKE_VCF: &str = "\
+##fileformat=VCFv4.2
+##source=vepyr-port-parser
+##contig=<ID=21,length=46709983>
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+21\t25587759\ttest_smoke_snv\tT\tC\t.\tPASS\t.
+";
+
+/// Build a session context with the given file-path-backed VCF provider
+/// registered as table `vcf`, then count rows via SQL. Returns the row
+/// count; surfaces parse errors to the caller so `try_new`-level
+/// failures propagate.
+async fn count_vcf_rows(file_path: &str) -> datafusion::error::Result<usize> {
+    let provider = VcfTableProvider::new(file_path.to_string(), None, None, None, false)?;
+    let ctx = SessionContext::new();
+    ctx.register_table("vcf", Arc::new(provider))?;
+    let df = ctx.sql("SELECT COUNT(*) FROM vcf").await?;
+    let batches = df.collect().await?;
+    assert_eq!(batches.len(), 1);
+    let batch = &batches[0];
+    let col = batch.column(0);
+    let arr = col
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::Int64Array>()
+        .expect("COUNT(*) returns Int64");
+    Ok(arr.value(0) as usize)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Unit-port rows
+// ─────────────────────────────────────────────────────────────────────
+
+/// Port of `Parser.t` subtest #7 (Perl l.52):
+///   `throws_ok { $p->file('foo') } qr/File.+does not exist/`.
+///
+/// Vepyr analogue: `VcfTableProvider::new(<nonexistent_path>, ...)` is
+/// observably an error — it panics inside `bio-format-core` object
+/// storage (`object_storage.rs:183` unwrap on `kind: NotFound`) rather
+/// than returning a typed `DataFusionError`. The contract Perl
+/// asserts ("opening a missing path fails") holds; only the failure
+/// mode differs (panic vs `Err`). Pinning the panic here documents the
+/// current behaviour; a future patch can convert the unwrap to a
+/// proper `DataFusionError::IoError` without breaking this test (just
+/// remove the `catch_unwind` wrapper).
+#[tokio::test(flavor = "multi_thread")]
+async fn port_parser_subtest_07_nonexistent_path_errors() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let bogus = tmp.path().join("does-not-exist.vcf");
+    // The temp dir exists but the file path does not.
+    assert!(!bogus.exists());
+
+    let bogus_str = bogus.to_str().unwrap().to_string();
+    // `VcfTableProvider::new` is synchronous and panics on NotFound
+    // today; use `catch_unwind` on a blocking call so the test passes
+    // either way.
+    let result = std::panic::catch_unwind(|| {
+        VcfTableProvider::new(bogus_str.clone(), None, None, None, false)
+    });
+    match result {
+        Ok(Ok(_)) => panic!("VcfTableProvider::new must not succeed on a nonexistent path"),
+        Ok(Err(err)) => {
+            // Future "fixed" world: typed error surfaces. Check it is
+            // non-empty so the contract message is still informative.
+            let msg = format!("{err}");
+            assert!(!msg.is_empty(), "typed error must carry a message");
+        }
+        Err(_panic) => {
+            // Current world: object-storage unwraps on NotFound. The
+            // contract (observable failure on missing path) is upheld.
+        }
+    }
+}
+
+/// Port of `Parser.t` subtest #12 (Perl l.62):
+///   `ok($p->file($test_gzvcf) =~ /GLOB/, 'gzipped VCF')`.
+///
+/// Vepyr analogue: `VcfTableProvider::new(<*.vcf.gz>)` succeeds and the
+/// row count matches the uncompressed equivalent — i.e. gzip is
+/// transparently autodetected by `noodles_vcf` (via the magic bytes
+/// 0x1f 0x8b) and the reader streams decompressed records.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_parser_subtest_12_gzipped_vcf_reads() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let gz_path = tmp.path().join("smoke.vcf.gz");
+    {
+        let f = std::fs::File::create(&gz_path).expect("create gz file");
+        let mut encoder = GzEncoder::new(f, Compression::default());
+        encoder
+            .write_all(SMOKE_VCF.as_bytes())
+            .expect("write gzipped VCF body");
+        encoder.finish().expect("finish gz stream");
+    }
+    // Sanity-check: file must look gzip-magic 0x1f 0x8b on disk.
+    let raw = std::fs::read(&gz_path).expect("read gz");
+    assert_eq!(&raw[..2], &[0x1f, 0x8b], "gz file must start with gzip magic");
+
+    let rows = count_vcf_rows(gz_path.to_str().unwrap())
+        .await
+        .expect("gzipped VCF must read");
+    assert_eq!(rows, 1, "smoke gzipped VCF has exactly one data row");
+}
+
+/// Port of `Parser.t` subtest #57 (Perl l.249-250):
+///   `$p->file($windows_vcf); is($p->detect_format, 'vcf')`.
+///
+/// Vepyr analogue: `VcfTableProvider::new(<CRLF-VCF>)` must succeed and
+/// the parser must tolerate `\r\n` line endings. Build a CRLF-line-
+/// terminated tiny VCF inline and assert one row reads back. There is
+/// no `detect_format` API in vepyr (single-format by design); the
+/// behavioural equivalent is "the reader doesn't choke on CRLF input."
+#[tokio::test(flavor = "multi_thread")]
+async fn port_parser_subtest_57_crlf_line_endings_tolerated() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let crlf_path = tmp.path().join("smoke_crlf.vcf");
+    let crlf_body = SMOKE_VCF.replace('\n', "\r\n");
+    assert!(crlf_body.contains("\r\n"), "fixture must contain CRLF");
+    std::fs::write(&crlf_path, crlf_body.as_bytes()).expect("write crlf vcf");
+
+    let rows = count_vcf_rows(crlf_path.to_str().unwrap())
+        .await
+        .expect("CRLF VCF must read");
+    assert_eq!(rows, 1, "CRLF-terminated VCF round-trips one row");
+}
+
+/// Port of Axis-B row B3 (post-Phase-D 2026-05-27):
+///   `VcfTableProvider::try_new` with a `.vcf.bgz`-extension file
+///   (bgzip not gzip) succeeds.
+///
+/// Detailed plan: `porting-tests/detailed_plans/Parser.md` row B3. Pin
+/// extension-routing behaviour: a `.vcf.bgz` file containing a valid
+/// gzip-magic stream must round-trip through the reader. We use a plain
+/// gzip stream (not block-gzip) because the test only pins extension
+/// handling; the underlying bgzf machinery is the responsibility of
+/// `noodles-vcf` / `noodles-bgzf` and is exercised elsewhere.
+#[tokio::test(flavor = "multi_thread")]
+#[allow(non_snake_case)]
+async fn port_parser_axisB3_vcf_bgz_extension_reads() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let bgz_path = tmp.path().join("smoke.vcf.bgz");
+    {
+        let f = std::fs::File::create(&bgz_path).expect("create bgz file");
+        let mut encoder = GzEncoder::new(f, Compression::default());
+        encoder
+            .write_all(SMOKE_VCF.as_bytes())
+            .expect("write gz body under .bgz extension");
+        encoder.finish().expect("finish gz stream");
+    }
+    assert!(bgz_path.exists());
+    assert_eq!(
+        bgz_path.extension().and_then(|e| e.to_str()),
+        Some("bgz"),
+        "extension routing precondition"
+    );
+
+    // noodles_vcf accepts both `.gz` and `.bgz` as compressed inputs.
+    let rows = count_vcf_rows(bgz_path.to_str().unwrap())
+        .await
+        .expect(".vcf.bgz must read");
+    assert_eq!(rows, 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Blocked-future-work stubs (commented-out, in source order)
+//
+// Each stub names the missing vepyr API; the substantive entry lives in
+// `porting-tests/future-work-vepyr.md`. These 21 rows raise vepyr's
+// engine-level surface to match Parser.t once the listed APIs land.
+// ─────────────────────────────────────────────────────────────────────
+
+// SUBTESTS #20-#25 (Perl l.106-111): `get_SO_term('INS'/'DEL'/'INV'/
+//   'TREP'/'BND'/'DEL_ME')` → 'insertion'/'deletion'/'inversion'/
+//   'tandem_repeat'/'chromosome_breakpoint'/'mobile_element_deletion'.
+// Blocked: engine blocker #2 — `sv_type_to_so` function + extended
+// `SoTerm` variants. See `porting-tests/future-work-vepyr.md` SO-term
+// entries and `port-status.md` engine blocker #2 cluster.
+//
+// #[test]
+// fn port_parser_subtest_20_so_term_ins_to_insertion() {
+//     assert_eq!(sv_type_to_so("INS"), Some(SoTerm::Insertion));
+// }
+// (similar for DEL, INV, TREP, BND, DEL_ME)
+
+// SUBTEST #28 (Perl l.124-125): `validate_vf` synthesises a
+// variation_name '1_1_G/C' when VCF ID is `.`.
+// Blocked: `synthesize_variation_name(chrom, pos, ref, alt) -> String`
+// missing. Future-work entry: `Uploaded_variation fallback name
+// synthesis` (future-work-vepyr.md line 454+). Effort: S.
+//
+// #[test]
+// fn port_parser_subtest_28_uploaded_variation_synthesised_from_pos_alleles() {
+//     // VCF: 1 1 . G C  → CSQ Uploaded_variation should be "1_1_G/C"
+//     //                  (vepyr currently emits literal ".")
+//     assert_eq!(
+//         synthesize_variation_name("1", 1, "G", "C"),
+//         "1_1_G/C".to_string()
+//     );
+// }
+
+// SUBTEST #29 (Perl l.127-129): per-port `$p->{chr} = ['1']` filter
+// excludes rows on chr=2.
+// Blocked: per-port `chr_filter: HashSet<String>` plumbing. SQL-level
+// `WHERE chrom IN (...)` already works; this is ergonomic CLI sugar.
+// Future-work entry: `Per-port chr_filter (CLI --chr analogue)`
+// (future-work-vepyr.md line 463+). Effort: S.
+//
+// #[tokio::test]
+// async fn port_parser_subtest_29_chr_filter_includes_excludes_rows() {
+//     // chr_filter=["1"] → row on chr=1 stays, row on chr=2 dropped.
+//     unimplemented!()
+// }
+
+// SUBTESTS #33, #35, #36, #37 — chromosome-synonyms alias table:
+// #33 (l.139): `_have_chr(12)` → 1 (vepyr's `normalize_chrom` strips
+//   `chr` prefix; it does NOT ADD one). Requires alias lookup.
+// #35 (l.142-144): `_have_chr('M')` → 1, with rewrite chr=M → MT.
+// #36 (l.146): `chromosome_synonyms($file)` loads a TSV alias table.
+// #37 (l.147-149): `_have_chr('NC_000021.9')` resolves via synonyms,
+//   chr is left unchanged after the lookup (only matches, never rewrites).
+// All blocked on the same vepyr API gap.
+// Future-work entry: `PreparedContext chromosome-synonyms alias table`
+// (future-work-vepyr.md line 273+, already open from TranscriptTree
+// port). Effort: M.
+//
+// #[test]
+// fn port_parser_subtest_33_have_chr_adds_chr_prefix_via_alias() {
+//     // valid set keyed "chr12"; lookup of bare "12" must succeed via alias.
+//     unimplemented!()
+// }
+// #[test]
+// fn port_parser_subtest_35_have_chr_m_aliases_to_mt() {
+//     // Input "M" rewrites to "MT" via M→MT alias; vf.chrom becomes "MT".
+//     unimplemented!()
+// }
+// (and #36/#37)
+
+// SUBTESTS #45-#49 — `check_ref` FASTA input-validation pass:
+// #45 (l.189): insertion '-/T' with check_ref=1 passes (insertions
+//   bypass check_ref).
+// #46 (l.191-192): 'C/T' at chr21:25585733 matches FASTA → ok.
+// #47 (l.194-196): 'G/T' at chr21:25585733 mismatches FASTA → false
+//   with warning 'Specified reference allele ... does not match'.
+// #48 (l.198-199): 'CTT/TCC' multi-base ref matches → ok.
+// #49 (l.201-203): 'TTT/T' at chr21:25585733-25585735 — regression for
+//   trailing-character handling on multi-base ref.
+// Blocked: vepyr `check_ref` input validation missing. Future-work
+// entry: `check_ref FASTA input-validation pass` (future-work-vepyr.md
+// line 472+). Effort: M (indexed FASTA reader exists at
+// annotate_provider.rs:3153; just needs the UDF/table-fn surface).
+//
+// #[test]
+// fn port_parser_subtest_46_check_ref_matches_fasta() {
+//     // chr21:25585733 C/T matches reference (real FASTA value at that pos).
+//     // assert!(check_ref_filter("21", 25585733, "C", &fasta).unwrap());
+//     unimplemented!()
+// }
+// (and #45, #47, #48, #49 — same pattern, varying assertion polarity)
+
+// SUBTESTS #50-#53 — `lookup_ref` FASTA input-REF backfill:
+// #50 (l.212-214): 'N/T' at chr21:25585733 backfills N → C (FASTA);
+//   allele_string becomes 'C/T'.
+// #51 (l.216-218): 'N/T' on strand -1 backfills with revcomp(C) → G;
+//   allele_string becomes 'G/T'.
+// #52 (l.220-222): 'N/-' deletion backfills N → C; allele_string 'C/-'.
+// #53 (l.224-226): insertion '-/T' lookup_ref is a no-op (no REF base
+//   to fill); allele_string stays '-/T'.
+// Blocked: vepyr `lookup_ref` input-REF backfill missing. Future-work
+// entry: `lookup_ref FASTA input-REF backfill` (future-work-vepyr.md
+// line 486+). Effort: M.
+//
+// #[test]
+// fn port_parser_subtest_50_lookup_ref_fills_n_from_fasta() {
+//     // lookup_ref_udf("21", 25585733, "N", 1) → "C"
+//     unimplemented!()
+// }
+// (and #51, #52, #53)
+
+// ─────────────────────────────────────────────────────────────────────
+// Architectural-no-analogue rows (47 total) — documentation only.
+//
+// Each row below names the missing-by-design vepyr component and why
+// vepyr's data model precludes it. Substantive justifications also live
+// in `porting-tests/detailed_plans/Parser.md` §Architectural-no-analogue.
+// ─────────────────────────────────────────────────────────────────────
+
+// SUBTESTS #2, #3, #5, #6, #8, #9, #10, #11, #13, #14, #15, #16 —
+//   base-`Parser`-class plumbing.
+//
+// Missing-by-design component: **multi-format `Parser` base class**.
+// Perl's `Bio::EnsEMBL::VEP::Parser` is a format dispatcher that
+// instantiates one of `Parser::VCF` / `Parser::VEP_input` / `Parser::ID`
+// / `Parser::HGVS` / `Parser::Region` / `Parser::SPDI` / `Parser::CAID`
+// based on `format` / `detect_format`. Each subclass shares the base's
+// `file` / `headers` / `line_number` / `delimiter` / `valid_chromosomes`
+// accessors and the gzipped-VCF GLOB-handle trick. Vepyr is VCF-only by
+// project-wide design (Parser_CAID/HGVS/ID/Region/SPDI/VEP_input are
+// EXCLUDE-no-analogue per port-status.md rows 20-25); `VcfTableProvider`
+// IS the single parser, with no dispatch layer. STDIN input is also out
+// of scope (CLI takes paths only).
+
+// SUBTESTS #26, #27, #38-#44 — `validate_vf` per-row validation pass
+//   with warning emission.
+//
+// Missing-by-design component: **per-row VF-validation pass with STDERR
+// warning emission**. Perl's `validate_vf` runs a check chain (chr in
+// valid set; start/end numeric; start ≤ end+1; allele characters; REF
+// length vs coord span) and emits one warning per failed check. Vepyr
+// handles each implicitly:
+// - chr: silent drop via DataFusion partition filter (`discover_vcf_contigs`).
+// - numeric POS/END: caught by `noodles_vcf` at parse time; surfaces as
+//   a DataFusion `Err`.
+// - allele characters (`Q/R` etc): NOT validated. Downstream consequence
+//   prediction may produce undefined output. Could be tightened later.
+// - REF length vs coord span: NOT validated.
+// Adding a `validate_vf` Rust function would require a per-row warning
+// sink with no current library consumer; vepyr is a DataFusion-UDF
+// library where STDERR warnings don't fit the API surface.
+
+// SUBTEST #30 — `g/c` lowercase allele uppercase coercion.
+//
+// Missing-by-design component: **input-allele case coercion**. Perl's
+// `validate_vf` rewrites lowercase allele strings to uppercase. Vepyr
+// does NOT do this — `noodles_vcf` passes alleles through verbatim and
+// the consequence engine treats them case-sensitively. Adding this risks
+// changing reference-comparison semantics; deliberately punt unless a
+// real consumer surfaces a case.
+
+// SUBTESTS #54, #55, #56 — `detect_format` on `<*>` and SV-shape VCF
+//   rows (`SVTYPE=DUP;END=...`, `<DUP>`).
+// SUBTESTS #58-#73 — `detect_format` on non-VCF formats (rsID, HGVSg,
+//   HGVSc, HGVSp, VEP-input, region in 8 strand/separator variants,
+//   incomplete-row sentinel).
+// SUBTESTS #74, #75 — input as in-memory FH and STDIN-detect-format
+//   throws.
+// SUBTESTS #76, #77, #78 — `new(format=>'vcf')` / `new(format=>'foo')`
+//   / `new(format=>'guess')` factory dispatch.
+//
+// Missing-by-design component: **format auto-detection and factory
+// dispatch**. Vepyr is VCF-only with no detection layer. All non-VCF
+// formats (ID, HGVS, Region, VEP-input, SPDI, CAID) are EXCLUDE-no-
+// analogue at the project level (port-status.md rows 20-25). Without a
+// multi-format parser, there is no "format" to detect or dispatch on.
+
+// SUBTEST #79 — DB-mode block (11 sub-assertions, gated by
+//   `SKIP: { ... unless $can_use_db }`).
+//
+// Missing-by-design component: **MySQL DB mode + contig→toplevel
+// transform + LRG mapping**. Vepyr is offline-cache-only by design (no
+// MySQL); LRG mapping is haplosaurus territory (also EXCLUDE per
+// categorization.md row 19). The Perl DB block exercises:
+//   - `validate_vf` on a contig name (`AP000235.3`) that transforms to
+//     toplevel coords (chr=21, start=25043768).
+//   - LRG round-trip: chr21:43774213 ↔ LRG_485:7166.
+// Neither is reachable without a database connection.


### PR DESCRIPTION
## Summary

v2-paradigm port of `ensembl-vep/t/Parser.t` (Tier 3 PORT row 8 in
`porting-tests/port-status.md`). Implements the 9 Axis A unit-ports + 3
Axis B unit-ports identified in `porting-tests/detailed_plans/Parser.md`
(post-Phase-D audit 2026-05-27).

11 active tests across 3 files (B2 cross-references InputBuffer test):

- `src/allele.rs::tests::port_parser_*` (4): subtest #17 `GA/GT` minimise
  via `vcf_to_vep_allele`; #18/#19 MNV-preserves-suffix divergence
  documented (vepyr per Ensembl-Variation `trim_sequences()` canon
  `allele.rs:300-302`); Axis B B1 degenerate same-allele.
- `src/transcript_consequence.rs::tests::port_parser_*` (3): subtests
  #31/#32/#34 — `_have_chr` via `normalize_chrom` + valid-set
  membership.
- `tests/port_parser.rs` (4): #7 nonexistent-path-errors (catches panic
  from `bio-format-core/object_storage.rs:183` unwrap); #12 gzipped VCF
  reads; #57 CRLF line endings tolerated; Axis B B3 `.vcf.bgz` extension.

Coverage: 12/77 = 16% Perl-denominator (incl. 3 Axis B); 39%
addressable once engine blockers land. 47 architectural-no-analogue
rows + 21 blocked-future-work rows documented as comment blocks /
commented stubs in `tests/port_parser.rs`. **0 new future-work
entries created** — all 21 blocked rows fold into 6 existing
`porting-tests/future-work-vepyr.md` entries.

Companion porting-tests update: `biodatageeks/vepyr-porting-tests`
commit `d4d8c51` (joint with Cache_Variation flip) + `518df9e`
(counter fix to 10/49 = 20%).

## Test plan

- [x] `cargo test -p datafusion-bio-function-vep --lib` — 834 passed
- [x] `cargo test -p datafusion-bio-function-vep --test port_parser` —
      4 passed
- [x] `cargo test -p datafusion-bio-function-vep --tests` (release) —
      full integration regression passed
- [x] Targeted regression: `port_input_buffer`,
      `port_annotation_source_adaptor` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)