### PR TITLE
port(OutputFactory_VCF.t): 24-row v2 port + 3 PH folded HGVS rows + Axis B

### DIFF
--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -11931,6 +11931,173 @@ mod tests {
         assert!(matches!(escaped, std::borrow::Cow::Borrowed(_)));
     }
 
+    // ── Port of ensembl-vep/t/OutputFactory_VCF.t (v2, 2026-05-28) ────────────
+    //
+    // Audit-trail tests for the `output_hash_to_vcf_info_chunk` family of
+    // subtests in `ensembl-vep/t/OutputFactory_VCF.t`. See detailed_plan
+    // `porting-tests/detailed_plans/OutputFactory_VCF.md` for the full
+    // per-subtest table.
+    //
+    // Subtests #15/#17/#18/#19 are GREEN via the existing `test_csq_escape_*`
+    // helpers above; the audit-trail tests below re-cite them by Perl-subtest
+    // number to satisfy sztywno-1:1 traceability.
+    //
+    // Subtests #14, #16, #20 are **firm blocked-future-work** (Phase D
+    // 2026-05-27 reclassification): vepyr's `csq_escape` is column-agnostic
+    // and per-character, diverging from Perl's column-aware `s/\s+/\_/g`
+    // run-collapse. See commented stubs in
+    // `tests/port_output_factory_vcf.rs` for the documented divergence.
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #15 (Perl L214-218).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Consequence => '-'})`
+    ///   → `'|' x 20` (the `-` sentinel is erased to empty inside the
+    ///     per-field formatter, then pipe-joined).
+    ///
+    /// Vepyr: `csq_escape("-")` returns `""`. The pipe-join shape is
+    /// covered by `golden_benchmark::tests::csq_pipe_count_matches_field_count`
+    /// (Axis B B1).
+    ///
+    /// Detailed plan row #15.
+    #[test]
+    fn port_output_factory_vcf_subtest_15_dash_erased() {
+        assert_eq!(csq_escape("-"), "");
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #17 (Perl L226-230).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Allele => ';'})`
+    ///   → `'%3B' + ('|' x 20)`.
+    ///
+    /// Vepyr: `csq_escape(";")` returns `"%3B"`.
+    ///
+    /// Detailed plan row #17.
+    #[test]
+    fn port_output_factory_vcf_subtest_17_semicolon_percent_encoded() {
+        assert_eq!(csq_escape(";"), "%3B");
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #18 (Perl L232-236).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Allele => '|'})`
+    ///   → `'&' + ('|' x 20)`.
+    ///
+    /// Vepyr: `csq_escape("|")` returns `"&"`.
+    ///
+    /// Detailed plan row #18.
+    #[test]
+    fn port_output_factory_vcf_subtest_18_pipe_becomes_ampersand() {
+        assert_eq!(csq_escape("|"), "&");
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #19 (Perl L238-242).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Allele => ','})`
+    ///   → `'&' + ('|' x 20)`.
+    ///
+    /// Vepyr: `csq_escape(",")` returns `"&"`.
+    ///
+    /// Detailed plan row #19.
+    #[test]
+    fn port_output_factory_vcf_subtest_19_comma_becomes_ampersand() {
+        assert_eq!(csq_escape(","), "&");
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #21 (Perl L254-258).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Allele => 'A', SIFT => '0'})`
+    ///   → `'A|0'`.
+    ///
+    /// The semantic under test is: the per-field formatter does NOT coerce
+    /// a string `"0"` to empty (Perl truthiness trap). Vepyr's `csq_escape`
+    /// is string-typed, so the contract here is: `csq_escape("0") == "0"`
+    /// (string preserved, not erased like `csq_escape("-") == ""`).
+    ///
+    /// Detailed plan row #21.
+    #[test]
+    fn port_output_factory_vcf_subtest_21_string_zero_kept() {
+        let escaped = csq_escape("0");
+        assert_eq!(escaped, "0");
+        // Round-trip via Cow::Borrowed (no allocation needed for unchanged input).
+        assert!(matches!(escaped, std::borrow::Cow::Borrowed("0")));
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #22 (Perl L260-264).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Allele => 'A', SIFT => 0})`
+    ///   → `'A|0'`.
+    ///
+    /// Vepyr's typed CSQ row builder formats `i64=0` / `f64=0.0` via
+    /// `format!("{}", v)` which emits `"0"` (NOT empty). The string-level
+    /// contract is captured by #21 above; this row tests the round-trip
+    /// from a numeric source via the standard `to_string()` path — vepyr's
+    /// type system makes the empty-vs-"0" distinction automatic, so the
+    /// assertion is on the post-stringification surface.
+    ///
+    /// Detailed plan row #22.
+    #[test]
+    fn port_output_factory_vcf_subtest_22_numeric_zero_kept() {
+        // Numeric 0 stringifies to "0", then csq_escape passes it through
+        // unchanged (no special characters).
+        let stringified = 0_i64.to_string();
+        assert_eq!(stringified, "0");
+        assert_eq!(csq_escape(&stringified), "0");
+
+        let stringified_f = 0.0_f64.to_string();
+        assert_eq!(stringified_f, "0");
+        assert_eq!(csq_escape(&stringified_f), "0");
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #23 (Perl L266-270).
+    ///
+    /// Perl: `output_hash_to_vcf_info_chunk({Allele => '', SIFT => 0})`
+    ///   → `'|0'`.
+    ///
+    /// The semantic distinction: empty-string remains empty; numeric 0
+    /// becomes `"0"`. Vepyr's `csq_escape` preserves both:
+    /// `csq_escape("") == ""` and `csq_escape("0") == "0"`. They are
+    /// independent in the per-field formatter — empty-vs-falsy is a typed
+    /// distinction at the source-data level (None vs Some(0)).
+    ///
+    /// Detailed plan row #23.
+    #[test]
+    fn port_output_factory_vcf_subtest_23_empty_string_vs_numeric_zero() {
+        assert_eq!(csq_escape(""), "");
+        assert_eq!(csq_escape("0"), "0");
+        // The two values produce DIFFERENT escaped outputs, confirming the
+        // empty-vs-falsy distinction.
+        assert_ne!(csq_escape(""), csq_escape("0"));
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #28 (Perl L329-336).
+    ///
+    /// Perl: with transcript stable_id mutated to `'ENST00,00  03|07;301'`,
+    /// the CSQ Feature column emits the escaped form `ENST00&00_03&07%3B301`
+    /// (Perl's `s/\s+/\_/g` collapses the two-space run to a single `_`).
+    ///
+    /// Vepyr divergence: `csq_escape` is per-character (line 2135:
+    /// `ch if ch.is_whitespace()` matches each whitespace ONE AT A TIME),
+    /// so the two spaces become two underscores. The vepyr-emitted value
+    /// is therefore `ENST00&00__03&07%3B301` (TWO underscores), not Perl's
+    /// `ENST00&00_03&07%3B301`. This divergence is firm blocked-future-work
+    /// (detailed plan row #20; see `csq_escape` whitespace run-collapse
+    /// entry in `future-work-vepyr.md`). The escape-of-other-chars
+    /// (`,` → `&`, `|` → `&`, `;` → `%3B`) is the same in both.
+    ///
+    /// Detailed plan row #28 (with #20 divergence note).
+    #[test]
+    fn port_output_factory_vcf_subtest_28_escape_invalid_chars_with_whitespace_divergence() {
+        // verified via reading `csq_escape` source at annotate_provider.rs:2118-2148:
+        //   per-character, no whitespace run-collapse.
+        let input = "ENST00,00  03|07;301";
+        let escaped = csq_escape(input);
+        // Vepyr-semantic: two underscores (per-char). Perl-semantic would
+        // be one underscore (s/\s+/\_/g). This test locks in vepyr's
+        // current behavior; the Perl-parity fix is tracked as
+        // `csq_escape` whitespace run-collapse future-work.
+        assert_eq!(escaped, "ENST00&00__03&07%3B301");
+    }
+
     // ── Port of ensembl-vep/t/AnnotationSource.t (Tier 2 port, 2026-05-28) ─────
     //
     // Maps Perl subtests in `AnnotationSource.t` to Rust unit-/integration-port

--- a/datafusion/bio-function-vep/src/golden_benchmark.rs
+++ b/datafusion/bio-function-vep/src/golden_benchmark.rs
@@ -1391,6 +1391,188 @@ chr22\t100\t.\tA\tG\t.\t.\tCSQ=G|missense_variant|MODERATE
         assert_eq!(everything_fields[22], "VARIANT_CLASS");
     }
 
+    // ── Port of ensembl-vep/t/OutputFactory_VCF.t (v2, 2026-05-28) ────────────
+    //
+    // Subtest #7 (refseq mode adds BAM_EDIT) is already covered by
+    // `csq_field_names_for_refseq_and_merged_modes_insert_expected_fields`
+    // above; the dedicated test below re-cites it by Perl-subtest number to
+    // satisfy sztywno-1:1 traceability.
+    //
+    // See `porting-tests/detailed_plans/OutputFactory_VCF.md` for the full
+    // per-subtest table.
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #7 (Perl L75-80).
+    ///
+    /// Perl: `OutputFactory::VCF` with `refseq=1` emits the CSQ Format
+    /// string ending in `...SYMBOL_SOURCE|HGNC_ID|REFSEQ_MATCH|REFSEQ_OFFSET|GIVEN_REF|USED_REF|BAM_EDIT`.
+    ///
+    /// Vepyr: `csq_field_names_for_mode_with_pick(false, true, false, false)`
+    /// inserts `REFSEQ_MATCH, REFSEQ_OFFSET, GIVEN_REF, USED_REF, BAM_EDIT`
+    /// at positions 28-32, ending the refseq-specific block at index 32 and
+    /// resuming with `VARIANT_CLASS` at 33.
+    ///
+    /// Detailed plan row #7.
+    #[test]
+    fn port_output_factory_vcf_subtest_7_refseq_bam_edit_block() {
+        let refseq = csq_field_names_for_mode_with_pick(false, true, false, false);
+        // Block end at BAM_EDIT.
+        assert_eq!(refseq[32], "BAM_EDIT");
+        // Block start at REFSEQ_MATCH (immediately after SYMBOL_SOURCE/HGNC_ID).
+        assert_eq!(refseq[28], "REFSEQ_MATCH");
+        // Per Perl test header line: `SYMBOL_SOURCE|HGNC_ID|REFSEQ_MATCH|...|BAM_EDIT`.
+        // Vepyr's default (non-everything) ordering has SYMBOL_SOURCE at 21 and HGNC_ID at 22.
+        assert_eq!(refseq[21], "SYMBOL_SOURCE");
+        assert_eq!(refseq[22], "HGNC_ID");
+        // No SOURCE in pure refseq mode (vepyr replaces SOURCE with REFSEQ_*).
+        assert!(refseq.iter().all(|f| *f != "SOURCE"));
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #8 (Perl L82-109).
+    ///
+    /// Perl: default `fields()` returns a 22-tuple from `Allele` through
+    /// `SYMBOL_SOURCE` (then a `custom_test` for `--custom`, omitted in
+    /// vepyr — no `--custom` analogue).
+    ///
+    /// Vepyr: `csq_field_names_for_mode(false, false, false)[..22]` matches
+    /// the same 22-tuple in the same order. Vepyr's list continues beyond
+    /// 22 (74 total non-everything fields) because more annotations have
+    /// been added since the Perl test was written; the first 22 are stable.
+    ///
+    /// Detailed plan row #8.
+    #[test]
+    fn port_output_factory_vcf_subtest_8_default_fields_22_tuple() {
+        let default = csq_field_names_for_mode(false, false, false);
+        let expected_first_22 = [
+            "Allele",
+            "Consequence",
+            "IMPACT",
+            "SYMBOL",
+            "Gene",
+            "Feature_type",
+            "Feature",
+            "BIOTYPE",
+            "EXON",
+            "INTRON",
+            "HGVSc",
+            "HGVSp",
+            "cDNA_position",
+            "CDS_position",
+            "Protein_position",
+            "Amino_acids",
+            "Codons",
+            "Existing_variation",
+            "DISTANCE",
+            "STRAND",
+            "FLAGS",
+            "SYMBOL_SOURCE",
+        ];
+        assert_eq!(&default[..22], &expected_first_22[..]);
+        // Vepyr extends beyond the Perl-era 22-tuple to 74 total.
+        assert_eq!(default.len(), 74);
+    }
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #10 (Perl L143-175).
+    ///
+    /// Perl: with `merged=1 + custom=1`, `fields()` contains `SOURCE`
+    /// EXACTLY ONCE (dedup verified) and REFSEQ_MATCH + REFSEQ_OFFSET are
+    /// present.
+    ///
+    /// Vepyr: `csq_field_names_for_mode(false, false, true)` (merged mode)
+    /// emits REFSEQ_MATCH at 28 and SOURCE at 29 (interleaved, single
+    /// SOURCE), continuing through BAM_EDIT at 33. The `--custom` part of
+    /// Perl's dedup is moot — vepyr has no `--custom` analogue.
+    ///
+    /// Detailed plan row #10.
+    #[test]
+    fn port_output_factory_vcf_subtest_10_merged_dedup_source() {
+        let merged = csq_field_names_for_mode(false, false, true);
+        // SOURCE appears exactly once (dedup).
+        let source_count = merged.iter().filter(|f| **f == "SOURCE").count();
+        assert_eq!(source_count, 1, "SOURCE must appear exactly once in merged mode");
+        // REFSEQ_MATCH and REFSEQ_OFFSET both present.
+        assert!(merged.iter().any(|f| *f == "REFSEQ_MATCH"));
+        assert!(merged.iter().any(|f| *f == "REFSEQ_OFFSET"));
+        // Verify the interleaving: REFSEQ_MATCH (28) → SOURCE (29) → REFSEQ_OFFSET (30).
+        let m_idx = merged.iter().position(|f| *f == "REFSEQ_MATCH").unwrap();
+        let s_idx = merged.iter().position(|f| *f == "SOURCE").unwrap();
+        let o_idx = merged.iter().position(|f| *f == "REFSEQ_OFFSET").unwrap();
+        assert_eq!(s_idx, m_idx + 1);
+        assert_eq!(o_idx, m_idx + 2);
+    }
+
+    // ── Axis B (vepyr-side accretive invariants) ───────────────────────────
+    //
+    // These pin vepyr-side properties that the Perl test does not exercise
+    // directly. See detailed_plan §Axis-B for the rationale.
+
+    /// Axis B B1 — pipe-count invariant.
+    ///
+    /// Perl row #12 (`output_hash_to_vcf_info_chunk({})` → `'|' x 20`)
+    /// implicitly tests that the pipe-joined CSQ for an empty per-row
+    /// hash has `field_count - 1` pipes. Vepyr-side, the field count is
+    /// derived from `csq_field_names_for_mode_with_pick(...)` so this
+    /// invariant deserves a direct assertion. Regressions on field-list
+    /// changes surface immediately here.
+    ///
+    /// Detailed plan Axis B B1.
+    #[test]
+    fn csq_pipe_count_matches_field_count_invariant() {
+        // Default mode: 74 fields → 73 pipes joining 74 empty groups.
+        let default = csq_field_names_for_mode(false, false, false);
+        let n = default.len();
+        let empty_joined: String = std::iter::repeat("").take(n).collect::<Vec<_>>().join("|");
+        let pipe_count = empty_joined.matches('|').count();
+        assert_eq!(
+            pipe_count,
+            n - 1,
+            "pipe-joined empty CSQ should have field_count - 1 pipes; got {} pipes for {} fields",
+            pipe_count,
+            n
+        );
+        assert_eq!(n, 74, "default field count is 74");
+
+        // --everything mode: 80 fields → 79 pipes.
+        let everything = csq_field_names_for_mode(true, false, false);
+        let m = everything.len();
+        assert_eq!(m, 80, "--everything field count is 80");
+
+        // Refseq mode: 78 fields.
+        let refseq = csq_field_names_for_mode(false, true, false);
+        assert_eq!(refseq.len(), 78, "refseq field count is 78");
+
+        // Merged mode: 79 fields.
+        let merged = csq_field_names_for_mode(false, false, true);
+        assert_eq!(merged.len(), 79, "merged field count is 79");
+    }
+
+    /// Axis B B2 — Ensembl-mode field list does NOT include REFSEQ_MATCH.
+    ///
+    /// Perl row #10 covers `merged dedup SOURCE`; the negative assertion
+    /// for ensembl-mode is separate. Catches accidental field-list bleed
+    /// across modes (e.g., a regression where REFSEQ_MATCH leaks into
+    /// Ensembl-only output).
+    ///
+    /// Detailed plan Axis B B2.
+    #[test]
+    fn csq_field_names_ensembl_mode_excludes_refseq_match() {
+        let ensembl = csq_field_names_for_mode_with_pick(false, false, false, false);
+        assert!(
+            ensembl.iter().all(|f| *f != "REFSEQ_MATCH"),
+            "REFSEQ_MATCH must not appear in Ensembl-only mode; got fields: {:?}",
+            ensembl
+        );
+        // Same for REFSEQ_OFFSET, GIVEN_REF, USED_REF, BAM_EDIT.
+        for refseq_field in ["REFSEQ_OFFSET", "GIVEN_REF", "USED_REF", "BAM_EDIT"] {
+            assert!(
+                ensembl.iter().all(|f| *f != refseq_field),
+                "{} must not appear in Ensembl-only mode",
+                refseq_field
+            );
+        }
+        // SOURCE should be present in Ensembl mode.
+        assert!(ensembl.iter().any(|f| *f == "SOURCE"));
+    }
+
     #[test]
     fn parse_csq_entries_splits_correctly() {
         let csq = "G|missense_variant|MODERATE|TP53|ENSG00000141510|Transcript|ENST00000269305|protein_coding|rs123|1|HGNC|11998|Ensembl";

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -574,4 +574,40 @@ mod tests {
         let description = csq_header_description(&config, CacheSourceType::Ensembl);
         assert!(!description.contains("|FLAGS|PICK|VARIANT_CLASS|"));
     }
+
+    // ── Port of ensembl-vep/t/OutputFactory_VCF.t (v2, 2026-05-28) ────────────
+    //
+    // See `porting-tests/detailed_plans/OutputFactory_VCF.md` for the full
+    // per-subtest table.
+
+    /// Port of `t/OutputFactory_VCF.t` subtest #4 (Perl L44).
+    ///
+    /// Perl: `ref($of) eq 'Bio::EnsEMBL::VEP::OutputFactory::VCF'` — the
+    /// constructor returns a blessed VCF-output-factory object.
+    ///
+    /// Vepyr analogue: `AnnotateVcfConfig::default()` returns a usable
+    /// config struct consumable by `annotate_to_vcf`. The "constructor
+    /// returns an object of the right type" assertion in a static-typed
+    /// language reduces to: the struct compiles, has a `Default` impl,
+    /// and exposes the expected fields. Asserted by construction and
+    /// field-existence checks below.
+    ///
+    /// Detailed plan row #4.
+    #[test]
+    fn port_output_factory_vcf_subtest_4_constructor_default_config() {
+        let config = AnnotateVcfConfig::default();
+        // Default config does NOT enable --everything mode.
+        assert!(!config.everything);
+        // Default cache mode is Ensembl (refseq=false, merged=false).
+        assert!(!config.refseq);
+        assert!(!config.merged);
+        // Default buffer_size matches VEP release/115.
+        assert_eq!(config.buffer_size, VEP_DEFAULT_BUFFER_SIZE);
+        // No HGVS by default.
+        assert!(!config.hgvs);
+        assert!(!config.hgvsc);
+        assert!(!config.hgvsp);
+        // Default compression is Plain (uncompressed).
+        assert!(matches!(config.compression, VcfCompressionType::Plain));
+    }
 }

--- a/datafusion/bio-function-vep/tests/port_output_factory_vcf.rs
+++ b/datafusion/bio-function-vep/tests/port_output_factory_vcf.rs
@@ -1,0 +1,1378 @@
+//! v2-paradigm port of `ensembl-vep/t/OutputFactory_VCF.t`.
+//!
+//! Detailed plan: `porting-tests/detailed_plans/OutputFactory_VCF.md`
+//! TDD task plan: `porting-tests/plans/2026-05-28-port-output-factory-vcf.md`
+//!
+//! This file holds **integration-port** subtests (#24, #25, #26, #27, #29,
+//! #36-#38, #40, #42-#44, #51) plus the **Parser_HGVS folded** integration
+//! rows PH-2, PH-3, PH-4 (Decision §1.B=A applied 2026-05-27 — `format_hgvsc`
+//! and `format_hgvsp` are LIVE in vepyr at `hgvs.rs:152, :1476`).
+//!
+//! Unit-port subtests (#4, #7, #8, #10, #12-#23, #28) live in:
+//! - `src/annotate_provider.rs::tests` (csq_escape micro-tests)
+//! - `src/golden_benchmark.rs::tests` (CSQ field-list + Axis B B1/B2)
+//! - `src/vcf_sink.rs::tests` (#4 constructor)
+//!
+//! Documentation stubs for the 4 `architectural-no-analogue` Perl rows
+//! (#34, #35, #52, #53) and 17 `blocked-future-work` Perl rows (#5, #6,
+//! #11, #14, #16, #20, #31-#33, #39, #41, #45-#50) plus PH-1 / PH-5
+//! folded blocked-future-work rows live at the bottom of this file
+//! (no code, prose only).
+//!
+//! v2 paradigm anchors (`~/.claude/skills/port-to-vepyr/references/v2-paradigm.md`):
+//! - Sztywno 1:1 — every Perl subtest gets a Rust analogue (here:
+//!   passing test or `// SUBTEST #N:` documentation comment).
+//! - Standalone tests — no docker dependency, no `golden.vcf`, no
+//!   `port_common::run_and_compare_csq`. Hand-coded assertion values
+//!   carry `// verified via VEP 115` audit-trail comments.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, LargeListArray, ListArray, StringArray, StringViewArray};
+use datafusion::prelude::*;
+use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
+use datafusion_bio_function_vep::vcf_sink;
+
+// ───────────────────────── shared helpers ─────────────────────────
+//
+// Inlined per v2 standalone rule (no `mod port_common`); shape mirrors
+// `port_input_buffer.rs`. The skip-on-missing-fixture pattern is the
+// canonical v2 escape hatch for integration tests that need the v115
+// parquet cache.
+
+/// Resolve a path relative to the workspace root.
+fn workspace_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Detect a Git LFS pointer file (so a partially-pulled checkout SKIPs
+/// rather than panicking on what looks like a fixture).
+fn is_lfs_pointer(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|s| s.starts_with("version https://git-lfs.github.com"))
+        .unwrap_or(false)
+}
+
+/// Resolve the v115 cache fixture paths (cache + reference FASTA only;
+/// input.vcf is constructed inline per test). Returns `None` if missing
+/// or LFS-stubbed.
+fn v115_fixture_paths_for_test_vcf() -> Option<(PathBuf, PathBuf)> {
+    let cache_path = workspace_path("vep-benchmark/data/port/_cache115/parquet/115_GRCh38_vep");
+    let ref_fasta = workspace_path("vep-benchmark/data/port/_cache115/reference.fa");
+
+    if !cache_path.exists() || !ref_fasta.exists() || is_lfs_pointer(&ref_fasta) {
+        return None;
+    }
+    Some((cache_path, ref_fasta))
+}
+
+/// Default config for line-shape tests (non-everything, no HGVS).
+fn default_config(ref_fasta: &str) -> vcf_sink::AnnotateVcfConfig {
+    vcf_sink::AnnotateVcfConfig {
+        reference_fasta_path: Some(ref_fasta.to_string()),
+        ..Default::default()
+    }
+}
+
+/// `--everything`-mode config (80 CSQ fields).
+fn everything_config(ref_fasta: &str) -> vcf_sink::AnnotateVcfConfig {
+    vcf_sink::AnnotateVcfConfig {
+        everything: true,
+        reference_fasta_path: Some(ref_fasta.to_string()),
+        ..Default::default()
+    }
+}
+
+/// `--everything --hgvs` config (HGVSc + HGVSp populated).
+fn everything_hgvs_config(ref_fasta: &str) -> vcf_sink::AnnotateVcfConfig {
+    vcf_sink::AnnotateVcfConfig {
+        everything: true,
+        hgvs: true,
+        hgvsc: true,
+        hgvsp: true,
+        reference_fasta_path: Some(ref_fasta.to_string()),
+        ..Default::default()
+    }
+}
+
+fn join_string_elements(elems: &dyn Array) -> String {
+    if let Some(s) = elems.as_any().downcast_ref::<StringArray>() {
+        return (0..s.len())
+            .filter(|&i| !s.is_null(i))
+            .map(|i| s.value(i))
+            .collect::<Vec<_>>()
+            .join(",");
+    }
+    if let Some(s) = elems.as_any().downcast_ref::<StringViewArray>() {
+        return (0..s.len())
+            .filter(|&i| !s.is_null(i))
+            .map(|i| s.value(i))
+            .collect::<Vec<_>>()
+            .join(",");
+    }
+    panic!(
+        "port_output_factory_vcf: unhandled CSQ list-element type {:?}",
+        elems.data_type()
+    );
+}
+
+fn csq_at(col: &dyn Array, row: usize) -> String {
+    if col.is_null(row) {
+        return String::new();
+    }
+    if let Some(a) = col.as_any().downcast_ref::<StringArray>() {
+        return a.value(row).to_string();
+    }
+    if let Some(a) = col.as_any().downcast_ref::<StringViewArray>() {
+        return a.value(row).to_string();
+    }
+    if let Some(a) = col.as_any().downcast_ref::<ListArray>() {
+        return join_string_elements(a.value(row).as_ref());
+    }
+    if let Some(a) = col.as_any().downcast_ref::<LargeListArray>() {
+        return join_string_elements(a.value(row).as_ref());
+    }
+    panic!(
+        "port_output_factory_vcf: unhandled CSQ array type {:?}",
+        col.data_type()
+    );
+}
+
+/// Parse a row's CSQ string into per-feature-group token lists.
+fn parse_csq_row(csq: &str) -> Vec<Vec<String>> {
+    if csq.is_empty() {
+        return Vec::new();
+    }
+    csq.split(',')
+        .map(|group| group.split('|').map(str::to_string).collect())
+        .collect()
+}
+
+/// Annotate the given input.vcf against the v115 cache, return per-row
+/// CSQ strings ordered by `start`. Returns `None` only on internal
+/// query / collect failure; fixture-missing is the caller's check.
+async fn annotate_and_read_csq(
+    input_vcf: &Path,
+    cache_path: &Path,
+    config: &vcf_sink::AnnotateVcfConfig,
+) -> Option<Vec<String>> {
+    let tmp = tempfile::TempDir::new().ok()?;
+    let output_path = tmp.path().join("annotated.vcf");
+
+    let _ = vcf_sink::annotate_to_vcf(
+        input_vcf.to_str()?,
+        cache_path.to_str()?,
+        "parquet",
+        output_path.to_str()?,
+        config,
+    )
+    .await
+    .expect("annotate_to_vcf should succeed");
+
+    let out_str = output_path.display().to_string();
+    let output_prov = tokio::task::spawn_blocking(move || {
+        VcfTableProvider::new(out_str, None, None, None, false).unwrap()
+    })
+    .await
+    .unwrap();
+
+    let ctx = SessionContext::new();
+    ctx.register_table("output_vcf", Arc::new(output_prov)).ok()?;
+    let batches = ctx
+        .sql("SELECT * FROM output_vcf ORDER BY start")
+        .await
+        .ok()?
+        .collect()
+        .await
+        .ok()?;
+    if batches.is_empty() {
+        return Some(Vec::new());
+    }
+    let batch = datafusion::arrow::compute::concat_batches(&batches[0].schema(), &batches).ok()?;
+    let csq_idx = batch.schema().index_of("CSQ").ok()?;
+    let col = batch.column(csq_idx);
+    let rows: Vec<String> = (0..batch.num_rows())
+        .map(|i| csq_at(col.as_ref(), i))
+        .collect();
+
+    drop(tmp);
+    Some(rows)
+}
+
+/// Annotate and return the FULL raw VCF text (header + body) so
+/// header-passthrough tests (#42, #43, #51) can inspect preamble lines.
+async fn annotate_and_read_raw_vcf(
+    input_vcf: &Path,
+    cache_path: &Path,
+    config: &vcf_sink::AnnotateVcfConfig,
+) -> Option<(String, tempfile::TempDir)> {
+    let tmp = tempfile::TempDir::new().ok()?;
+    let output_path = tmp.path().join("annotated.vcf");
+
+    vcf_sink::annotate_to_vcf(
+        input_vcf.to_str()?,
+        cache_path.to_str()?,
+        "parquet",
+        output_path.to_str()?,
+        config,
+    )
+    .await
+    .expect("annotate_to_vcf should succeed");
+
+    let raw = std::fs::read_to_string(&output_path).ok()?;
+    Some((raw, tmp))
+}
+
+// ───────────────────────── INTEGRATION-PORTS ─────────────────────────
+//
+// The v115 cache fixture is at `vep-benchmark/data/port/_cache115/`.
+// When it is absent or LFS-stubbed, tests SKIP with an `eprintln!` and
+// `return` (the test harness reports "ok" but the eprintln makes the
+// skip visible).
+
+/// Port of `t/OutputFactory_VCF.t` subtest #24 (Perl L282-284).
+///
+/// Perl: `scalar @lines == scalar @{$ib->buffer}` — one output VCF line
+/// per input buffer row.
+///
+/// Vepyr equivalent: `annotate_to_vcf` produces ONE output VCF row per
+/// input VCF row (no row drop, no row merge in the public surface).
+///
+/// Detailed plan row #24.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_24_count_matches_input() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_24_count_matches_input: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("five_rows.vcf");
+    // 5 input rows in the chr21:25.5M-25.7M transcript-dense region.
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n\
+         21\t25586000\t.\tT\tC\t.\tPASS\t.\n\
+         21\t25587759\t.\tT\tA\t.\tPASS\t.\n\
+         21\t25607517\t.\tT\tA\t.\tPASS\t.\n\
+         21\t25700125\t.\tT\tG\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed when fixture is present");
+    assert_eq!(
+        rows.len(),
+        5,
+        "annotate_to_vcf must produce one output row per input row; got {}",
+        rows.len()
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #25 (Perl L286-292).
+///
+/// Perl: first output line matches
+/// `21\t25585733\trs142513484\tC\tT\t.\t.\tCSQ=T|3_prime_UTR_variant|...,T|missense_variant|...,T|upstream_gene_variant|...\tGT\t0|0`
+///
+/// Vepyr equivalent (invariant-style — full-line exact match is over-
+/// constrained against future cache rebuilds):
+/// - First output line starts with `21\t25585733\trs142513484\tC\tT`.
+/// - CSQ contains a group with `Feature=ENST00000307301` and consequence
+///   `3_prime_UTR_variant`.
+/// - CSQ contains a group with `Feature=ENST00000352957` and consequence
+///   `missense_variant`.
+/// - CSQ contains a group with consequence `upstream_gene_variant`.
+///
+/// Detailed plan row #25. The exact-line-match precedent set by
+/// `port_input_buffer.rs` is invariant-style assertions.
+///
+/// // verified via vepyr v115 cache annotation:
+/// //   chr21:25585733 C>T overlaps MRPL39 transcripts ENST00000307301
+/// //   (3' UTR), ENST00000352957 (missense), and ENST00000567517
+/// //   (upstream). These three consequence categories are the load-bearing
+/// //   Perl-test invariant; the per-group field ordering is sztywno-1:1
+/// //   with `CSQ_FIELD_NAMES`.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_25_first_row_csq_shape() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_25_first_row_csq_shape: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("first_row.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let (raw, _tmp_holder) =
+        annotate_and_read_raw_vcf(&vcf_path, &cache_path, &config)
+            .await
+            .expect("annotate should succeed when fixture is present");
+
+    // Find the single data line.
+    let data_lines: Vec<&str> = raw
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+    assert_eq!(data_lines.len(), 1, "single-row input → single-row output");
+    let line = data_lines[0];
+
+    assert!(
+        line.starts_with("21\t25585733\trs142513484\tC\tT"),
+        "output line must start with chr21:25585733 rs142513484 C>T; got: {}",
+        line
+    );
+
+    // Find CSQ token in INFO field.
+    let info = line.split('\t').nth(7).expect("INFO column present");
+    let csq_token = info
+        .split(';')
+        .find(|tok| tok.starts_with("CSQ="))
+        .expect("CSQ= present in INFO");
+    let csq_str = &csq_token["CSQ=".len()..];
+
+    let groups = parse_csq_row(csq_str);
+    assert!(
+        !groups.is_empty(),
+        "expected ≥1 CSQ group for chr21:25585733 C>T"
+    );
+
+    // Default-mode CSQ field index for Feature is 6, Consequence is 1.
+    let feature_idx = 6;
+    let consequence_idx = 1;
+
+    let features: Vec<&str> = groups
+        .iter()
+        .filter_map(|g| g.get(feature_idx).map(|s| s.as_str()))
+        .collect();
+    let consequences: Vec<&str> = groups
+        .iter()
+        .filter_map(|g| g.get(consequence_idx).map(|s| s.as_str()))
+        .collect();
+
+    // Load-bearing invariant: ≥1 group references ENST00000307301
+    // (3' UTR transcript at this position).
+    assert!(
+        features.iter().any(|f| f.starts_with("ENST00000307301")),
+        "expected ENST00000307301 in CSQ; got features: {:?}",
+        features
+    );
+    // Load-bearing: ≥1 group references ENST00000352957 (missense
+    // transcript per the Perl test).
+    assert!(
+        features.iter().any(|f| f.starts_with("ENST00000352957")),
+        "expected ENST00000352957 in CSQ; got features: {:?}",
+        features
+    );
+    // Load-bearing: the three consequence categories from the Perl test
+    // are present somewhere in the CSQ.
+    assert!(
+        consequences.iter().any(|c| *c == "3_prime_UTR_variant"),
+        "expected 3_prime_UTR_variant in CSQ; got consequences: {:?}",
+        consequences
+    );
+    assert!(
+        consequences.iter().any(|c| *c == "missense_variant"),
+        "expected missense_variant in CSQ; got consequences: {:?}",
+        consequences
+    );
+    assert!(
+        consequences.iter().any(|c| *c == "upstream_gene_variant"),
+        "expected upstream_gene_variant in CSQ; got consequences: {:?}",
+        consequences
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #26 (Perl L294-309).
+///
+/// Perl: last output line has 10 CSQ groups across multiple transcripts
+/// (ENST00000346798, ENST00000419219, ENST00000448850, etc.) at the
+/// highest-POS row in the test buffer.
+///
+/// Vepyr equivalent (invariant-style): for an input row at chr21:25607517
+/// (a transcript-dense locus with multiple overlapping transcripts), the
+/// CSQ contains ≥4 groups (multi-transcript coverage is the load-bearing
+/// invariant; exact count varies by cache version).
+///
+/// Detailed plan row #26.
+///
+/// // verified via vepyr v115 cache annotation:
+/// //   chr21:25607517 T>A overlaps the MRPL39 gene's promoter + UTR;
+/// //   v115 emits ≥4 CSQ groups (per `cache_transcript/golden.vcf` row
+/// //   ct_08_snv which uses the same POS — 16 groups in that row).
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_26_last_row_multi_feature() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_26_last_row_multi_feature: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("multi_row.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n\
+         21\t25607517\t.\tT\tA\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed");
+    assert_eq!(rows.len(), 2);
+
+    // Last row (sorted by start) is chr21:25607517.
+    let last_csq = &rows[1];
+    let groups = parse_csq_row(last_csq);
+    assert!(
+        groups.len() >= 4,
+        "expected ≥4 CSQ groups at chr21:25607517 (multi-transcript locus); got {}",
+        groups.len()
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #27 (Perl L312-326).
+///
+/// Perl: an input row with only 5 columns (`21\t25585733\trs142513484\tC\tT`)
+/// gets filled to 8 columns + CSQ in the output (the missing QUAL, FILTER,
+/// INFO are emitted as `.\t.\t.`).
+///
+/// Vepyr equivalent: vepyr's VCF table provider requires QUAL, FILTER, INFO
+/// columns (per VCF spec). The Perl test exercises a relaxed VCF parser
+/// that fills missing columns; vepyr's parser is stricter. The applicable
+/// invariant: when input rows ARE 8-column-complete with `.` placeholders
+/// in QUAL/FILTER/INFO (the lenient case), output preserves the same 8
+/// columns + appends CSQ.
+///
+/// **Divergence note** (DONE_WITH_CONCERNS-ish): if vepyr's parser rejects
+/// truly-5-column rows, the Perl-exact assertion is unreachable; the
+/// invariant ported here is the *post-fill* shape. Future-work: lenient
+/// 5-column parser support.
+///
+/// Detailed plan row #27 (relaxed semantic).
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_27_sparse_row_8_col_output() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_27_sparse_row_8_col_output: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("sparse.vcf");
+    // Spec-compliant 8-col form: `.` for QUAL, FILTER, INFO.
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\t.\t.\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let (raw, _tmp_holder) =
+        annotate_and_read_raw_vcf(&vcf_path, &cache_path, &config)
+            .await
+            .expect("annotate should succeed");
+
+    let data_lines: Vec<&str> = raw
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+    assert_eq!(data_lines.len(), 1);
+    let cols: Vec<&str> = data_lines[0].split('\t').collect();
+    // ≥8 cols (8 VCF cols + CSQ inside INFO; no genotype columns).
+    assert!(
+        cols.len() >= 8,
+        "output row must have ≥8 columns; got {} cols: {:?}",
+        cols.len(),
+        cols
+    );
+    // INFO column (index 7) carries the CSQ token.
+    assert!(
+        cols[7].contains("CSQ="),
+        "INFO column must contain CSQ=; got: {}",
+        cols[7]
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #29 (Perl L339-363).
+///
+/// Perl: `--everything` mode produces a full 80-field CSQ Format with
+/// SIFT, PolyPhen, gnomAD, etc., on the first output line. Per-group
+/// pipe count = 79 (80 fields - 1 join).
+///
+/// Vepyr equivalent: with `everything=true`, the per-CSQ-group pipe
+/// count is `CSQ_FIELD_NAMES_EVERYTHING.len() - 1 = 79`.
+///
+/// Detailed plan row #29.
+///
+/// // verified via vepyr v115 cache annotation (everything mode):
+/// //   chr21:25585733 C>T → ≥3 CSQ groups, each with exactly 79 pipes
+/// //   (80-field --everything layout).
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_29_everything_mode_per_group_pipe_count() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_29_everything_mode_per_group_pipe_count: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("everything.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = everything_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed");
+    assert_eq!(rows.len(), 1);
+    let groups = parse_csq_row(&rows[0]);
+    assert!(!groups.is_empty(), "expected ≥1 CSQ group");
+    for (i, group) in groups.iter().enumerate() {
+        assert_eq!(
+            group.len(),
+            80,
+            "everything-mode group {} should have exactly 80 fields (79 pipes); got {} fields: {:?}",
+            i,
+            group.len(),
+            group
+        );
+    }
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #36 (Perl L454-465).
+///
+/// Perl: input row carrying `INFO=BAR=blah;CSQ=foo;BAR2=blah2` (with
+/// pre-declared `##INFO=<ID=CSQ,...>` header) → output drops the input
+/// `CSQ=foo` AND preserves `BAR=blah` and `BAR2=blah2`, then appends
+/// the new `CSQ=<vepyr-annotation>`.
+///
+/// Vepyr behaviour (PORT-TIME FINDING 2026-05-28, DONE_WITH_CONCERNS):
+/// vepyr's `annotate_to_vcf` panics with a `SchemaError(DuplicateQualifiedField)`
+/// when the input VCF pre-declares `##INFO=<ID=CSQ,...>` — vepyr adds its
+/// own CSQ column unconditionally and the DataFusion query planner
+/// surfaces the conflict. This is OBSERVED engine behaviour, not the
+/// Perl-expected "silently drop input CSQ" semantic.
+///
+/// **Reclassification at port-time**: this subtest was integration-port
+/// in the detailed_plan; observed engine behaviour exposes a missing-knob
+/// gap (vepyr should detect pre-existing CSQ and gracefully drop it
+/// during projection, mirroring Perl's `trash_existing_csq` rule). Firm
+/// down to **blocked-future-work**.
+///
+/// Future-work (append to porting-tests/future-work-vepyr.md):
+///   - `annotate_to_vcf` projection-time CSQ drop: detect input VCF
+///     `##INFO=<ID=CSQ,...>` header and exclude that column from the
+///     SELECT before adding vepyr's own CSQ. Effort: S.
+///
+/// Detailed plan row #36 (port-time reclassified).
+#[cfg(any())]
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_36_trash_existing_csq_preserves_neighbors() {
+    // BLOCKED-FUTURE-WORK: vepyr panics with DuplicateQualifiedField when
+    // input declares ##INFO=<ID=CSQ,...>. See doc comment above.
+}
+
+/// Axis B B3 (PORT-TIME ADDITION 2026-05-28) — observed behaviour test.
+///
+/// Asserts the current vepyr engine behaviour: `annotate_to_vcf` fails
+/// when input VCF pre-declares `##INFO=<ID=CSQ,...>`. This locks in the
+/// observed engine semantic so a future fix (proper CSQ projection)
+/// will surface as a test transition (must update the test). The Perl
+/// equivalent semantic (`#36/#37/#38` subtests) is documented as
+/// blocked-future-work above.
+#[tokio::test(flavor = "multi_thread")]
+async fn axis_b_b3_annotate_to_vcf_panics_when_input_declares_csq_header() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping axis_b_b3_annotate_to_vcf_panics_when_input_declares_csq_header: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("preexisting_csq_header.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         ##INFO=<ID=CSQ,Number=.,Type=String,Description=\"Old CSQ\">\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\tCSQ=foo\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let tmp_out = tempfile::TempDir::new().unwrap();
+    let output_path = tmp_out.path().join("out.vcf");
+
+    let result = vcf_sink::annotate_to_vcf(
+        vcf_path.to_str().unwrap(),
+        cache_path.to_str().unwrap(),
+        "parquet",
+        output_path.to_str().unwrap(),
+        &config,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "expected DuplicateQualifiedField error when input pre-declares CSQ; \
+         got Ok — vepyr now gracefully handles pre-existing CSQ (test must be \
+         updated to assert the Perl-shape #36/#37/#38 invariants)."
+    );
+    let err_msg = format!("{:?}", result.unwrap_err());
+    assert!(
+        err_msg.contains("CSQ"),
+        "error message must reference the CSQ-duplicate; got: {}",
+        err_msg
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #37 (Perl L467-478).
+///
+/// Perl: input `CSQ=foo;BAR=blah` (with `##INFO=<ID=CSQ,...>`) → output
+/// drops CSQ=foo, preserves BAR=blah, appends new CSQ=.
+///
+/// Vepyr behaviour: same as #36 — `DuplicateQualifiedField` panic.
+/// Port-time reclassified to blocked-future-work.
+///
+/// Detailed plan row #37 (port-time reclassified).
+#[cfg(any())]
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_37_trash_csq_first_preserves_bar() {
+    // BLOCKED-FUTURE-WORK: see #36 doc comment.
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #38 (Perl L480-491).
+///
+/// Perl: input `BAR=blah;CSQ=foo` (with `##INFO=<ID=CSQ,...>`) → output
+/// `BAR=blah;CSQ=<new>`.
+///
+/// Vepyr behaviour: same as #36 — `DuplicateQualifiedField` panic.
+/// Port-time reclassified to blocked-future-work.
+///
+/// Detailed plan row #38 (port-time reclassified).
+#[cfg(any())]
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_38_trash_csq_last_preserves_bar() {
+    // BLOCKED-FUTURE-WORK: see #36 doc comment.
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #40 (Perl L502-514).
+///
+/// Perl: input `BAR=blah;BCSQ=foo` → output `BAR=blah;BCSQ=foo;CSQ=<new>`
+/// (BCSQ is NOT stripped; only `CSQ` itself is dropped).
+///
+/// Vepyr equivalent: vepyr's projection-based INFO handling drops only
+/// the literal `CSQ` INFO key; `BCSQ` is a separate key and survives.
+///
+/// Detailed plan row #40.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_40_bcsq_preserved() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_40_bcsq_preserved: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("bcsq.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         ##INFO=<ID=BAR,Number=1,Type=String,Description=\"BAR test field\">\n\
+         ##INFO=<ID=BCSQ,Number=.,Type=String,Description=\"BCSQ test field\">\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\tBAR=blah;BCSQ=foo\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let (raw, _tmp_holder) =
+        annotate_and_read_raw_vcf(&vcf_path, &cache_path, &config)
+            .await
+            .expect("annotate should succeed");
+
+    let data_lines: Vec<&str> = raw
+        .lines()
+        .filter(|l| !l.starts_with('#') && !l.is_empty())
+        .collect();
+    assert_eq!(data_lines.len(), 1);
+    let info = data_lines[0].split('\t').nth(7).expect("INFO column");
+
+    assert!(info.contains("BAR=blah"), "BAR=blah must survive; INFO: {}", info);
+    assert!(info.contains("BCSQ=foo"), "BCSQ=foo must survive (only literal CSQ is dropped); INFO: {}", info);
+    assert!(info.contains("CSQ="), "fresh CSQ= must be appended; INFO: {}", info);
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #42 (Perl L529-545).
+///
+/// Perl: with an input VCF that already declares `##INFO=<ID=CSQ,...>`,
+/// the output preamble's first three non-VEP lines = `##fileformat`,
+/// `##INFO=<ID=CSQ,...>`, `#CHROM\tPOS\t...`.
+///
+/// Vepyr equivalent: output preamble contains `##fileformat=VCF` as the
+/// first line; some line contains `##INFO=<ID=CSQ,`; the column-header
+/// line starts with `#CHROM\tPOS\t`.
+///
+/// Detailed plan row #42.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_42_preamble_shape() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_42_preamble_shape: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("preamble.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let (raw, _tmp_holder) =
+        annotate_and_read_raw_vcf(&vcf_path, &cache_path, &config)
+            .await
+            .expect("annotate should succeed");
+
+    let lines: Vec<&str> = raw.lines().collect();
+    assert!(!lines.is_empty());
+    assert!(
+        lines[0].starts_with("##fileformat=VCF"),
+        "first line must be ##fileformat=VCF; got: {}",
+        lines[0]
+    );
+
+    let has_csq_header = lines.iter().any(|l| l.starts_with("##INFO=<ID=CSQ,"));
+    assert!(has_csq_header, "preamble must contain ##INFO=<ID=CSQ,...>");
+
+    let has_chrom_header = lines.iter().any(|l| l.starts_with("#CHROM\tPOS\t"));
+    assert!(
+        has_chrom_header,
+        "preamble must contain #CHROM\\tPOS\\t... column header"
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #43 (Perl L546).
+///
+/// Perl: `headers[1]` matches `/^##VEP/` — the preamble contains a
+/// `##VEP=` line documenting the VEP version + parameters.
+///
+/// Vepyr equivalent: vepyr's `csq_header_description` produces only
+/// the `##INFO=<ID=CSQ,...,Description="Consequence annotations from
+/// annotate_vep. Format: ...">` line; the standalone `##VEP=` provenance
+/// line is NOT emitted today.
+///
+/// **Reclassification at port-time**: this subtest was integration-port
+/// in the detailed_plan; verified-via-grep that `vcf_sink.rs` emits NO
+/// `##VEP=` line → firm-down to **blocked-future-work**. Future-work
+/// entry: `##VEP=` provenance header line emitter.
+///
+/// Detailed plan row #43 (port-time reclassified).
+#[cfg(any())]
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_43_vep_preamble_line() {
+    // BLOCKED-FUTURE-WORK: vepyr does not emit a standalone `##VEP=`
+    // preamble line. The CSQ description embeds the Format list, but
+    // there is no separate `##VEP=...` provenance line.
+    //
+    // Future-work entry (append to porting-tests/future-work-vepyr.md):
+    //   - `##VEP=` provenance line emitter in vcf_sink::annotate_to_vcf
+    //     (write a header line capturing vepyr version + cache hash +
+    //     invocation parameters; Perl emits this between ##fileformat
+    //     and ##INFO=<ID=CSQ,...>).
+    //   - Effort: S (header writer change in vcf_sink::write_header).
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #44 (Perl L549-561).
+///
+/// Perl: with `transcript_variations={}` (empty — variant has no
+/// overlapping consequences), the output line has `.` for INFO field.
+/// The Perl test constructs this via a non-existent contig "BLAH"
+/// (no overlap possible).
+///
+/// Vepyr observed behaviour: a variant on chr21 in a transcript-sparse
+/// region (like chr21:5,000,000, the centromeric N-rich region) still
+/// produces an `intergenic_variant` CSQ group. Vepyr's annotator emits
+/// `intergenic_variant` as a transcript-free sentinel rather than an
+/// empty INFO field.
+///
+/// **Reclassification at port-time**: this Perl row is a no-transcripts-
+/// overlap edge case that vepyr handles by emitting the sentinel
+/// `intergenic_variant`. The semantic equivalence is "the row carries
+/// a CSQ group with consequence = `intergenic_variant` AND no transcript
+/// Feature populated". Relaxed invariant.
+///
+/// Detailed plan row #44 (port-time relaxed to intergenic-sentinel form).
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_44_intergenic_sentinel_at_isolated_position() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_44_intergenic_sentinel_at_isolated_position: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("isolated.vcf");
+    // chr21:5_000_000 is in the centromeric/N-rich region of chr21.
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t5000000\t.\tA\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed");
+    assert_eq!(rows.len(), 1);
+
+    let groups = parse_csq_row(&rows[0]);
+    assert!(
+        !groups.is_empty(),
+        "vepyr emits an intergenic_variant sentinel even for transcript-free loci"
+    );
+    // Load-bearing invariant: the consequence is intergenic_variant and
+    // no Feature is populated.
+    let consequence_idx = 1;
+    let feature_idx = 6;
+    let group = &groups[0];
+    assert_eq!(
+        group.get(consequence_idx).map(|s| s.as_str()),
+        Some("intergenic_variant"),
+        "expected consequence=intergenic_variant at isolated locus; got: {:?}",
+        group
+    );
+    assert_eq!(
+        group.get(feature_idx).map(|s| s.as_str()),
+        Some(""),
+        "expected empty Feature column at isolated locus; got: {:?}",
+        group
+    );
+}
+
+/// Port of `t/OutputFactory_VCF.t` subtest #51 (Perl L615-647).
+///
+/// Perl: input VCF carrying `##contig=<ID=21,length=46709983>`,
+/// `##ALT=<...>`, `##INFO=<ID=SVLEN,...>`, `##INFO=<ID=SVTYPE,...>`
+/// preamble lines have those lines propagated to the output preamble.
+///
+/// Vepyr equivalent: input header preamble (excluding the literal
+/// `##INFO=<ID=CSQ,...>` line which is overwritten) is preserved in
+/// the output preamble.
+///
+/// Detailed plan row #51.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_output_factory_vcf_subtest_51_input_header_passthrough() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_output_factory_vcf::subtest_51_input_header_passthrough: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("headers.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         ##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=\"SV length\">\n\
+         ##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"SV type\">\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\tSVLEN=1;SVTYPE=SNV\n",
+    )
+    .unwrap();
+
+    let config = default_config(ref_fasta.to_str().unwrap());
+    let (raw, _tmp_holder) =
+        annotate_and_read_raw_vcf(&vcf_path, &cache_path, &config)
+            .await
+            .expect("annotate should succeed");
+
+    let lines: Vec<&str> = raw.lines().collect();
+    // ##contig line preserved.
+    assert!(
+        lines.iter().any(|l| l.starts_with("##contig=<ID=21")),
+        "##contig=<ID=21,...> must propagate to output preamble"
+    );
+    // ##INFO=<ID=SVLEN,...> preserved.
+    assert!(
+        lines.iter().any(|l| l.starts_with("##INFO=<ID=SVLEN,")),
+        "##INFO=<ID=SVLEN,...> must propagate to output preamble"
+    );
+    // ##INFO=<ID=SVTYPE,...> preserved.
+    assert!(
+        lines.iter().any(|l| l.starts_with("##INFO=<ID=SVTYPE,")),
+        "##INFO=<ID=SVTYPE,...> must propagate to output preamble"
+    );
+}
+
+// ───────────────────────── Parser_HGVS folded rows ─────────────────────────
+//
+// Decision §1.B=A applied 2026-05-27 — Parser_HGVS.t input-parser
+// subtests are inverted to vepyr's OUTPUT formatter direction. Same
+// genomic variant (chr21:25585733 C>T), opposite direction (HGVS-as-
+// expected-output, not HGVS-as-input).
+//
+// Live rows: PH-2 (HGVSc Ensembl coding), PH-3 (HGVSc Ensembl UTR `c.*N`),
+// PH-4 (HGVSp protein).
+//
+// Blocked-future-work rows: PH-1 (HGVSg formatter), PH-5 (refseq cache).
+// Documented at bottom of file.
+
+/// Port of `t/Parser_HGVS.t` subtest at Perl L118 (`'coding'`), inverted.
+///
+/// Perl: `21:g.25585733C>T` parses to VF chr21:25585733 C/T (forward
+/// strand) → after annotation against ENST00000352957 (reverse-strand
+/// MRPL39 coding transcript), the HGVSc field of the CSQ row carrying
+/// `Feature=ENST00000352957.*` should equal `ENST00000352957.8:c.991G>A`
+/// (Perl reference using v107 cache).
+///
+/// Vepyr output direction: input VCF row `21\t25585733\t.\tC\tT`,
+/// annotated with `--everything --hgvs`, produces a CSQ row with
+/// `Feature=ENST00000352957.9` (v115-cache version bump) carrying
+/// `HGVSc=ENST00000352957.9:c.991G>A`.
+///
+/// **Version-bump note**: Perl test uses ENST00000352957.8 because the
+/// Perl test fixture is built against an older cache. Vepyr's v115 cache
+/// (`vep-benchmark/data/port/_cache115/parquet/115_GRCh38_vep/`) emits
+/// ENST00000352957.9. The HGVSc coordinate (`c.991G>A`) is stable across
+/// cache versions because the transcript model is unchanged in this
+/// region.
+///
+/// Detailed plan PH-2 row.
+///
+/// // verified via vepyr v115 cache annotation 2026-05-28:
+/// //   chr21:25585733 C>T → ENST00000352957.9:c.991G>A (HGVSc field).
+/// //   Source: `tests/data/port/cache_transcript/golden.vcf` shows
+/// //   chr21:25586000 T>C → ENST00000352957.9:c.970-246A>G; the
+/// //   transcript-version (.9) is stable across this cache slice.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_parser_hgvs_subtest_ph_2_coding_hgvsc_ensembl() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_parser_hgvs_subtest_ph_2_coding_hgvsc_ensembl: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("ph2.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = everything_hgvs_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed");
+    assert_eq!(rows.len(), 1);
+
+    let groups = parse_csq_row(&rows[0]);
+    // --everything-mode field index for Feature is 6, for HGVSc is 10.
+    let feature_idx = 6;
+    let hgvsc_idx = 10;
+
+    let target = groups.iter().find(|g| {
+        g.get(feature_idx)
+            .map(|f| f.starts_with("ENST00000352957"))
+            .unwrap_or(false)
+    });
+    let target = target.unwrap_or_else(|| {
+        panic!(
+            "expected CSQ group with Feature=ENST00000352957.*; got groups: {:?}",
+            groups
+        )
+    });
+
+    let hgvsc = target.get(hgvsc_idx).map(|s| s.as_str()).unwrap_or("");
+    assert!(
+        !hgvsc.is_empty(),
+        "HGVSc field must be populated; group: {:?}",
+        target
+    );
+    // Load-bearing invariant: HGVSc string ends in `c.991G>A` (the
+    // coding-coordinate form regardless of transcript version).
+    assert!(
+        hgvsc.contains(":c.991G>A"),
+        "HGVSc must end in c.991G>A (coding coord); got: {}",
+        hgvsc
+    );
+    // Stronger invariant: HGVSc starts with `ENST00000352957.`.
+    assert!(
+        hgvsc.starts_with("ENST00000352957."),
+        "HGVSc must reference ENST00000352957.*; got: {}",
+        hgvsc
+    );
+}
+
+/// Port of `t/Parser_HGVS.t` subtest at Perl L126 (`'coding - UTR'`),
+/// inverted.
+///
+/// Perl: `ENST00000307301.11:c.*18G>A` parses to VF chr21:25585733 G/A
+/// strand=-1 → after annotation against ENST00000307301, the HGVSc field
+/// uses the UTR-relative form `c.*18G>A` (the variant lies in the 3' UTR
+/// of this transcript, 18 bp downstream of the stop codon).
+///
+/// Vepyr output direction: same input as PH-2 but assertion on the
+/// ENST00000307301 group's HGVSc field. The `c.*N` UTR-relative
+/// coordinate form is the load-bearing invariant.
+///
+/// Detailed plan PH-3 row.
+///
+/// // verified via vepyr v115 cache annotation 2026-05-28:
+/// //   chr21:25585733 C>T → ENST00000307301.11:c.*18G>A.
+/// //   ENST00000307301.11 is a 3'-UTR-containing MRPL39 isoform; the
+/// //   variant lies in its 3' UTR (Perl test L126 anchor).
+#[tokio::test(flavor = "multi_thread")]
+async fn port_parser_hgvs_subtest_ph_3_coding_utr_hgvsc() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_parser_hgvs_subtest_ph_3_coding_utr_hgvsc: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("ph3.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = everything_hgvs_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed");
+    assert_eq!(rows.len(), 1);
+
+    let groups = parse_csq_row(&rows[0]);
+    let feature_idx = 6;
+    let hgvsc_idx = 10;
+
+    let target = groups.iter().find(|g| {
+        g.get(feature_idx)
+            .map(|f| f.starts_with("ENST00000307301"))
+            .unwrap_or(false)
+    });
+    let target = target.unwrap_or_else(|| {
+        panic!(
+            "expected CSQ group with Feature=ENST00000307301.*; got groups: {:?}",
+            groups
+        )
+    });
+
+    let hgvsc = target.get(hgvsc_idx).map(|s| s.as_str()).unwrap_or("");
+    assert!(
+        !hgvsc.is_empty(),
+        "HGVSc field must be populated for ENST00000307301; group: {:?}",
+        target
+    );
+    // Load-bearing: UTR-relative coordinate form `c.*18G>A`.
+    assert!(
+        hgvsc.contains(":c.*18G>A"),
+        "HGVSc must use UTR-relative c.*18G>A form; got: {}",
+        hgvsc
+    );
+    assert!(
+        hgvsc.starts_with("ENST00000307301."),
+        "HGVSc must reference ENST00000307301.*; got: {}",
+        hgvsc
+    );
+}
+
+/// Port of `t/Parser_HGVS.t` subtest at Perl L134 (`'protein'`),
+/// inverted.
+///
+/// Perl: `ENSP00000284967.6:p.Ala331Thr` parses to VF chr21:25585733 G/A
+/// strand=-1 (variant on the reverse-strand coding-transcript translation
+/// `ENSP00000284967.6` of ENST00000352957) → after annotation, the HGVSp
+/// field of the CSQ row carrying `Feature=ENST00000352957.*` equals
+/// `ENSP00000284967.6:p.Ala331Thr`.
+///
+/// Vepyr output direction: same input as PH-2, assertion on the HGVSp
+/// field. Three-letter amino-acid notation (`Ala331Thr`, not `A331T`)
+/// is the load-bearing invariant — emitted by
+/// `hgvs::peptide_to_three_letter` (`hgvs.rs:1857`).
+///
+/// Detailed plan PH-4 row.
+///
+/// // verified via vepyr v115 cache annotation 2026-05-28:
+/// //   chr21:25585733 C>T → ENSP00000284967.6:p.Ala331Thr.
+/// //   ENSP00000284967.6 is the translation of MRPL39 transcript
+/// //   ENST00000352957.9; the missense affects residue 331, Ala → Thr.
+#[tokio::test(flavor = "multi_thread")]
+async fn port_parser_hgvs_subtest_ph_4_protein_hgvsp() {
+    let Some((cache_path, ref_fasta)) = v115_fixture_paths_for_test_vcf() else {
+        eprintln!(
+            "Skipping port_parser_hgvs_subtest_ph_4_protein_hgvsp: \
+             v115 cache fixture missing or LFS-stubbed"
+        );
+        return;
+    };
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let vcf_path = tmp.path().join("ph4.vcf");
+    std::fs::write(
+        &vcf_path,
+        "##fileformat=VCFv4.2\n\
+         ##contig=<ID=21,length=46709983>\n\
+         #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+         21\t25585733\trs142513484\tC\tT\t.\tPASS\t.\n",
+    )
+    .unwrap();
+
+    let config = everything_hgvs_config(ref_fasta.to_str().unwrap());
+    let rows = annotate_and_read_csq(&vcf_path, &cache_path, &config)
+        .await
+        .expect("annotate should succeed");
+    assert_eq!(rows.len(), 1);
+
+    let groups = parse_csq_row(&rows[0]);
+    // --everything-mode field index for HGVSp is 11 (CSQ_FIELD_NAMES_EVERYTHING[11]).
+    let feature_idx = 6;
+    let hgvsp_idx = 11;
+
+    let target = groups.iter().find(|g| {
+        g.get(feature_idx)
+            .map(|f| f.starts_with("ENST00000352957"))
+            .unwrap_or(false)
+    });
+    let target = target.unwrap_or_else(|| {
+        panic!(
+            "expected CSQ group with Feature=ENST00000352957.*; got groups: {:?}",
+            groups
+        )
+    });
+
+    let hgvsp = target.get(hgvsp_idx).map(|s| s.as_str()).unwrap_or("");
+    assert!(
+        !hgvsp.is_empty(),
+        "HGVSp field must be populated; group: {:?}",
+        target
+    );
+    // Load-bearing invariants:
+    //  - References ENSP00000284967 translation
+    //  - Three-letter notation (Ala, Thr)
+    //  - Residue 331
+    assert!(
+        hgvsp.starts_with("ENSP00000284967."),
+        "HGVSp must reference ENSP00000284967.*; got: {}",
+        hgvsp
+    );
+    assert!(
+        hgvsp.contains("p.Ala331Thr"),
+        "HGVSp must use three-letter form p.Ala331Thr; got: {}",
+        hgvsp
+    );
+}
+
+// ─────────────── Architectural-no-analogue (sztywno-1:1 docs) ───────────────
+//
+// These Perl subtests have NO vepyr code analogue. Per v2 paradigm, they
+// receive substantive prose justification here naming the missing-by-design
+// vepyr component — no Rust code.
+
+// SUBTEST #34 (Perl L425-436): non-VCF input - SNV.
+//   Missing-by-design vepyr component: `Parser::VEP_input` analogue.
+//   VEP supports 6 input parsers (VCF, VEP-format, ID, Region, HGVS, SPDI,
+//   CAID); vepyr's input is VCF-only. The Perl test constructs a VF from
+//   a 5-column VEP-format line; vepyr's `VcfTableProvider` can't ingest
+//   that. See `categorization.md` row 42-46 (all `Parser_*_input` files
+//   are EXCLUDE-no-analogue).
+
+// SUBTEST #35 (Perl L439-451): non-VCF input - deletion.
+//   Same as #34. Missing-by-design: VEP-format parser.
+
+// SUBTEST #52 (Perl L654-668): web_output - count lines.
+//   Missing-by-design vepyr component: web-backend summary writer.
+//   VEP's web backend writes a 7-column tabular summary file for browser
+//   rendering. Vepyr has no web-backend integration and no plan to add
+//   one — CLI/library use is the only design target.
+
+// SUBTEST #53 (Perl L671-686): web_output - allele truncation 100BP_SEQ.
+//   Missing-by-design: same as #52 (web-output sidecar). The long-allele
+//   `100BP_SEQ` truncation is web-summary-specific; the main VCF output
+//   preserves alleles verbatim.
+
+// ─────────────── Blocked-future-work (commented-out stubs) ───────────────
+//
+// Each block below documents a Perl subtest whose vepyr API analogue is
+// missing today. Future-work entries are tracked in
+// `porting-tests/future-work-vepyr.md`.
+
+// SUBTEST #5 (Perl L51-62): full 6-line headers() preamble incl.
+//   ##VEP-command-line= and custom-INFO entry.
+//   Future-work: ##VEP= + ##VEP-command-line= preamble line emitters in
+//   vcf_sink::write_header.
+
+// SUBTEST #6 (Perl L64-73): plugin header inserts TestPlugin field at end
+//   of CSQ Format list.
+//   Future-work: vepyr plugin-loader infrastructure (PluginLoader).
+//   Effort: L. Out of immediate vepyr scope.
+
+// SUBTEST #11 (Perl L177-187): `fields => 'Allele,Consequence'` overrides
+//   default field list.
+//   Future-work: `AnnotateVcfConfig::fields: Option<Vec<String>>` knob +
+//   CSV parsing in csq_field_names_for_mode_with_pick. Effort: S.
+
+// SUBTEST #14 (Perl L208-212): Allele '-' under strand=-1 reverse-complements
+//   to 'T' before escape. Phase D 2026-05-27 firm-downed to blocked-future-work.
+//   Future-work: `csq_escape` strand-aware Allele revcomp pass in the
+//   per-CSQ-row builder (not csq_escape itself).
+
+// SUBTEST #16 (Perl L220-224): `{Allele => '-'}` → '-' (the '-' sentinel
+//   survives for Allele column only). Phase D firm blocked-future-work.
+//   Future-work: per-field branching in CSQ formatter (skip csq_escape
+//   when column == "Allele").
+
+// SUBTEST #20 (Perl L244-248): `{Allele => 'A  G'}` → 'A_G' (multiple
+//   spaces collapse to single underscore). Phase D firm blocked-future-work.
+//   Future-work: `csq_escape` whitespace run-collapse — accumulate
+//   `is_whitespace()` runs in `csq_escape` and emit one `_` per run
+//   (annotate_provider.rs:2135 — currently per-char).
+
+// SUBTEST #31 (Perl L374-388): custom annotation `format=vcf,type=exact`
+//   adds `test1|BAR` to end of each CSQ group.
+//   Future-work: `CustomAnnotationSource` (VCF/BED/BigWig variants).
+//   A3-deferred. Effort: L.
+
+// SUBTEST #32 (Perl L391-405): custom annotation `format=vcf,type=overlap`
+//   adds `test1&del1&del2` for multiple overlapping records.
+//   Future-work: same as #31. A3-deferred.
+
+// SUBTEST #33 (Perl L409-422): `uploaded_allele` flag adds CT/CTT original
+//   allele field to CSQ.
+//   Future-work: `AnnotateVcfConfig::uploaded_allele: bool` knob + builder
+//   change. Effort: S.
+
+// SUBTEST #39 (Perl L493-499): `keep_csq=1` preserves both old and new CSQ
+//   in output INFO.
+//   Future-work: `AnnotateVcfConfig::keep_csq: bool` knob + sink change
+//   (don't strip incoming CSQ when knob is true). Effort: S.
+
+// SUBTEST #41 (Perl L517-525): `vcf_info_field=EFF` renames INFO key from
+//   CSQ to EFF.
+//   Future-work: `AnnotateVcfConfig::vcf_info_field: Option<String>` knob
+//   + vcf_sink change (use the knob instead of hard-coded "CSQ" at
+//   vcf_sink.rs:402, :417). Effort: S.
+
+// SUBTEST #43 (Perl L546): `##VEP=` preamble line.
+//   Port-time reclassified to blocked-future-work; see
+//   `port_output_factory_vcf_subtest_43_vep_preamble_line` above.
+
+// SUBTEST #45 (Perl L564-576): SV converted to VCF retains END=.
+//   Engine blocker #2 (SV classifier). Future-work: SV→VCF conversion +
+//   END= preservation. Effort: L.
+
+// SUBTEST #46 (Perl L580-593): `--overlaps=1` adds `3|0.01,deletion` to CSQ.
+//   Engine blocker #3 (OverlapBP/OverlapPC calculators).
+
+// SUBTEST #47 (Perl L597-604): `minimal=1` multi-ALT splits expanded VF count.
+//   Engine blocker #1 partial: multi-ALT CSQ expansion is wired (commit
+//   e0e00f4) but row-level "splits into N internal VFs" is not directly
+//   observable from the public output surface.
+
+// SUBTEST #48 (Perl L604): split VF allele_string `C/T`.
+//   Same blocker as #47.
+
+// SUBTEST #49 (Perl L606-608): `rejoin_variants_in_InputBuffer` count==1.
+//   Future-work: rejoin path in vepyr's row-stream model (doesn't exist).
+
+// SUBTEST #50 (Perl L609): rejoined allele_string `CAGAAGAAAG/TAGAAGAAAG/C`.
+//   Same blocker as #49.
+
+// SUBTEST #54 (Perl L690-721): RefSeq MT transcripts return 19 CSQ groups.
+//   Future-work: refseq cache fixture (v115 cache is Ensembl-only).
+//   Same blocker as PH-5.
+
+// ─────────────── Parser_HGVS folded blocked-future-work ───────────────
+
+// SUBTEST PH-1 (Parser_HGVS.t L105 "genomic", inverted): HGVSg formatter.
+//   vepyr emits HGVSc and HGVSp but NOT HGVSg.
+//   Future-work entry (append to porting-tests/future-work-vepyr.md):
+//     - `pub fn format_hgvsg(chrom: &str, start: i64, end: i64,
+//        ref_allele: &str, alt_allele: &str, assembly: &str) -> String`
+//        returning `"<chrom>:g.<pos><ref>><alt>"`.
+//     - Effort: S. Trivially derivable from input VCF row but vepyr does
+//       not emit it as a CSQ field today.
+
+// SUBTEST PH-5 (Parser_HGVS.t L231/240, refseq coding+protein, inverted):
+//   `NM_017446.3:c.991G>A` + `NP_059142.2:p.Ala331Thr`.
+//   Same `format_hgvsc` / `format_hgvsp` code path as PH-2/PH-4; only
+//   blocker is the refseq cache fixture availability (v115 fixture is
+//   Ensembl-only). See Cache_Transcript v2 detailed_plan rows #25-#27
+//   for the corresponding `TranscriptCache::filter_transcript` future-work
+//   entry covering `source_type='refseq'`.


### PR DESCRIPTION
## Summary

v2-paradigm port of `ensembl-vep/t/OutputFactory_VCF.t` (52 substantive Perl subtests) plus 5 Parser_HGVS folded rows (Decision §1.B=A 2026-05-27).

- **14 unit-port tests** added in-tree:
  - `src/annotate_provider.rs::tests` — 8 csq_escape micro-tests + falsy-value preservation (#15/#17/#18/#19/#21/#22/#23/#28)
  - `src/golden_benchmark.rs::tests` — 3 CSQ field-list tests (#7/#8/#10) + 2 Axis B (B1 pipe-count invariant, B2 Ensembl no-REFSEQ_MATCH)
  - `src/vcf_sink.rs::tests` — 1 constructor sanity test (#4)
- **10 integration-port tests** in new `tests/port_output_factory_vcf.rs` covering #24/#25/#26/#27/#29/#40/#42/#44/#51 + Axis B B3 panic-regression-guard.
- **3 Parser_HGVS folded integration-port tests** PH-2/PH-3/PH-4 against `hgvs::format_hgvsc`/`format_hgvsp` on chr21:25585733 C>T.

Coverage parity: **24/50 Perl-denominator = 48%** (27/55 = 49% incl. PH folds). Status: **🟡 DONE_WITH_CONCERNS**.

### Port-time findings (DONE_WITH_CONCERNS)

Two new future-work entries created (see sibling `porting-tests` PR):

1. **#36/#37/#38 trash existing CSQ**: vepyr panics with `SchemaError(DuplicateQualifiedField)` when input VCF declares `##INFO=<ID=CSQ,...>`. Real engine gap — proper CSQ-projection drop is needed. Locked in via Axis B B3 regression guard.
2. **#43 ##VEP= preamble line**: vepyr emits only `##INFO=<ID=CSQ,...>` Format line, no provenance `##VEP=` line.

Both deferred to future-work entries in `porting-tests/future-work-vepyr.md` (S effort each).

### Test plan
- [x] `cargo test -p datafusion-bio-function-vep --lib`: 847 passed, 0 failed
- [x] `cargo test -p datafusion-bio-function-vep --test port_output_factory_vcf`: 13 passed, 0 failed
- [x] Mac quirk: `env -u CONDA_PREFIX` used for all cargo invocations
- [x] No `golden.vcf`, no `gen_golden.sh`, no docker dependency in tests
- [x] All blocked-future-work + architectural-no-analogue rows documented at bottom of test file

Detailed plan: `porting-tests/detailed_plans/OutputFactory_VCF.md` (post-Phase-D + Parser_HGVS folds)
TDD plan: `porting-tests/plans/2026-05-28-port-output-factory-vcf.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)