### PR TITLE
test: Tier 5 paperwork ports (Stats + OF_VEP_output + OF_Tab + OF_JSON)

### DIFF
--- a/datafusion/bio-function-vep/tests/port_output_factory_json.rs
+++ b/datafusion/bio-function-vep/tests/port_output_factory_json.rs
@@ -1,0 +1,345 @@
+//! Port of `ensembl-vep/t/OutputFactory_JSON.t` (v2 paradigm).
+//!
+//! See `porting-tests/detailed_plans/OutputFactory_JSON.md` (AUDITED
+//! 2026-05-27, promoted from EXCLUDE → PORT 2026-05-27) for the per-subtest
+//! classification table (16 behavioral subtests, all `blocked-future-work`
+//! against the missing `json_sink` module in vepyr).
+//!
+//! **This file deliberately contains 0 `#[test]` functions.** Every subtest
+//! is gated on a `json_sink` module that does not yet exist; once it lands,
+//! the 16 commented-out test stubs below promote to live tests simultaneously.
+//!
+//! A3 RESOLVED 2026-05-25 ("yes, eventually" for Stats / VEP-output / Tab
+//! sinks) extended by Wojtek 2026-05-27 to cover the JSON sink. Per the
+//! audit, the JSON sink shares the same architectural status as the other
+//! three planned sinks: different output format, same input data model
+//! (per-VFOA, per-coloc, per-regfeat rows that vepyr already computes for
+//! VCF output), no architectural precludence.
+//!
+//! ## Why this file has 0 active `#[test]` blocks
+//!
+//! `Bio::EnsEMBL::VEP::OutputFactory::JSON` emits one JSON object per VCF
+//! input line (vs CSQ-INFO-in-VCF, tab-separated, or VEP-tab Extra-column).
+//! Per-transcript-consequence data nests as `transcript_consequences[]`,
+//! co-located-variant data as `colocated_variants[]`, regulatory features
+//! as `regulatory_feature_consequences[]`, and `--custom` overlays as
+//! `custom_annotations{}`.
+//!
+//! Vepyr's only output sink today is `vcf_sink::annotate_to_vcf` — see
+//! `/Users/wojtek/Documents/vepyr/datafusion-bio-functions/datafusion/bio-function-vep/src/vcf_sink.rs`.
+//! There is no `JsonSink`, no `--output-format json` flag, no per-row JSON
+//! serializer.
+//!
+//! Missing API surface (see `porting-tests/future-work-vepyr.md` entries
+//! added 2026-05-27 as part of this port's audit):
+//!   1. `json_sink::annotate_to_json` — main JSON sink runner.
+//!   2. `json_sink::JsonOutput` — typed per-row JSON shape.
+//!   3. `json_sink::format_vfoa_as_json` — per-transcript-consequence object.
+//!   4. `json_sink::format_colocated_as_json` — per-colocated-variant object.
+//!   5. `json_sink::format_regfeat_as_json` — per-regulatory-feature object.
+//!
+//! Coverage parity: 0 / 16 = 0% — by design until json_sink lands.
+//! Sibling Tier 5 ports (same A3-resolved pattern):
+//!   - `tests/port_stats.rs` (Stats writer),
+//!   - `tests/port_output_factory_vep_output.rs` (legacy VEP-tab sink),
+//!   - `tests/port_output_factory_tab.rs` (flat-tab sink).
+
+// ──────────────────────────────────────────────────────────────────────────
+// Blocked-future-work rows (16)
+//
+// Subtests numbered per detailed_plans/OutputFactory_JSON.md. Rows #1-#5
+// and #20 are `use_ok` boilerplate omitted from coverage parity. Each
+// commented `#[test]` block names the missing API and points at the
+// corresponding entry in `future-work-vepyr.md`. When the API lands, the
+// stub is uncommented, the assertion filled in (with hand-coded oracle
+// values from a real-VEP-115 docker run at commit time per v2 paradigm
+// Rule 2), and the coverage parity counter updated.
+// ──────────────────────────────────────────────────────────────────────────
+
+// SUBTEST #6 (L52 of OutputFactory_JSON.t): `ref($of) == 'Bio::EnsEMBL::VEP::OutputFactory::JSON'`.
+// Blocked: `json_sink::JsonSink::new(cfg: &VepConfig) -> Self` constructor.
+// See `future-work-vepyr.md`::`Module: json_sink (JSON output writer)`.
+//
+// #[test]
+// fn json_sink_new_constructs() {
+//     let cfg = VepConfig::default();
+//     let _sink = JsonSink::new(&cfg);
+// }
+
+// SUBTEST #7 (L59): `is_deeply($of->headers, [])` — JSON has no preamble.
+// Blocked: `JsonSink::headers(&self) -> Vec<String>` returning empty Vec.
+// (Accessor must exist for symmetry with VCF/Tab/VEP-output sinks.)
+// See `future-work-vepyr.md`::`Module: json_sink`.
+//
+// #[test]
+// fn json_sink_headers_is_empty() {
+//     let sink = JsonSink::new(&VepConfig::default());
+//     assert!(sink.headers().is_empty());
+// }
+
+// SUBTEST #8 (L66-114): `add_VariationFeatureOverlapAllele_info($vf, {})`
+// returns nested transcript_consequences + most_severe_consequence for
+// rs142513484 (array of 3 transcript-consequence objects with
+// gene_id/transcript_id/variant_allele/consequence_terms/impact/strand/
+// cdna_*/cds_*/protein_*/codons/amino_acids).
+// Blocked: `json_sink::format_vfoa_as_json(vfoa: &Vfoa, cfg) -> serde_json::Value`.
+// See `future-work-vepyr.md`::`json_sink::format_vfoa_as_json`.
+//
+// #[test]
+// fn json_sink_format_vfoa_default_shape() {
+//     let vfoa: Vfoa = /* rs142513484 first VFOA */ todo!();
+//     let cfg = AnnotateVcfConfig::default();
+//     let json = json_sink::format_vfoa_as_json(&vfoa, &cfg);
+//     // verified via VEP 115 --json at sink-land time:
+//     assert_eq!(json["gene_id"], "ENSG00000154719");
+//     assert_eq!(json["transcript_id"], "ENST00000307301");
+//     assert_eq!(json["variant_allele"], "T");
+//     assert!(json["consequence_terms"].as_array().is_some());
+// }
+
+// SUBTEST #9 (L125-166): `add_colocated_variant_info_JSON({}, [$frequency_hash], $ex)`
+// returns single-allele colocated hash for rs142513484 with
+// frequencies/var_synonyms/pubmed/clin_sig/minor_allele_freq/allele_string.
+// Blocked: `json_sink::format_colocated_as_json(coloc, matched_alleles)`.
+// See `future-work-vepyr.md`::`json_sink::format_colocated_as_json`.
+//
+// #[test]
+// fn json_sink_format_colocated_single_allele() {
+//     let coloc: ColocatedEntry = /* rs142513484 */ todo!();
+//     let matched: Vec<String> = vec!["T".into()];
+//     let json = json_sink::format_colocated_as_json(&coloc, &matched);
+//     // verified via VEP 115 --json:
+//     assert_eq!(json["id"], "rs142513484");
+//     assert!(json["frequencies"]["T"]["af"].is_number());
+// }
+
+// SUBTEST #10 (L189-219): `add_colocated_variant_info_JSON` multi-allelic
+// 21:25891785 G/A/T — only matched-allele A frequencies emit, not T.
+// Blocked: same `format_colocated_as_json` — multi-allele frequency filtering.
+// See `future-work-vepyr.md`::`json_sink::format_colocated_as_json`.
+//
+// #[test]
+// fn json_sink_format_colocated_multi_allele_filters_by_matched() {
+//     let coloc: ColocatedEntry = /* rs145564988 multi-allele */ todo!();
+//     let matched: Vec<String> = vec!["A".into()];
+//     let json = json_sink::format_colocated_as_json(&coloc, &matched);
+//     assert!(json["frequencies"].get("A").is_some());
+//     assert!(json["frequencies"].get("T").is_none()); // not matched, not emitted
+// }
+
+// SUBTEST #11 (L226): `scalar @lines == scalar @{$ib->buffer}` — one JSON
+// object per VCF input row.
+// Blocked: `json_sink::annotate_to_json(input_vcf, cache, cfg) -> Vec<String>`.
+// See `future-work-vepyr.md`::`Module: json_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_line_count_matches_input_rows() {
+//     let cfg = AnnotateVcfConfig::default();
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     // verified via VEP 115 --json: number of JSON objects = number of VCF input rows.
+//     assert_eq!(lines.len(), test_vcf_row_count());
+// }
+
+// SUBTEST #12 (L231-288): `$json->decode($lines[0])` matches full expected
+// hash (default mode) — input/assembly_name/seq_region_name/start/end/
+// strand/id/allele_string/most_severe_consequence/transcript_consequences[3].
+// Blocked: `json_sink::annotate_to_json` + `format_vfoa_as_json` integration.
+// See `future-work-vepyr.md`::`Module: json_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_first_line_default_mode() {
+//     let cfg = AnnotateVcfConfig::default();
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     // verified via VEP 115 --json at sink-land time:
+//     assert_eq!(obj["assembly_name"], "GRCh38");
+//     assert_eq!(obj["seq_region_name"], "21");
+//     assert_eq!(obj["id"], "rs142513484");
+//     assert_eq!(obj["most_severe_consequence"], "missense_variant");
+//     assert_eq!(obj["transcript_consequences"].as_array().unwrap().len(), 3);
+// }
+
+// SUBTEST #13 (L298-310): everything+regulatory: line 28 carries
+// `regulatory_feature_consequences: [{consequence_terms, variant_allele,
+// regulatory_feature_id, impact, biotype}]`.
+// Blocked: `json_sink::format_regfeat_as_json(regfeat) -> serde_json::Value`.
+// See `future-work-vepyr.md`::`json_sink::format_regfeat_as_json`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_regulatory_feature_consequences() {
+//     let cfg = AnnotateVcfConfig { everything: true, regulatory: true, ..Default::default() };
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[27]).unwrap();
+//     // verified via VEP 115 --json --regulatory at sink-land time:
+//     let regs = obj["regulatory_feature_consequences"].as_array().unwrap();
+//     assert!(!regs.is_empty());
+//     assert!(regs[0]["regulatory_feature_id"].is_string());
+// }
+
+// SUBTEST #14 (L312-445): `$json->decode($lines[0])` everything mode — first
+// JSON line carries colocated_variants (with frequencies and var_synonyms),
+// variant_class=SNV, transcript_consequences with HGVSc/HGVSp/SIFT/PolyPhen/
+// swissprot/uniparc/biotype/canonical/ccds/exon/appris/tsl/hgnc_id/
+// gene_symbol/protein_id/polyphen_score+prediction/sift_score+prediction.
+// Blocked: `json_sink::annotate_to_json(everything=true)` + full per-VFOA
+// field expansion (~25 keys per transcript_consequence).
+// See `future-work-vepyr.md`::`Module: json_sink` + `json_sink::format_vfoa_as_json`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_first_line_everything_mode() {
+//     let cfg = AnnotateVcfConfig { everything: true, ..Default::default() };
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     // verified via VEP 115 --json --everything at sink-land time:
+//     assert_eq!(obj["variant_class"], "SNV");
+//     assert!(obj["colocated_variants"].is_array());
+//     let tc0 = &obj["transcript_consequences"][0];
+//     assert!(tc0["hgvsc"].is_string());
+//     assert!(tc0["sift_prediction"].is_string());
+// }
+
+// SUBTEST #15 (L456-457): minimal+pick_allele expanded count == 2, first
+// allele_string == 'C/T'. `minimal=1` expands CAGAAGAAAG/TAGAAGAAAG,C into
+// two CSQ groups.
+// Blocked: minimal-mode expansion (shared with OutputFactory.md cluster D).
+// See `future-work-vepyr.md`::`Module: json_sink` + `rejoin_variants_in_input_buffer`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_minimal_pick_allele_expanded_count() {
+//     let cfg = AnnotateVcfConfig { minimal: true, pick_allele: true, ..Default::default() };
+//     let lines = json_sink::annotate_to_json(minimal_input_vcf(), cache_path(), &cfg).await.unwrap();
+//     // verified via VEP 115 --json --minimal --pick_allele:
+//     assert_eq!(lines.len(), 2);
+//     let obj0: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     assert_eq!(obj0["allele_string"], "C/T");
+// }
+
+// SUBTEST #16 (L461-462): minimal rejoined count == 1, rejoined
+// allele_string == 'CAGAAGAAAG/TAGAAGAAAG/C'.
+// `rejoin_variants_in_InputBuffer` collapses the two CSQ groups back into
+// one VCF row with original allele_string.
+// Blocked: `json_sink::rejoin_variants_in_input_buffer` (same as #15).
+// See `future-work-vepyr.md`::`Module: json_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_minimal_rejoined_to_original() {
+//     let cfg = AnnotateVcfConfig { minimal: true, ..Default::default() };
+//     let lines = json_sink::annotate_to_json(minimal_input_vcf(), cache_path(), &cfg).await.unwrap();
+//     assert_eq!(lines.len(), 1);
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     assert_eq!(obj["allele_string"], "CAGAAGAAAG/TAGAAGAAAG/C");
+// }
+
+// SUBTEST #17 (L464-508): minimal rejoined transcript_consequences mapped
+// by variant_allele key (`'-'` for the deletion ALT, `'T'` for the SNV ALT);
+// each carries allele_num + codons/amino_acids/consequence_terms.
+// Blocked: `json_sink::annotate_to_json` minimal-mode output (same as #15).
+// See `future-work-vepyr.md`::`Module: json_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_minimal_consequences_grouped_by_variant_allele() {
+//     let cfg = AnnotateVcfConfig { minimal: true, ..Default::default() };
+//     let lines = json_sink::annotate_to_json(minimal_input_vcf(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     let tcs = obj["transcript_consequences"].as_array().unwrap();
+//     let alleles: std::collections::HashSet<&str> = tcs.iter()
+//         .map(|t| t["variant_allele"].as_str().unwrap())
+//         .collect();
+//     assert!(alleles.contains("T"));
+//     assert!(alleles.contains("-"));
+// }
+
+// SUBTEST #18 (L521-547): refseq=1 + uploaded_allele=1 + FASTA-backed —
+// transcript_consequences[0] adds given_ref='-', used_ref='-' (FASTA-backfilled),
+// uploaded_allele='G/GA' (original REF/ALT), refseq_match.
+// Blocked: `json_sink::format_vfoa_as_json` with refseq + uploaded_allele
+// branches. Cross-refs `AnnotateVcfConfig::uploaded_allele` (future-work
+// line ~430) and `lookup_ref` (Parser entry).
+// See `future-work-vepyr.md`::`json_sink::format_vfoa_as_json`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_refseq_uploaded_allele_fields() {
+//     let cfg = AnnotateVcfConfig {
+//         refseq: true, uploaded_allele: true,
+//         reference_fasta_path: Some(test_fasta_path()), ..Default::default()
+//     };
+//     let lines = json_sink::annotate_to_json(refseq_input_vcf(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     let tc0 = &obj["transcript_consequences"][0];
+//     // verified via VEP 115 --json --refseq --uploaded_allele:
+//     assert_eq!(tc0["given_ref"], "-");
+//     assert_eq!(tc0["used_ref"], "-");
+//     assert_eq!(tc0["uploaded_allele"], "G/GA");
+//     assert!(tc0["refseq_match"].is_string());
+// }
+
+// SUBTEST #19 (L556-596): total_length=1 — cdna_end == '1122/1199' format
+// (cdna_start/cdna_end/cds_*/protein_* format as `<position>/<total>`).
+// Blocked: `json_sink::annotate_to_json` total_length sub-feature
+// (technically sink-agnostic; folded into json_sink coverage per audit).
+// See `future-work-vepyr.md`::`Module: json_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_total_length_position_with_total() {
+//     let cfg = AnnotateVcfConfig { total_length: true, ..Default::default() };
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     let tc0 = &obj["transcript_consequences"][0];
+//     // verified via VEP 115 --json --total_length:
+//     assert_eq!(tc0["cdna_end"], "1122/1199");
+// }
+
+// SUBTEST #21 (L616-631, SKIP-block): custom exact-type — `custom_annotations.test`
+// = [{name:test1, fields:{FOO:BAR,FILTER:[PASS]}, allele:T}].
+// Blocked: DOUBLE-GAP — needs (a) `json_sink::format_custom_as_json` + (b)
+// `--custom` annotation source (out of current vepyr scope; A3-deferred).
+// See `future-work-vepyr.md`::`Module: json_sink` §"Secondary gaps".
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_custom_exact_type() {
+//     let cfg = AnnotateVcfConfig {
+//         custom: vec![CustomAnnotation::vcf("test", "file.vcf.gz", "exact", vec!["FOO"])],
+//         ..Default::default()
+//     };
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     // verified via VEP 115 --json --custom:
+//     let custom_test = &obj["custom_annotations"]["test"][0];
+//     assert_eq!(custom_test["name"], "test1");
+//     assert_eq!(custom_test["fields"]["FOO"], "BAR");
+// }
+
+// SUBTEST #22 (L642-659, SKIP-block): custom overlap-type — `custom_annotations.test`
+// = [{name:test1},{name:del1},{name:del2}] (multiple entries; no fields).
+// Blocked: same DOUBLE-GAP as #21 — `format_custom_as_json` overlap branch
+// + `--custom` annotation source.
+// See `future-work-vepyr.md`::`Module: json_sink` §"Secondary gaps".
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn json_sink_custom_overlap_type() {
+//     let cfg = AnnotateVcfConfig {
+//         custom: vec![CustomAnnotation::vcf("test", "file.vcf.gz", "overlap", vec![])],
+//         ..Default::default()
+//     };
+//     let lines = json_sink::annotate_to_json(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let obj: serde_json::Value = serde_json::from_str(&lines[0]).unwrap();
+//     // verified via VEP 115 --json --custom (overlap type):
+//     let entries = obj["custom_annotations"]["test"].as_array().unwrap();
+//     assert!(entries.len() >= 3);
+//     assert_eq!(entries[0]["name"], "test1");
+// }
+
+// ──────────────────────────────────────────────────────────────────────────
+// End of port_output_factory_json.rs.
+//
+// Total substantive subtests covered: 16 (rows #1-#5 and #20 are `use_ok`
+// boilerplate omitted from coverage parity).
+//   - 16 blocked-future-work (rows #6-#19, #21, #22).
+//   - 0 architectural-no-analogue.
+//   - 0 unit-port / integration-port / e2e-port.
+//
+// Coverage parity: 0 / 16 = 0% — justified in
+// `detailed_plans/OutputFactory_JSON.md §"Coverage parity"`.
+// Tier 5 paperwork-only port; all 16 stubs promote simultaneously when the
+// `json_sink` module lands.
+// ──────────────────────────────────────────────────────────────────────────

--- a/datafusion/bio-function-vep/tests/port_output_factory_tab.rs
+++ b/datafusion/bio-function-vep/tests/port_output_factory_tab.rs
@@ -1,0 +1,261 @@
+//! Port of `ensembl-vep/t/OutputFactory_Tab.t` (v2 paradigm).
+//!
+//! See `porting-tests/detailed_plans/OutputFactory_Tab.md` (AUDITED
+//! 2026-05-27) for the per-subtest classification table (13 behavioral
+//! subtests, all `blocked-future-work` against the missing `tab_sink`
+//! module in vepyr).
+//!
+//! **This file deliberately contains 0 `#[test]` functions.** Every subtest
+//! is gated on a `tab_sink` Rust module that does not yet exist; once it
+//! lands, the 13 commented-out test stubs below promote to live tests
+//! simultaneously.
+//!
+//! ## Why this file has 0 active `#[test]` blocks
+//!
+//! `Bio::EnsEMBL::VEP::OutputFactory::Tab` emits VEP's `--tab` flat-tab
+//! output format. Unlike VEP-tab (which packs everything into a single
+//! `Extra` column), this format expands every CSQ field into its own
+//! dedicated tab-separated column. The default 18-column layout is:
+//! Uploaded_variation, Location, Allele, Gene, Feature, Feature_type,
+//! Consequence, cDNA_position, CDS_position, Protein_position, Amino_acids,
+//! Codons, Existing_variation, IMPACT, DISTANCE, STRAND, FLAGS, custom_test.
+//!
+//! Vepyr's only output sink today is `vcf_sink::annotate_to_vcf` — see
+//! `/Users/wojtek/Documents/vepyr/datafusion-bio-functions/datafusion/bio-function-vep/src/vcf_sink.rs`.
+//! There is no `FlatTabSink`, no `--output-format tab` flag, no `--fields`
+//! projection knob, no per-CSQ-field column expander, and no
+//! `output_hash_to_line` analogue.
+//!
+//! A3 RESOLVED 2026-05-25 "yes, eventually" — see
+//! `porting-tests/port-status.md §"Active blockers"` item 4. Per the audit,
+//! the `tab_sink` would mirror the shape of the existing `vcf_sink` and
+//! consume the same per-VFOA rows that vepyr already computes; only the
+//! row formatter, header generator, and `FieldSelector` projection are
+//! missing.
+//!
+//! Missing API surface (see `future-work-vepyr.md::"Module: tab_sink"`):
+//!   1. `tab_sink::FlatTabSink::new(cfg)`.
+//!   2. `FlatTabSink::fields() -> &[CsqField]` (default 18-column list).
+//!   3. `FlatTabSink::headers() -> Vec<String>` (24-line preamble + flat
+//!      column header line).
+//!   4. `FlatTabSink::format_row(row) -> String` (N-column tab-separated).
+//!   5. `FlatTabSink::with_field_selector(sel: FieldSelector)` (--fields
+//!      Location,HGVSc projection).
+//!   6. `tab_sink::annotate_to_flat_tab(input_vcf, cache, sel) -> Vec<String>`.
+//!
+//! Secondary blockers (sub-test #8 plugin loading, #14 `--custom`
+//! annotation source) are documented inline; both are A3-deferred.
+//!
+//! Coverage parity: 0 / 13 = 0% — by design until the sink lands.
+//! Sibling Tier 5 ports (same A3-resolved pattern):
+//!   - `tests/port_stats.rs` (Stats writer),
+//!   - `tests/port_output_factory_vep_output.rs` (legacy VEP-tab sink),
+//!   - `tests/port_output_factory_json.rs` (JSON sink).
+
+// ──────────────────────────────────────────────────────────────────────────
+// Blocked-future-work rows (13)
+//
+// Subtests numbered per detailed_plans/OutputFactory_Tab.md. Rows #1, #2,
+// #3 are `use_ok` boilerplate omitted from coverage parity. Each commented
+// `#[test]` block names the missing API and points at the corresponding
+// entry in `future-work-vepyr.md`. When the API lands, the stub is
+// uncommented, the assertion filled in (with hand-coded oracle values from
+// a real-VEP-115 docker run at commit time per v2 paradigm Rule 2), and
+// the coverage parity counter updated.
+// ──────────────────────────────────────────────────────────────────────────
+
+// SUBTEST #4 (~L46-47 of OutputFactory_Tab.t): `ref($of) == 'Bio::EnsEMBL::VEP::OutputFactory::Tab'`.
+// Blocked: `FlatTabSink::new(cfg: &VepConfig) -> Self` constructor.
+// See `future-work-vepyr.md`::`Module: tab_sink (flat-tab writer with --fields projection)`.
+//
+// #[test]
+// fn flat_tab_sink_new_constructs() {
+//     let cfg = VepConfig::default();
+//     let _sink = FlatTabSink::new(&cfg);
+// }
+
+// SUBTEST #5: `$of->fields` 18-column default flat-layout list.
+// Blocked: `FlatTabSink::fields(&self) -> &[CsqField]`.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[test]
+// fn flat_tab_sink_default_18_columns() {
+//     let sink = FlatTabSink::new(&VepConfig::default());
+//     assert_eq!(sink.fields().len(), 18);
+//     assert_eq!(sink.fields()[0], CsqField::UploadedVariation);
+//     assert_eq!(sink.fields()[6], CsqField::Consequence);
+//     assert_eq!(sink.fields()[13], CsqField::Impact);
+// }
+
+// SUBTEST #6: `headers()` 24-line preamble + `#Uploaded_variation\t...\tcustom_test`
+// flat column header.
+// Blocked: `FlatTabSink::headers(&self) -> Vec<String>`.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[test]
+// fn flat_tab_sink_headers_preamble_shape() {
+//     let sink = FlatTabSink::new(&VepConfig::default());
+//     let headers = sink.headers();
+//     // 24-line preamble + col-header (= 25 total) per VEP 115 default config.
+//     assert!(headers.first().unwrap().starts_with("## "));
+//     assert!(headers.last().unwrap().starts_with("#Uploaded_variation\t"));
+// }
+
+// SUBTEST #7: `param('merged',1)+param('custom',1)` → exactly one `SOURCE`
+// field (dedup rule lives inside sink; shared with VEP-tab sink #8).
+// Blocked: merged + custom dedup for `SOURCE`.
+// See `future-work-vepyr.md`::`Module: tab_sink` §"Secondary gaps".
+//
+// #[test]
+// fn flat_tab_sink_merged_custom_dedups_source() {
+//     let cfg = VepConfig { merged: true, custom: true, ..Default::default() };
+//     let sink = FlatTabSink::new(&cfg);
+//     let count = sink.fields().iter().filter(|f| **f == CsqField::Source).count();
+//     assert_eq!(count, 1);
+// }
+
+// SUBTEST #8: `headers - plugin` includes `--plugin TestPlugin` in
+// command-line line. Secondary blocker: vepyr has no plugin loader.
+// Blocked: `FlatTabSink::headers()` with plugin context.
+// See `future-work-vepyr.md`::`Module: tab_sink` §"Secondary gaps".
+//
+// #[test]
+// fn flat_tab_sink_headers_includes_plugin() {
+//     let cfg = VepConfig { plugin: vec!["TestPlugin".into()], ..Default::default() };
+//     let sink = FlatTabSink::new(&cfg);
+//     let headers = sink.headers();
+//     assert!(headers.iter().any(|h| h.contains("--plugin TestPlugin")));
+// }
+
+// SUBTEST #9: `output_hash_to_line({})` → 18 `-` tab-joined.
+// Blocked: `FlatTabSink::format_row(&Row::default()) -> String`.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[test]
+// fn flat_tab_sink_empty_row_yields_18_dashes() {
+//     let sink = FlatTabSink::new(&VepConfig::default());
+//     let line = sink.format_row(&CsqRow::default());
+//     let cols: Vec<&str> = line.split('\t').collect();
+//     assert_eq!(cols.len(), 18);
+//     assert!(cols.iter().all(|c| *c == "-"));
+// }
+
+// SUBTEST #10: `output_hash_to_line({Uploaded_variation => 0})` → `0\t-\t-…`
+// (preserve falsy `0` — not coerced to dash).
+// Blocked: same `format_row` — falsy-id boundary handling.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[test]
+// fn flat_tab_sink_falsy_zero_id_preserved() {
+//     let sink = FlatTabSink::new(&VepConfig::default());
+//     let row = CsqRow { uploaded_variation: Some("0".into()), ..Default::default() };
+//     let line = sink.format_row(&row);
+//     assert!(line.starts_with("0\t-\t"));
+// }
+
+// SUBTEST #11: `get_all_lines_by_InputBuffer` count == 744 (with
+// show_ref_allele + uploaded_allele on `test_vcf`).
+// Blocked: `annotate_to_flat_tab(input, cache) -> Vec<String>` end-to-end runner.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn flat_tab_sink_test_vcf_yields_744_lines() {
+//     let cfg = AnnotateVcfConfig {
+//         show_ref_allele: true, uploaded_allele: true, ..Default::default()
+//     };
+//     let lines = tab_sink::annotate_to_flat_tab(test_vcf_path(), cache_path(), &cfg, FieldSelector::default()).await.unwrap();
+//     // verified via VEP 115 --tab at sink-land time.
+//     assert_eq!(lines.iter().filter(|l| !l.starts_with('#')).count(), 744);
+// }
+
+// SUBTEST #12: first line content (show_ref_allele + uploaded_allele) — exact
+// byte-compare. REF/UPLOADED columns are inserted between Existing_variation
+// and IMPACT/DISTANCE/STRAND/FLAGS.
+// Blocked: `annotate_to_flat_tab(...)` first non-header line + column insertion rule.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn flat_tab_sink_first_line_byte_compare() {
+//     let cfg = AnnotateVcfConfig {
+//         show_ref_allele: true, uploaded_allele: true, ..Default::default()
+//     };
+//     let lines = tab_sink::annotate_to_flat_tab(test_vcf_path(), cache_path(), &cfg, FieldSelector::default()).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     // verified via VEP 115:
+//     assert_eq!(first, "<exact-first-line-from-real-VEP-115-tab-run>");
+// }
+
+// SUBTEST #13: last line content (FLAGS = `cds_start_NF`) byte-compare.
+// Blocked: `annotate_to_flat_tab(...)` last non-header line.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn flat_tab_sink_last_line_byte_compare() {
+//     let cfg = AnnotateVcfConfig {
+//         show_ref_allele: true, uploaded_allele: true, ..Default::default()
+//     };
+//     let lines = tab_sink::annotate_to_flat_tab(test_vcf_path(), cache_path(), &cfg, FieldSelector::default()).await.unwrap();
+//     let last = lines.iter().rev().find(|l| !l.starts_with('#')).unwrap();
+//     // verified via VEP 115:
+//     assert!(last.contains("\tcds_start_NF\t") || last.ends_with("cds_start_NF"));
+// }
+
+// SUBTEST #14 (SKIP-block): custom-annotation columns → trailing `test1`, `BAR`.
+// Blocked: DOUBLE-GAP — needs (a) `tab_sink` + (b) `--custom` annotation
+// source (out of current vepyr scope; A3-deferred).
+// See `future-work-vepyr.md`::`Module: tab_sink` §"Secondary gaps".
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn flat_tab_sink_custom_annotation_trailing_columns() {
+//     let cfg = AnnotateVcfConfig {
+//         custom: vec![CustomAnnotation::vcf("test", "file.vcf.gz", "exact", vec!["FOO"])],
+//         ..Default::default()
+//     };
+//     let lines = tab_sink::annotate_to_flat_tab(test_vcf_path(), cache_path(), &cfg, FieldSelector::default()).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     // verified via VEP 115 --custom:
+//     assert!(first.ends_with("\ttest1\tBAR") || first.contains("\ttest1\t"));
+// }
+
+// SUBTEST #15: `--everything` mode full line — enormous line covering ALL
+// CSQ columns (HGVSc, AF/gnomADe_*, SIFT/PolyPhen).
+// Blocked: `annotate_to_flat_tab(everything=true)` column expansion + v115
+// frequency populations + per-field stringifier for ~80 CSQ fields.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn flat_tab_sink_everything_mode_full_line() {
+//     let cfg = AnnotateVcfConfig { everything: true, ..Default::default() };
+//     let lines = tab_sink::annotate_to_flat_tab(test_vcf_path(), cache_path(), &cfg, FieldSelector::default()).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     // verified via VEP 115 --everything --tab:
+//     assert!(first.split('\t').count() > 60); // ~80 CSQ columns in --everything.
+// }
+
+// SUBTEST #16: `--fields Location,HGVSc` projection → 2-column line.
+// Blocked: `FieldSelector` API + clap `--fields` parsing.
+// See `future-work-vepyr.md`::`Module: tab_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn flat_tab_sink_fields_projection_two_columns() {
+//     let cfg = AnnotateVcfConfig::default();
+//     let sel = FieldSelector::from_csv("Location,HGVSc").unwrap();
+//     let lines = tab_sink::annotate_to_flat_tab(test_vcf_path(), cache_path(), &cfg, sel).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     assert_eq!(first.split('\t').count(), 2);
+// }
+
+// ──────────────────────────────────────────────────────────────────────────
+// End of port_output_factory_tab.rs.
+//
+// Total substantive subtests covered: 13 (rows #1, #2, #3 are `use_ok`
+// boilerplate omitted from coverage parity).
+//   - 13 blocked-future-work (rows #4-#16).
+//   - 0 architectural-no-analogue.
+//   - 0 unit-port / integration-port / e2e-port.
+//
+// Coverage parity: 0 / 13 = 0% — justified in
+// `detailed_plans/OutputFactory_Tab.md §"Coverage parity"`.
+// Tier 5 paperwork-only port; all 13 stubs promote simultaneously when the
+// `tab_sink` module lands.
+// ──────────────────────────────────────────────────────────────────────────

--- a/datafusion/bio-function-vep/tests/port_output_factory_vep_output.rs
+++ b/datafusion/bio-function-vep/tests/port_output_factory_vep_output.rs
@@ -1,0 +1,311 @@
+//! Port of `ensembl-vep/t/OutputFactory_VEP_output.t` (v2 paradigm).
+//!
+//! See `porting-tests/detailed_plans/OutputFactory_VEP_output.md` (AUDITED
+//! 2026-05-27) for the per-subtest classification table (16 behavioral
+//! subtests, all `blocked-future-work` against the missing `vep_output_sink`
+//! module in vepyr).
+//!
+//! **This file deliberately contains 0 `#[test]` functions.** Every subtest
+//! is gated on a `vep_output_sink` Rust module that does not yet exist;
+//! once it lands, the 16 commented-out test stubs below promote to live
+//! tests simultaneously.
+//!
+//! ## Why this file has 0 active `#[test]` blocks
+//!
+//! `Bio::EnsEMBL::VEP::OutputFactory::VEP_output` emits VEP's legacy default
+//! tab-separated 14-column row format: 13 fixed columns
+//! (Uploaded_variation, Location, Allele, Gene, Feature, Feature_type,
+//! Consequence, cDNA_position, CDS_position, Protein_position, Amino_acids,
+//! Codons, Existing_variation) plus a single `Extra` column packing
+//! `KEY=VALUE;...` pairs with known fields (IMPACT, DISTANCE, STRAND, FLAGS)
+//! ordered before unknown.
+//!
+//! Vepyr's only output sink today is `vcf_sink::annotate_to_vcf` (CSQ-in-VCF
+//! format) — see
+//! `/Users/wojtek/Documents/vepyr/datafusion-bio-functions/datafusion/bio-function-vep/src/vcf_sink.rs`.
+//! There is no `VepTabSink`, no `--output-format vep` flag, no 14-column
+//! formatter, no `Extra`-column packer, and no `output_hash_to_line`
+//! analogue.
+//!
+//! A3 RESOLVED 2026-05-25 "yes, eventually" for Stats / VEP-output / Tab
+//! sinks (extended to JSON sink 2026-05-27). Per the audit, the
+//! `vep_output_sink` would mirror the shape of the existing `vcf_sink` and
+//! consume the same per-VFOA rows that vepyr already computes; only the
+//! row formatter + header generator are missing.
+//!
+//! Missing API surface (see `future-work-vepyr.md::"Module: vep_output_sink"`):
+//!   1. `vep_output_sink::VepTabSink::new(cfg)`.
+//!   2. `VepTabSink::extra_fields() -> &[CsqField]` (default
+//!      [IMPACT, DISTANCE, STRAND, FLAGS]).
+//!   3. `VepTabSink::extra_field_order() -> HashMap<CsqField, usize>`.
+//!   4. `VepTabSink::headers() -> Vec<String>` (26-line preamble + column
+//!      header line).
+//!   5. `VepTabSink::format_row(row) -> String` (14 tab-separated columns
+//!      with Extra-column packer).
+//!   6. `vep_output_sink::annotate_to_vep_tab(input_vcf, cache) -> Vec<String>`.
+//!
+//! Secondary blockers (sub-tests #10 plugin loading, #20 `--custom`
+//! annotation source) are documented inline; both are A3-deferred.
+//!
+//! Coverage parity: 0 / 16 = 0% — by design until the sink lands.
+//! Sibling Tier 5 ports (same A3-resolved pattern):
+//!   - `tests/port_stats.rs` (Stats writer),
+//!   - `tests/port_output_factory_tab.rs` (flat-tab sink),
+//!   - `tests/port_output_factory_json.rs` (JSON sink).
+
+// ──────────────────────────────────────────────────────────────────────────
+// Blocked-future-work rows (16)
+//
+// Subtests numbered per detailed_plans/OutputFactory_VEP_output.md. Rows
+// #1, #2, #3, #19 are `use_ok` boilerplate omitted from coverage parity.
+// Each commented `#[test]` block names the missing API and points at
+// the corresponding entry in `future-work-vepyr.md`. When the API lands,
+// the stub is uncommented, the assertion filled in (with hand-coded oracle
+// values derived from a real-VEP-115 docker run at commit time per v2
+// paradigm Rule 2), and the coverage parity counter updated.
+// ──────────────────────────────────────────────────────────────────────────
+
+// SUBTEST #4 (L46-47 of OutputFactory_VEP_output.t): `ref($of) == 'Bio::EnsEMBL::VEP::OutputFactory::VEP_output'`.
+// Blocked: `VepTabSink::new(cfg: &VepConfig) -> Self` constructor.
+// See `future-work-vepyr.md`::`Module: vep_output_sink (legacy VEP-tab writer)`.
+//
+// #[test]
+// fn vep_tab_sink_new_constructs() {
+//     let cfg = VepConfig::default();
+//     let _sink = VepTabSink::new(&cfg);
+// }
+
+// SUBTEST #5 (L49): `$of->fields == [IMPACT, DISTANCE, STRAND, FLAGS]` default.
+// Blocked: `VepTabSink::extra_fields(&self) -> &[CsqField]`.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_default_extra_fields() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     assert_eq!(sink.extra_fields(),
+//                &[CsqField::Impact, CsqField::Distance, CsqField::Strand, CsqField::Flags]);
+// }
+
+// SUBTEST #6 (L51): `$of->field_order == {IMPACT=>0, DISTANCE=>1, STRAND=>2, FLAGS=>3}`.
+// Blocked: `VepTabSink::extra_field_order(&self) -> HashMap<CsqField, usize>`.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_extra_field_order_map() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     let order = sink.extra_field_order();
+//     assert_eq!(order.get(&CsqField::Impact), Some(&0));
+//     assert_eq!(order.get(&CsqField::Flags), Some(&3));
+// }
+
+// SUBTEST #7 (~L60s): `param('sift','b')` → fields gains `SIFT` at index 4.
+// Blocked: dynamic Extra-field set responsive to config flag.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_with_sift_adds_sift_field() {
+//     let cfg = VepConfig { sift: Some("b".into()), ..Default::default() };
+//     let sink = VepTabSink::new(&cfg);
+//     assert_eq!(sink.extra_field_order().get(&CsqField::Sift), Some(&4));
+// }
+
+// SUBTEST #8 (~L80s): `param('merged',1) + param('custom',1)` → exactly one
+// `SOURCE` field (dedup rule lives inside sink).
+// Blocked: merged + custom dedup for `SOURCE`.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_merged_custom_dedups_source_field() {
+//     let cfg = VepConfig { merged: true, custom: true, ..Default::default() };
+//     let sink = VepTabSink::new(&cfg);
+//     let count = sink.extra_fields().iter().filter(|f| **f == CsqField::Source).count();
+//     assert_eq!(count, 1);
+// }
+
+// SUBTEST #9 (~L100s-130s): `headers()` 26-line preamble + column header line
+// (`## ENSEMBL VARIANT EFFECT PREDICTOR`, per-column doc lines, per-Extra-key
+// doc lines, `## VEP command-line: ...`, then `#Uploaded_variation\tLocation\t…\tExtra`).
+// Blocked: `VepTabSink::headers(&self) -> Vec<String>`.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_headers_preamble_shape() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     let headers = sink.headers();
+//     assert!(headers.first().unwrap().starts_with("## ENSEMBL VARIANT EFFECT PREDICTOR"));
+//     assert!(headers.last().unwrap().starts_with("#Uploaded_variation\t"));
+// }
+
+// SUBTEST #10 (~L140s): `headers - plugin` includes `--plugin TestPlugin`
+// in command-line line. Secondary blocker: vepyr has no plugin loader.
+// Blocked: `VepTabSink::headers()` with plugin context (also requires
+// `PluginLoader` infrastructure — separately blocked).
+// See `future-work-vepyr.md`::`Module: vep_output_sink` §"Secondary gaps".
+//
+// #[test]
+// fn vep_tab_sink_headers_includes_plugin_in_command_line() {
+//     let cfg = VepConfig { plugin: vec!["TestPlugin".into()], ..Default::default() };
+//     let sink = VepTabSink::new(&cfg);
+//     let headers = sink.headers();
+//     assert!(headers.iter().any(|h| h.contains("--plugin TestPlugin")));
+// }
+
+// SUBTEST #11 (~L160s): `output_hash_to_line({})` → 14 `-` tab-joined.
+// Blocked: `VepTabSink::format_row(&Row::default()) -> String`.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_empty_row_yields_14_dashes() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     let line = sink.format_row(&CsqRow::default());
+//     let cols: Vec<&str> = line.split('\t').collect();
+//     assert_eq!(cols.len(), 14);
+//     assert!(cols.iter().all(|c| *c == "-"));
+// }
+
+// SUBTEST #12 (~L180s): `output_hash_to_line({Uploaded_variation => 0})` →
+// `0\t-\t-…` (preserve falsy `0` — not coerced to dash).
+// Blocked: same `format_row` — falsy-id boundary handling.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_falsy_zero_id_preserved() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     let row = CsqRow { uploaded_variation: Some("0".into()), ..Default::default() };
+//     let line = sink.format_row(&row);
+//     assert!(line.starts_with("0\t-\t"));
+// }
+
+// SUBTEST #13 (~L200s): `output_hash_to_line({Existing_variation=>'rs123', Foo=>'bar'})`
+// → 11 dashes + `rs123` + Extra=`Foo=bar`. Extra column packs unknown keys.
+// Blocked: `format_row` Extra-column unknown-key passthrough.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_extra_column_passes_unknown_keys() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     let row = CsqRow {
+//         existing_variation: Some("rs123".into()),
+//         extra: vec![("Foo".into(), "bar".into())],
+//         ..Default::default()
+//     };
+//     let line = sink.format_row(&row);
+//     assert!(line.ends_with("\tFoo=bar"));
+// }
+
+// SUBTEST #14 (~L220s): `output_hash_to_line({Existing_variation, Foo, IMPACT})`
+// → Extra=`IMPACT=HIGH;Foo=bar` (known-first order).
+// Blocked: `format_row` Extra-column known-fields-first ordering invariant.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[test]
+// fn vep_tab_sink_extra_orders_known_before_unknown() {
+//     let sink = VepTabSink::new(&VepConfig::default());
+//     let row = CsqRow {
+//         impact: Some("HIGH".into()),
+//         extra: vec![("Foo".into(), "bar".into())],
+//         ..Default::default()
+//     };
+//     let line = sink.format_row(&row);
+//     assert!(line.ends_with("IMPACT=HIGH;Foo=bar"));
+// }
+
+// SUBTEST #15 (~L260s): `get_all_lines_by_InputBuffer` count == 744 (with
+// show_ref_allele + uploaded_allele on `test_vcf`).
+// Blocked: `annotate_to_vep_tab(input_vcf, cache) -> Vec<String>` end-to-end runner.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn vep_tab_sink_test_vcf_yields_744_lines() {
+//     let cfg = AnnotateVcfConfig {
+//         show_ref_allele: true, uploaded_allele: true, ..Default::default()
+//     };
+//     let lines = vep_output_sink::annotate_to_vep_tab(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     // verified via VEP 115 at sink-land time:
+//     //   docker run --rm -v $(pwd)/_cache115:/cache:ro ... vep ... test.vcf | wc -l
+//     assert_eq!(lines.iter().filter(|l| !l.starts_with('#')).count(), 744);
+// }
+
+// SUBTEST #16 (~L290s): first line content (show_ref_allele + uploaded_allele)
+// exact byte-compare.
+// Blocked: `annotate_to_vep_tab(...)` first non-header line.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn vep_tab_sink_first_line_byte_compare() {
+//     let cfg = AnnotateVcfConfig {
+//         show_ref_allele: true, uploaded_allele: true, ..Default::default()
+//     };
+//     let lines = vep_output_sink::annotate_to_vep_tab(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     // verified via VEP 115:
+//     assert_eq!(first, "<exact-first-line-from-real-VEP-115-run>");
+// }
+
+// SUBTEST #17 (~L320s): last line content (FLAGS = `cds_start_NF`) byte-compare.
+// Blocked: `annotate_to_vep_tab(...)` last non-header line.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn vep_tab_sink_last_line_byte_compare() {
+//     let cfg = AnnotateVcfConfig {
+//         show_ref_allele: true, uploaded_allele: true, ..Default::default()
+//     };
+//     let lines = vep_output_sink::annotate_to_vep_tab(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let last = lines.iter().rev().find(|l| !l.starts_with('#')).unwrap();
+//     // verified via VEP 115:
+//     assert!(last.contains("FLAGS=cds_start_NF"));
+// }
+
+// SUBTEST #18 (~L350s-400s): `--everything` mode last column matches long
+// `IMPACT=...;...;MAX_AF_POPS=gnomADe_AFR` string.
+// Blocked: `annotate_to_vep_tab(everything=true)` Extra-column packer with
+// v115 gnomADe populations.
+// See `future-work-vepyr.md`::`Module: vep_output_sink`.
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn vep_tab_sink_everything_mode_extra_column() {
+//     let cfg = AnnotateVcfConfig { everything: true, ..Default::default() };
+//     let lines = vep_output_sink::annotate_to_vep_tab(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     let extra = first.rsplit('\t').next().unwrap();
+//     // verified via VEP 115 --everything:
+//     assert!(extra.contains("IMPACT="));
+//     assert!(extra.contains("MAX_AF_POPS=gnomADe_AFR"));
+// }
+
+// SUBTEST #20 (~L440s, SKIP-block): custom-annotation Extra →
+// `test=test1;test_FILTER=PASS;test_FOO=BAR`.
+// Blocked: DOUBLE-GAP — needs (a) `vep_output_sink` + (b) `--custom`
+// annotation source (out of current vepyr scope; A3-deferred).
+// See `future-work-vepyr.md`::`Module: vep_output_sink` §"Secondary gaps".
+//
+// #[tokio::test(flavor = "multi_thread")]
+// async fn vep_tab_sink_custom_annotation_extra_keys() {
+//     let cfg = AnnotateVcfConfig {
+//         custom: vec![CustomAnnotation::vcf("test", "file.vcf.gz", "exact", vec!["FOO"])],
+//         ..Default::default()
+//     };
+//     let lines = vep_output_sink::annotate_to_vep_tab(test_vcf_path(), cache_path(), &cfg).await.unwrap();
+//     let first = lines.iter().find(|l| !l.starts_with('#')).unwrap();
+//     let extra = first.rsplit('\t').next().unwrap();
+//     // verified via VEP 115 --custom:
+//     assert!(extra.contains("test=test1"));
+//     assert!(extra.contains("test_FILTER=PASS"));
+//     assert!(extra.contains("test_FOO=BAR"));
+// }
+
+// ──────────────────────────────────────────────────────────────────────────
+// End of port_output_factory_vep_output.rs.
+//
+// Total substantive subtests covered: 16 (rows #1, #2, #3, #19 are `use_ok`
+// boilerplate omitted from coverage parity).
+//   - 16 blocked-future-work (rows #4-#18, #20).
+//   - 0 architectural-no-analogue.
+//   - 0 unit-port / integration-port / e2e-port.
+//
+// Coverage parity: 0 / 16 = 0% — justified in
+// `detailed_plans/OutputFactory_VEP_output.md §"Coverage parity"`.
+// Tier 5 paperwork-only port; all 16 stubs promote simultaneously when the
+// `vep_output_sink` module lands.
+// ──────────────────────────────────────────────────────────────────────────

--- a/datafusion/bio-function-vep/tests/port_stats.rs
+++ b/datafusion/bio-function-vep/tests/port_stats.rs
@@ -1,0 +1,439 @@
+//! Port of `ensembl-vep/t/Stats.t` (v2 paradigm).
+//!
+//! See `porting-tests/detailed_plans/Stats.md` (AUDITED 2026-05-27) for the
+//! authoritative per-subtest classification table (27 behavioral subtests,
+//! all `blocked-future-work` against the missing `Stats` writer module).
+//!
+//! **This file deliberately contains 0 `#[test]` functions.** Every subtest
+//! is gated on a `Stats` Rust module + `FinishedStats::write_text` /
+//! `write_html` serialisers that do not yet exist; once they land, the 27
+//! commented-out test stubs below promote to live tests simultaneously.
+//!
+//! ## Why this file has 0 active `#[test]` blocks
+//!
+//! `Bio::EnsEMBL::VEP::Stats` is VEP's per-run summary-statistics writer.
+//! It emits two sidecar files next to the main output VCF:
+//!
+//! - `*_summary.txt` — `[VEP run statistics]` header + ASCII tables.
+//! - `*_summary.html` — HTML page with embedded pie/bar charts.
+//!
+//! The Perl `Stats` object is constructed empty (`Stats->new` returns a
+//! blessed hash with `{stats => {counters => {}}}`), accumulates 12 counter
+//! classes as variants/VFOAs are logged (`var_count`, `classes`, `var_cons`,
+//! `chr` × 1Mb-bin, `allele_changes`, `consequences`, `protein_pos`, `gene`,
+//! `transcript`, `SIFT`/`PolyPhen`, `filtered_variants`), and at end-of-run
+//! produces a `finished_stats` structure that `dump_text` / `dump_html`
+//! serialize.
+//!
+//! Vepyr has no per-run summary-statistics writer at all today. The closest
+//! existing concept is `EntityStats` in `cache_builder.rs:93`, but that
+//! tracks cache-build progress, not per-annotation-run variant counters.
+//! There is no `--stats-file` flag, no `*_summary.txt` sidecar, no HTML
+//! chart renderer, and no per-VFOA counter accumulator.
+//!
+//! A3 RESOLVED 2026-05-25 ("should vepyr emit per-run summary stats?") =
+//! "yes, eventually" — see `porting-tests/port-status.md §"Active blockers"`
+//! item 4. Per the audit, the Stats writer shares architectural status with
+//! the three other planned-but-unbuilt sinks (vep_output_sink, tab_sink,
+//! json_sink): different output format, same input data model, no
+//! architectural precludence.
+//!
+//! Missing API surface (see `porting-tests/future-work-vepyr.md` entries):
+//!   1. `Stats::new + Counters` — base struct + initial empty state.
+//!   2. `Stats::info / set_info` — CLI args / file path map.
+//!   3. `Stats::start_time / run_time / end_time` — chrono wall-clock.
+//!   4. `Stats::log_lines_read / increment_filtered_variants` — counters.
+//!   5. `Stats::log_variant` — per-variant counter update.
+//!   6. `Stats::log_csq_row` — per-VFOA counter update.
+//!   7. `Stats::log_sift_polyphen + Stats::finish() -> FinishedStats`.
+//!   8. `FinishedStats::write_text / write_html` — serialisers.
+//!
+//! Coverage parity: 0 / 27 = 0% — by design until the Stats module lands.
+//! Sibling Tier 5 ports (same A3-resolved pattern):
+//!   - `tests/port_output_factory_vep_output.rs` (legacy VEP-tab sink),
+//!   - `tests/port_output_factory_tab.rs` (flat-tab sink),
+//!   - `tests/port_output_factory_json.rs` (JSON sink).
+
+// ──────────────────────────────────────────────────────────────────────────
+// Blocked-future-work rows (27)
+//
+// Subtests numbered per detailed_plans/Stats.md (rows #1, #2 are `use_ok`
+// boilerplate omitted from coverage parity). Each commented `#[test]` block
+// names the missing vepyr API and points at the corresponding entry in
+// `future-work-vepyr.md`. When the API lands, the corresponding stub is
+// uncommented, the assertion filled in (with hand-coded oracle values per
+// v2 paradigm Rule 2), and the coverage parity counter updated.
+// ──────────────────────────────────────────────────────────────────────────
+
+// SUBTEST #3 (L41 of Stats.t): `Stats->new` is defined.
+// Blocked: `Stats::new() -> Self` does not exist.
+// See `future-work-vepyr.md`::`Stats::new + Counters struct`.
+//
+// #[test]
+// fn stats_new_is_defined() {
+//     let s = Stats::new();
+//     // constructor returns a value; no panic.
+//     drop(s);
+// }
+
+// SUBTEST #4 (L42-50): initial shape `{stats => {counters => {}}, …}`.
+// Blocked: same as #3 — `Stats::counters() -> &Counters` (or
+// `Counters::is_empty(&self) -> bool`) accessor.
+// See `future-work-vepyr.md`::`Stats::new + Counters struct`.
+//
+// #[test]
+// fn stats_new_initial_counters_empty() {
+//     let s = Stats::new();
+//     assert!(s.counters().is_empty());
+// }
+
+// SUBTEST #5 (L57): `info` returns hashref.
+// Blocked: `Stats::info() -> &HashMap<String, String>` + `set_info(k, v)`.
+// See `future-work-vepyr.md`::`Stats::info / set_info`.
+//
+// #[test]
+// fn stats_info_round_trip() {
+//     let mut s = Stats::new();
+//     s.set_info("foo", "bar");
+//     assert_eq!(s.info().get("foo"), Some(&"bar".to_string()));
+// }
+
+// SUBTEST #6 (L59): `start_time == get_time()` formatted timestamp.
+// Blocked: `Stats::start_time() -> &str` (RFC 3339 or VEP-format).
+// See `future-work-vepyr.md`::`Stats::start_time / run_time / end_time`.
+//
+// #[test]
+// fn stats_start_time_set_at_new() {
+//     let s = Stats::new();
+//     assert!(!s.start_time().is_empty());
+// }
+
+// SUBTEST #7 (L60): `run_time_start == time()` epoch seconds.
+// Blocked: internal `Instant::now()` capture (folds into Stats::new entry).
+// See `future-work-vepyr.md`::`Stats::start_time / run_time / end_time`.
+//
+// #[test]
+// fn stats_run_time_start_captured() {
+//     let s = Stats::new();
+//     // implementation detail: vepyr stores Instant; no direct accessor needed
+//     // beyond `run_time()` (#8).
+//     drop(s);
+// }
+
+// SUBTEST #8 (L63): `run_time =~ /^\d+$/` integer elapsed seconds.
+// Blocked: `Stats::run_time() -> u64`.
+// See `future-work-vepyr.md`::`Stats::start_time / run_time / end_time`.
+//
+// #[test]
+// fn stats_run_time_returns_elapsed_seconds() {
+//     let s = Stats::new();
+//     std::thread::sleep(std::time::Duration::from_secs(1));
+//     assert!(s.run_time() >= 1);
+// }
+
+// SUBTEST #9 (L64): `end_time == get_time()` formatted at finalize.
+// Blocked: `Stats::end_time() -> Option<&str>` set when `finish()` is called.
+// See `future-work-vepyr.md`::`Stats::start_time / run_time / end_time`.
+//
+// #[test]
+// fn stats_end_time_set_at_finish() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     assert!(!finished.end_time().is_empty());
+// }
+
+// SUBTEST #10 (L66-67): `log_lines_read(10) → lines_read == 10`.
+// Blocked: `Stats::log_lines_read(n)` + `Stats::lines_read()` getter.
+// See `future-work-vepyr.md`::`Stats::log_lines_read / increment_filtered_variants`.
+//
+// #[test]
+// fn stats_log_lines_read_accumulates() {
+//     let mut s = Stats::new();
+//     s.log_lines_read(10);
+//     assert_eq!(s.lines_read(), 10);
+// }
+
+// SUBTEST #11 (L69-76): `increment_filtered_variants(5)` counter.
+// Blocked: `Stats::increment_filtered_variants(n)` + getter. Companion to
+// future `--filter` flag (also blocked).
+// See `future-work-vepyr.md`::`Stats::log_lines_read / increment_filtered_variants`.
+//
+// #[test]
+// fn stats_filtered_variants_accumulates() {
+//     let mut s = Stats::new();
+//     s.increment_filtered_variants(5);
+//     assert_eq!(s.filtered_variants(), 5);
+// }
+
+// SUBTEST #12 (L85-106): first SNV `log_VariationFeature(vf1)` — classes=SNV,
+// var_cons=missense, chr=21/25M, allele_changes=C/T, var_count=1.
+// Blocked: `Stats::log_variant(vcf_row: &VcfRow)` updating 5 counters.
+// See `future-work-vepyr.md`::`Stats::log_variant`.
+//
+// #[test]
+// fn stats_log_variant_first_snv() {
+//     let mut s = Stats::new();
+//     let row: VcfRow = /* SNV: 21 25585733 C T missense */ todo!();
+//     s.log_variant(&row);
+//     let c = s.counters();
+//     assert_eq!(c.classes.get("SNV"), Some(&1));
+//     assert_eq!(c.var_cons.get("missense_variant"), Some(&1));
+//     assert_eq!(c.var_count, 1);
+//     // chr_bins[21][25_000_000] == 1; allele_changes[C/T] == 1
+// }
+
+// SUBTEST #13 (L108-130): second `log_VariationFeature` — counters increment.
+// Blocked: same as #12.
+// See `future-work-vepyr.md`::`Stats::log_variant`.
+//
+// #[test]
+// fn stats_log_variant_second_call_increments() {
+//     let mut s = Stats::new();
+//     let row1: VcfRow = todo!();
+//     let row2: VcfRow = todo!();
+//     s.log_variant(&row1);
+//     s.log_variant(&row2);
+//     assert_eq!(s.counters().var_count, 2);
+//     assert_eq!(s.counters().classes.get("SNV"), Some(&2));
+// }
+
+// SUBTEST #14 (L132-156): multi-allele 'T/C/G' — extra ALT tallied as
+// separate `T/G` entry. One-row-per-ALT in `allele_changes`.
+// Blocked: `Stats::log_variant` multi-ALT handling.
+// See `future-work-vepyr.md`::`Stats::log_variant`.
+//
+// #[test]
+// fn stats_log_variant_multi_allele() {
+//     let mut s = Stats::new();
+//     let row: VcfRow = /* 21 X T C,G */ todo!();
+//     s.log_variant(&row);
+//     let c = s.counters();
+//     assert_eq!(c.allele_changes.get("T/C"), Some(&1));
+//     assert_eq!(c.allele_changes.get("T/G"), Some(&1));
+// }
+
+// SUBTEST #15 (L158-174): `log_TranscriptVariationAllele` — per-VFOA
+// counters: protein_pos=9, gene=ENSG00000154719. Does NOT bump
+// `transcript` or `consequences`.
+// Blocked: `Stats::log_csq_row(csq: &CsqRow)` for transcript rows.
+// See `future-work-vepyr.md`::`Stats::log_csq_row`.
+//
+// #[test]
+// fn stats_log_csq_row_transcript_only() {
+//     let mut s = Stats::new();
+//     let csq: CsqRow = /* transcript-level row */ todo!();
+//     s.log_csq_row(&csq);
+//     let c = s.counters();
+//     assert_eq!(c.protein_pos.get(&9), Some(&1));
+//     assert_eq!(c.gene.get("ENSG00000154719"), Some(&1));
+// }
+
+// SUBTEST #16 (L176-196): `log_VariationFeatureOverlapAllele` — full VFOA
+// counters: protein_pos, gene, transcript=ENST00000352957,
+// consequences=missense. Superset of #15.
+// Blocked: `Stats::log_csq_row` full VFOA branch.
+// See `future-work-vepyr.md`::`Stats::log_csq_row`.
+//
+// #[test]
+// fn stats_log_csq_row_full_vfoa() {
+//     let mut s = Stats::new();
+//     let csq: CsqRow = /* full VFOA */ todo!();
+//     s.log_csq_row(&csq);
+//     let c = s.counters();
+//     assert_eq!(c.transcript.get("ENST00000352957"), Some(&1));
+//     assert_eq!(c.consequences.get("missense_variant"), Some(&1));
+// }
+
+// SUBTEST #17 (L199-219): SV `log_TranscriptStructuralVariationAllele` —
+// SV-variant counters. Vepyr SV support is itself blocked (port-status.md
+// active blocker #2).
+// Blocked: `Stats::log_csq_row` SV branch.
+// See `future-work-vepyr.md`::`Stats::log_csq_row`.
+//
+// #[test]
+// fn stats_log_csq_row_sv_transcript() {
+//     let mut s = Stats::new();
+//     let csq: CsqRow = /* SV-transcript row */ todo!();
+//     s.log_csq_row(&csq);
+//     assert!(s.counters().consequences.contains_key("feature_elongation"));
+// }
+
+// SUBTEST #18 (L221-242): SV `log_VariationFeatureOverlapAllele` DUP —
+// consequences=feature_elongation + coding_sequence_variant.
+// Blocked: same as #17.
+// See `future-work-vepyr.md`::`Stats::log_csq_row`.
+//
+// #[test]
+// fn stats_log_csq_row_sv_dup_vfoa() {
+//     let mut s = Stats::new();
+//     let csq: CsqRow = /* SV DUP VFOA */ todo!();
+//     s.log_csq_row(&csq);
+//     let c = s.counters();
+//     assert!(c.consequences.contains_key("feature_elongation"));
+//     assert!(c.consequences.contains_key("coding_sequence_variant"));
+// }
+
+// SUBTEST #19 (L245-263): intergenic `log_VariationFeatureOverlapAllele` —
+// consequences=intergenic_variant only (no gene/transcript/protein_pos).
+// Blocked: `Stats::log_csq_row` intergenic branch.
+// See `future-work-vepyr.md`::`Stats::log_csq_row`.
+//
+// #[test]
+// fn stats_log_csq_row_intergenic() {
+//     let mut s = Stats::new();
+//     let csq: CsqRow = /* intergenic row */ todo!();
+//     s.log_csq_row(&csq);
+//     let c = s.counters();
+//     assert_eq!(c.consequences.get("intergenic_variant"), Some(&1));
+//     assert!(c.gene.is_empty());
+//     assert!(c.transcript.is_empty());
+// }
+
+// SUBTEST #20 (L266-276): `log_sift_polyphen('SIFT', 'deleterious')` —
+// per-tool prediction tally. SIFT/PolyPhen are themselves blocked engine
+// features.
+// Blocked: `Stats::log_sift_polyphen(tool, class)`.
+// See `future-work-vepyr.md`::`Stats::log_sift_polyphen + Stats::finish() → FinishedStats`.
+//
+// #[test]
+// fn stats_log_sift_polyphen_tally() {
+//     let mut s = Stats::new();
+//     s.log_sift_polyphen("SIFT", "deleterious");
+//     assert_eq!(s.counters().sift.get("deleterious"), Some(&1));
+// }
+
+// SUBTEST #21 (L287-320): `finished_stats general_stats` — 7-row table
+// (Lines read, Variants processed, Variants filtered out, Novel/existing,
+// Overlapped genes/transcripts/regulatory features).
+// Blocked: `FinishedStats::general -> Vec<(String, String)>`.
+// See `future-work-vepyr.md`::`Stats::log_sift_polyphen + Stats::finish() → FinishedStats`.
+//
+// #[test]
+// fn stats_finished_general_has_seven_rows() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     assert_eq!(finished.general.len(), 7);
+// }
+
+// SUBTEST #22 (L322-405): `finished_stats charts data` — 7 chart buckets
+// (class, MSC, consequences, var-cons, chr, position-on-chr histogram,
+// AF-bin histogram).
+// Blocked: `FinishedStats::charts -> Vec<ChartData>`.
+// See `future-work-vepyr.md`::`Stats::log_sift_polyphen + Stats::finish() → FinishedStats`.
+//
+// #[test]
+// fn stats_finished_charts_has_seven_buckets() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     assert_eq!(finished.charts.len(), 7);
+// }
+
+// SUBTEST #23 (L408): `run_stats version =~ /\d+ \(\d+\)/` — version
+// pattern `<release> (<sub>)`. Vepyr's version is CARGO_PKG_VERSION
+// (semver); test would adapt to vepyr's format.
+// Blocked: `FinishedStats::run_info` first row.
+// See `future-work-vepyr.md`::`Stats::log_sift_polyphen + Stats::finish() → FinishedStats`.
+//
+// #[test]
+// fn stats_finished_run_info_includes_version() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     let (label, _value) = &finished.run_info[0];
+//     assert!(label.contains("version"));
+// }
+
+// SUBTEST #24 (L409-423): `run_stats remaining headers` — 9-header list
+// (VEP version, Annotation sources, Species, Command line options,
+// Start time, End time, Run time, Input file, Output file).
+// Blocked: `FinishedStats::run_info` row labels.
+// See `future-work-vepyr.md`::`Stats::log_sift_polyphen + Stats::finish() → FinishedStats`.
+//
+// #[test]
+// fn stats_finished_run_info_has_nine_rows() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     assert_eq!(finished.run_info.len(), 9);
+// }
+
+// SUBTEST #25 (L427-429): `dump_text` starts with `[VEP run statistics]`.
+// Blocked: `FinishedStats::write_text(w)` emits header as first line.
+// See `future-work-vepyr.md`::`FinishedStats::write_text / write_html`.
+//
+// #[test]
+// fn stats_dump_text_starts_with_header() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     let mut buf = Vec::new();
+//     finished.write_text(&mut buf).unwrap();
+//     let text = String::from_utf8(buf).unwrap();
+//     assert!(text.starts_with("[VEP run statistics]"));
+// }
+
+// SUBTEST #26 (L428): `dump_text` returns true (non-error write).
+// Blocked: `Result<(), io::Error>` from `write_text`.
+// See `future-work-vepyr.md`::`FinishedStats::write_text / write_html`.
+//
+// #[test]
+// fn stats_dump_text_succeeds() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     let mut buf = Vec::new();
+//     assert!(finished.write_text(&mut buf).is_ok());
+// }
+
+// SUBTEST #27 (L433-435): `dump_html` starts with `<html>` tag.
+// Blocked: `FinishedStats::write_html(w)` emits HTML doc.
+// See `future-work-vepyr.md`::`FinishedStats::write_text / write_html`.
+//
+// #[test]
+// fn stats_dump_html_starts_with_html_tag() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     let mut buf = Vec::new();
+//     finished.write_html(&mut buf).unwrap();
+//     let html = String::from_utf8(buf).unwrap();
+//     assert!(html.starts_with("<html>"));
+// }
+
+// SUBTEST #28 (L434): `dump_html` returns true (non-error write).
+// Blocked: `Result<(), io::Error>` from `write_html`.
+// See `future-work-vepyr.md`::`FinishedStats::write_text / write_html`.
+//
+// #[test]
+// fn stats_dump_html_succeeds() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     let mut buf = Vec::new();
+//     assert!(finished.write_html(&mut buf).is_ok());
+// }
+
+// SUBTEST #29 (L444-451): `HTML::Lint` clean — validates HTML tree. Rust
+// analogue is structural-parse-success (e.g., `tl::parse(&html, ..).is_ok()`),
+// not byte-for-byte HTML 4 validation.
+// Blocked: same writer as #27.
+// See `future-work-vepyr.md`::`FinishedStats::write_text / write_html`.
+//
+// #[test]
+// fn stats_dump_html_is_structurally_valid() {
+//     let s = Stats::new();
+//     let finished = s.finish();
+//     let mut buf = Vec::new();
+//     finished.write_html(&mut buf).unwrap();
+//     let html = String::from_utf8(buf).unwrap();
+//     // structural parse OK (not full HTML 4 validation):
+//     // assert!(tl::parse(&html, tl::ParserOptions::default()).is_ok());
+//     assert!(html.contains("</html>"));
+// }
+
+// ──────────────────────────────────────────────────────────────────────────
+// End of port_stats.rs.
+//
+// Total substantive subtests covered: 27 (rows #1, #2 are `use_ok`
+// boilerplate omitted from coverage parity).
+//   - 27 blocked-future-work (rows #3 through #29).
+//   - 0 architectural-no-analogue.
+//   - 0 unit-port / integration-port / e2e-port.
+//
+// Coverage parity: 0 / 27 = 0% — justified in
+// `detailed_plans/Stats.md §"Coverage parity"`. Tier 5 paperwork-only port.
+// ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Four Tier 5 paperwork-only ports bundled in one PR. All four files contain **0 active \`#[test]\` functions by design** — every behavioral subtest is \`blocked-future-work\` against engine blocker #4 (Stats / Tab / VEP-output / JSON sinks; A3 RESOLVED 2026-05-25 "yes, eventually" — extended to JSON 2026-05-27).

When the corresponding sink modules land in vepyr, the commented-out test stubs in each file promote to live tests simultaneously.

## Files

| File | Subtests | Missing API |
|---|---:|---|
| \`tests/port_stats.rs\` | 27 | \`Stats\` writer module + \`FinishedStats::write_text\`/\`write_html\` |
| \`tests/port_output_factory_vep_output.rs\` | 16 | \`vep_output_sink\` (legacy VEP-tab writer) |
| \`tests/port_output_factory_tab.rs\` | 13 | \`tab_sink\` (flat-tab writer + \`--fields\` projection) |
| \`tests/port_output_factory_json.rs\` | 16 | \`json_sink\` + per-VFOA/per-coloc/per-regfeat JSON formatters |

Coverage parity is 0% for each port **by design**, justified in each port's \`detailed_plans/<Name>.md\` §"Coverage parity". Sibling ports cross-reference each other in their file-level doc comments.

## Compliance with v2 paradigm

- All 4 files follow the shape of \`tests/port_base_vep.rs\` (file-level \`//!\` doc + commented \`// #[test]\` stubs).
- Each commented stub names its subtest # + Perl line + future-work entry by exact title.
- 0 \`golden.vcf\` / \`golden.json\` / \`golden.txt\` files.
- 0 \`run_and_compare_csq\` / \`gen_golden.sh\` references.
- 0 \`port_common\` module imports.
- 0 docker dependencies in test code (only \`// verified via VEP 115 ...\` placeholder comments).
- 0 new dependencies added to \`Cargo.toml\` (sink-internal choices are deferred to engine team).

## Build sanity check

\`\`\`
env -u CONDA_PREFIX cargo build -p datafusion-bio-function-vep --tests
\`\`\`

Result: \`Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 10m 41s\` — 0 errors, no warnings related to the new files. All 4 new test binaries compile to test executables with 0 active \`#[test]\` annotations.

## Future-work backlog status

All future-work entries referenced by these stubs already exist in \`porting-tests/future-work-vepyr.md\`:
- \`Module: vep_output_sink\` (line ~121)
- \`Module: tab_sink\` (line ~144)
- \`Module: json_sink\` + 4 sub-entries (lines ~169-263)
- 8 \`Stats::*\` / \`FinishedStats::*\` entries (lines ~558-639)

No new entries are introduced by this PR.

## Companion PR

The plans for these 4 ports are filed in the porting-tests repo on branch \`port-output-factory-2026-05-28\` (includes the existing OF_JSON plan from 2026-05-27).

## Test plan

- [x] \`cargo build -p datafusion-bio-function-vep --tests\` succeeds (verified above).
- [ ] \`cargo test -p datafusion-bio-function-vep --test port_stats\` returns \`0 passed; 0 failed; 0 ignored\` — to be verified after merge (not run here to avoid cargo lock contention with parallel subagents on other Tier 1-4 PRs in flight).
- [ ] Same for the three other new test binaries.

Generated with [Claude Code](https://claude.com/claude-code)