### PR TITLE
VEP: pipelined per-contig shard assembler (plain + bgzf) + serial-path truncation fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,8 +1246,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.8.7"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.7#a6f79686f1a64a42bb36ba6d90dff343eb953d0e"
+version = "1.8.8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1268,12 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.8.7"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.7#a6f79686f1a64a42bb36ba6d90dff343eb953d0e"
+version = "1.8.8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.8.7",
+ "datafusion-bio-format-core 1.8.8",
  "datafusion-execution",
  "flate2",
  "log",
@@ -1286,15 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.8.7"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.7#a6f79686f1a64a42bb36ba6d90dff343eb953d0e"
+version = "1.8.8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.8.7",
+ "datafusion-bio-format-core 1.8.8",
  "datafusion-execution",
  "env_logger",
  "flate2",

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -29,8 +29,8 @@ serde = { version = "1", features = ["derive"] }
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf ={ git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.7" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.7", optional = true }
+datafusion-bio-format-vcf ={ git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8", optional = true }
 indicatif = "0.18.4"
 
 [dev-dependencies]

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9517,6 +9517,10 @@ struct ParallelContigState {
     join_fut: ShardJoinFuture,
     /// Abort handles for the shard workers (error / drop cleanup).
     abort_handles: Vec<tokio::task::AbortHandle>,
+    /// First global shard id owned by this contig (inclusive). The exclusive end
+    /// is `next_global_shard_id` at contig completion. Published as a
+    /// `ContigShardRange` to the assembler when the contig finishes.
+    contig_first_shard_id: usize,
     /// Per-partition lookup worker tasks (aborted on cleanup).
     lookup_join: Vec<tokio::task::JoinHandle<Result<()>>>,
     ephemeral_tables: Vec<String>,
@@ -9601,7 +9605,8 @@ type PrepareFuture = Pin<Box<dyn Future<Output = Result<Option<ContigReadyState>
 type CleanupFuture = Pin<Box<dyn Future<Output = Result<()>> + Send>>;
 /// Resolves when all `threads>1` shard workers for a contig have finished,
 /// yielding the total output-row count (or the first worker error).
-type ShardJoinFuture = Pin<Box<dyn Future<Output = Result<usize>> + Send>>;
+// (input_rows, output_body_lines) summed across the contig's shard workers.
+type ShardJoinFuture = Pin<Box<dyn Future<Output = Result<(usize, usize)>> + Send>>;
 
 enum StreamState {
     StartContig,
@@ -9901,6 +9906,11 @@ where
 /// accounting). On error the shard may be left partially written; the
 /// orchestrator aborts the sibling workers and surfaces the error before any
 /// concat, so no partial shard is ever assembled.
+pub(crate) struct ShardResult {
+    pub(crate) input_rows: usize,
+    pub(crate) output_lines: usize,
+}
+
 fn spawn_annotation_from_lookup_sharded(
     shared: Arc<SharedContigAnnotationContext>,
     mut lookup_rx: tokio::sync::mpsc::Receiver<Result<LookupBatchMessage>>,
@@ -9910,7 +9920,7 @@ fn spawn_annotation_from_lookup_sharded(
     shard_ctx: Arc<crate::vcf_sink::VcfShardContext>,
     shard_path: std::path::PathBuf,
     slice: Option<WorkerGridSlice>,
-) -> tokio::task::JoinHandle<Result<usize>> {
+) -> tokio::task::JoinHandle<Result<ShardResult>> {
     tokio::spawn(async move {
         let mut worker = AnnotationWorkerState::new(shared)?;
         let mut shard = crate::vcf_sink::VcfBodyShardWriter::create(
@@ -9919,6 +9929,7 @@ fn spawn_annotation_from_lookup_sharded(
             Arc::clone(&shard_ctx.unique_format_tags),
             Arc::clone(&shard_ctx.sample_names),
             shard_ctx.coordinate_zero_based,
+            shard_ctx.shard_compression,
         )?;
         // Grid bounds (global row ranks). The worker's stream is its
         // [scan_lo_pos, scan_hi_pos) window; its first row is rank `warm_up_start`
@@ -10039,10 +10050,14 @@ fn spawn_annotation_from_lookup_sharded(
                 peak_rss_mb(),
             );
         }
-        let rows = shard.input_rows;
+        let input_rows = shard.input_rows;
+        let output_lines = shard.lines;
         let _ = (emit_start, emit_end, global_row);
         shard.finish()?;
-        Ok(rows)
+        Ok(ShardResult {
+            input_rows,
+            output_lines,
+        })
     })
 }
 
@@ -11568,8 +11583,13 @@ impl Stream for ContigAnnotationStream {
                             let mut handles: Vec<LookupPartitionHandle> =
                                 ready.lookup_partitions.drain(..).collect();
                             handles.sort_by_key(LookupPartitionHandle::partition_id);
-                            let mut shard_handles: Vec<tokio::task::JoinHandle<Result<usize>>> =
-                                Vec::with_capacity(handles.len());
+                            // First shard id this contig owns (inclusive). The
+                            // exclusive end is `next_global_shard_id` after the
+                            // loop; published as a `ContigShardRange` on completion.
+                            let contig_first_shard_id = self.next_global_shard_id;
+                            let mut shard_handles: Vec<
+                                tokio::task::JoinHandle<Result<ShardResult>>,
+                            > = Vec::with_capacity(handles.len());
                             let mut lookup_join = Vec::with_capacity(handles.len());
                             let mut inline_seen = false;
                             for mut handle in handles {
@@ -11622,10 +11642,14 @@ impl Stream for ContigAnnotationStream {
                             // dropped on error, detaching the rest — abort_handles
                             // aborts the still-running siblings).
                             let join_fut: ShardJoinFuture = Box::pin(async move {
-                                let mut total = 0usize;
+                                let mut input_rows = 0usize;
+                                let mut output_lines = 0usize;
                                 for h in shard_handles {
                                     match h.await {
-                                        Ok(Ok(rows)) => total += rows,
+                                        Ok(Ok(r)) => {
+                                            input_rows += r.input_rows;
+                                            output_lines += r.output_lines;
+                                        }
                                         Ok(Err(e)) => return Err(e),
                                         Err(join_err) => {
                                             return Err(DataFusionError::External(Box::new(
@@ -11634,11 +11658,12 @@ impl Stream for ContigAnnotationStream {
                                         }
                                     }
                                 }
-                                Ok(total)
+                                Ok((input_rows, output_lines))
                             });
                             let state = ParallelContigState {
                                 join_fut,
                                 abort_handles,
+                                contig_first_shard_id,
                                 lookup_join,
                                 ephemeral_tables: ready.ephemeral_tables,
                                 chrom: ready.chrom,
@@ -11694,10 +11719,25 @@ impl Stream for ContigAnnotationStream {
                             self.state = StreamState::AnnotatingParallel(state);
                             return Poll::Pending;
                         }
-                        Poll::Ready(Ok(contig_rows)) => {
+                        Poll::Ready(Ok((contig_rows, contig_lines))) => {
                             // Lookups have all closed by now; abort any stragglers.
                             for h in &state.lookup_join {
                                 h.abort();
+                            }
+                            // Publish this contig's completed shard-id range to the
+                            // assembler thread so it can concat these shards while
+                            // the next contig prepares/annotates. `end` is the
+                            // current global counter (later contigs not yet
+                            // allocated). Best-effort: if the assembler is gone
+                            // (error teardown), ignore.
+                            if let Some(shard_ctx) = state.config.vcf_shard_ctx.clone() {
+                                let _ = shard_ctx.contig_done_tx.send(
+                                    crate::vcf_sink::ContigShardRange {
+                                        first_shard_id: state.contig_first_shard_id,
+                                        end_shard_id: self.next_global_shard_id,
+                                        output_lines: contig_lines,
+                                    },
+                                );
                             }
                             profile_end!(
                                 &format!("{}: TOTAL", state.chrom),

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -11417,6 +11417,18 @@ fn poll_lookup_fan_in(
     Poll::Pending
 }
 
+/// Whether `poll_lookup_partitions` may hand control back to the outer serial
+/// loop with a partially-filled (sub-window) buffer when the lookup stalls
+/// (Poll::Pending) after this poll already grabbed >=1 batch. Safe ONLY when
+/// there is in-flight annotation work the outer loop can drain — then it makes
+/// progress and re-polls the lookup. With nothing in flight, yielding a partial
+/// buffer is misread as "contig done" (no full window + empty inflight), which
+/// aborts the still-running lookup and truncates the contig; the caller must
+/// park with a waker (`start_lookup_waits` + Poll::Pending) and keep pulling.
+fn may_yield_partial_buffer(made_progress: bool, has_inflight: bool) -> bool {
+    made_progress && has_inflight
+}
+
 fn poll_lookup_partitions(
     ann: &mut ContigAnnotationState,
     cx: &mut TaskCtx<'_>,
@@ -11442,7 +11454,10 @@ fn poll_lookup_partitions(
             Poll::Pending => {
                 record_lookup_fan_in_profile(&profile, &ann.lookup_partitions);
                 let ordered_blocked = ann.lookup_partitions.has_buffered_after_next();
-                if made_progress {
+                // Only yield a partial buffer when there is in-flight work to
+                // drain; otherwise park (below) so the contig resumes when more
+                // lookup batches arrive rather than being falsely finalized.
+                if may_yield_partial_buffer(made_progress, !ann.inflight.is_empty()) {
                     return Poll::Ready(Ok(()));
                 }
                 if ordered_blocked {
@@ -12643,6 +12658,28 @@ mod tests {
     use crate::transcript_consequence::{
         CachedPredictions, FeatureType, ProteinDomainFeature, SiftPolyphenCache, TranslationFeature,
     };
+
+    // Regression: the serial (workers==1) AnnotatingContig loop truncated a
+    // contig at ~one buffer when a lookup stall arrived mid-buffer-fill after the
+    // poll had already grabbed >=1 batch (`made_progress`) with nothing in
+    // flight. `poll_lookup_partitions` returned Ready(Ok(())) with a sub-window
+    // buffer and no waker; the outer loop then saw no full window + empty inflight
+    // and misread it as "contig done", aborting the still-running lookup.
+    //
+    // The gate below decides whether yielding a partial buffer is safe: ONLY when
+    // there is in-flight annotation work the outer loop can drain (so it makes
+    // progress and re-polls). With nothing in flight, the caller MUST park with a
+    // waker instead of yielding — else the contig is falsely finalized.
+    #[test]
+    fn partial_buffer_yield_requires_inflight_work() {
+        // The bug case: progress made, nothing in flight → must NOT yield.
+        assert!(!may_yield_partial_buffer(true, false));
+        // Safe: progress made, in-flight window to drain → yield is fine.
+        assert!(may_yield_partial_buffer(true, true));
+        // No progress → always park (waker armed), regardless of inflight.
+        assert!(!may_yield_partial_buffer(false, false));
+        assert!(!may_yield_partial_buffer(false, true));
+    }
 
     /// `colocated::AF_COL_NAMES` is maintained by hand alongside `AF_COLUMNS`
     /// here, and the two must stay in the same order (the colocated AF lookup

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -659,18 +659,75 @@ const BGZF_EOF: [u8; 28] = [
 
 /// Read a finished bgzf file and return its bytes with the trailing 28-byte EOF
 /// marker removed, ready for raw concatenation into a larger bgzf stream.
+/// Read a small finished bgzf file (the header) whole and return its bytes with
+/// the trailing 28-byte EOF marker removed. Used only for the header, which is
+/// tiny; shards stream via [`append_bgzf_shard`] instead. The EOF check is a real
+/// runtime error (not a `debug_assert`) so it holds in release builds.
 fn bgzf_blocks_no_eof(path: &Path) -> Result<Vec<u8>> {
     let mut bytes = std::fs::read(path).map_err(|e| {
-        DataFusionError::Execution(format!("read bgzf shard {}: {e}", path.display()))
+        DataFusionError::Execution(format!("read bgzf file {}: {e}", path.display()))
     })?;
-    debug_assert!(
-        bytes.len() >= BGZF_EOF.len() && bytes[bytes.len() - BGZF_EOF.len()..] == BGZF_EOF,
-        "bgzf file {} does not end with the canonical EOF marker",
-        path.display()
-    );
-    let keep = bytes.len().saturating_sub(BGZF_EOF.len());
+    if bytes.len() < BGZF_EOF.len() || bytes[bytes.len() - BGZF_EOF.len()..] != BGZF_EOF {
+        return Err(DataFusionError::Execution(format!(
+            "bgzf file {} does not end with the canonical EOF marker",
+            path.display()
+        )));
+    }
+    let keep = bytes.len() - BGZF_EOF.len();
     bytes.truncate(keep);
     Ok(bytes)
+}
+
+/// Append a finished bgzf shard file to `out`, stripping its trailing 28-byte EOF
+/// marker, streaming the body in `buf`-sized chunks so a large shard is never
+/// loaded whole into memory (mirrors the plain assembler's bounded-buffer copy).
+/// Uses the file length to locate the marker, then reads + validates it. Returns
+/// a real runtime error (holds in release) if the shard is shorter than the
+/// marker or does not end with it — never silently truncating corrupt input.
+fn append_bgzf_shard<W: Write>(path: &Path, out: &mut W, buf: &mut [u8]) -> Result<()> {
+    let mut f = std::fs::File::open(path).map_err(|e| {
+        DataFusionError::Execution(format!("assembler open bgzf shard {}: {e}", path.display()))
+    })?;
+    let total = f
+        .metadata()
+        .map_err(|e| {
+            DataFusionError::Execution(format!("assembler stat bgzf shard {}: {e}", path.display()))
+        })?
+        .len();
+    let eof_len = BGZF_EOF.len() as u64;
+    if total < eof_len {
+        return Err(DataFusionError::Execution(format!(
+            "bgzf shard {} is {total} bytes, shorter than the canonical EOF marker",
+            path.display()
+        )));
+    }
+    // Stream the body (everything except the trailing EOF marker) in bounded chunks.
+    let mut remaining = total - eof_len;
+    while remaining > 0 {
+        let want = remaining.min(buf.len() as u64) as usize;
+        f.read_exact(&mut buf[..want]).map_err(|e| {
+            DataFusionError::Execution(format!("assembler read bgzf shard {}: {e}", path.display()))
+        })?;
+        out.write_all(&buf[..want])
+            .map_err(|e| DataFusionError::Execution(format!("assembler write bgzf shard: {e}")))?;
+        remaining -= want as u64;
+    }
+    // Read + validate the trailing EOF marker; never write it (the assembler emits
+    // exactly one canonical EOF at the very end of the assembled file).
+    let mut marker = [0u8; 28]; // == BGZF_EOF.len()
+    f.read_exact(&mut marker).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "assembler read bgzf EOF of {}: {e}",
+            path.display()
+        ))
+    })?;
+    if marker != BGZF_EOF {
+        return Err(DataFusionError::Execution(format!(
+            "bgzf shard {} does not end with the canonical EOF marker",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 /// Dedicated assembler thread for Plain/Gzip output. Owns the header-primed
@@ -688,6 +745,7 @@ fn run_assembler_thread(
     temp_output: PathBuf,
     tempdir: PathBuf,
     rx: std::sync::mpsc::Receiver<ContigShardRange>,
+    finalize: Arc<std::sync::atomic::AtomicBool>,
 ) -> std::thread::JoinHandle<Result<usize>> {
     std::thread::spawn(move || -> Result<usize> {
         let mut total_lines = 0usize;
@@ -717,7 +775,15 @@ fn run_assembler_thread(
             }
             total_lines += range.output_lines;
         }
-        // Sender dropped == annotation finished with no error.
+        // Channel closed. Finalize (finish + atomic rename) ONLY if the driver
+        // signalled success; otherwise the run failed mid-annotation and this temp
+        // holds only the contigs completed before the error — discard it so no
+        // truncated-but-valid-looking VCF is ever renamed into the output path.
+        if !finalize.load(std::sync::atomic::Ordering::Acquire) {
+            drop(writer);
+            let _ = std::fs::remove_file(&temp_output);
+            return Ok(0);
+        }
         writer.finish()?;
         std::fs::rename(&temp_output, &final_output).map_err(|e| {
             DataFusionError::Execution(format!(
@@ -743,6 +809,7 @@ fn run_assembler_thread_bgzf(
     tempdir: PathBuf,
     header_blocks: Vec<u8>,
     rx: std::sync::mpsc::Receiver<ContigShardRange>,
+    finalize: Arc<std::sync::atomic::AtomicBool>,
 ) -> std::thread::JoinHandle<Result<usize>> {
     std::thread::spawn(move || -> Result<usize> {
         let file = std::fs::File::create(&temp_output).map_err(|e| {
@@ -752,16 +819,21 @@ fn run_assembler_thread_bgzf(
         out.write_all(&header_blocks)
             .map_err(|e| DataFusionError::Execution(format!("assembler write header: {e}")))?;
         let mut total_lines = 0usize;
+        let mut buffer = vec![0u8; 8 * 1024 * 1024];
         while let Ok(range) = rx.recv() {
             for id in range.first_shard_id..range.end_shard_id {
                 let path = tempdir.join(format!("partition_{id:04}.vcf.body"));
-                let blocks = bgzf_blocks_no_eof(&path)?;
-                out.write_all(&blocks).map_err(|e| {
-                    DataFusionError::Execution(format!("assembler write shard: {e}"))
-                })?;
+                append_bgzf_shard(&path, &mut out, &mut buffer)?;
                 let _ = std::fs::remove_file(&path);
             }
             total_lines += range.output_lines;
+        }
+        // Channel closed. Discard the partial temp on a mid-run failure (see the
+        // plain assembler) — do NOT write the EOF or rename a truncated file.
+        if !finalize.load(std::sync::atomic::Ordering::Acquire) {
+            drop(out);
+            let _ = std::fs::remove_file(&temp_output);
+            return Ok(0);
         }
         out.write_all(&BGZF_EOF)
             .map_err(|e| DataFusionError::Execution(format!("assembler write EOF: {e}")))?;
@@ -1183,6 +1255,12 @@ pub async fn annotate_to_vcf(
         // Spawn the assembler (owns the output writer); its mode matches the
         // output compression. Header is written BEFORE the field vecs are moved
         // into the shard context.
+        // Set to true only if annotation completes successfully; the assembler
+        // reads it after the channel closes and finalizes (finish + atomic rename)
+        // ONLY when true. On a mid-run error the assembler discards its partial
+        // temp file instead of renaming a truncated-but-valid-looking VCF into the
+        // output path.
+        let finalize = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let assembler = if config.compression == VcfCompressionType::Bgzf {
             // Pre-compress the header into bgzf blocks (strip its EOF); the raw
             // assembler writes those, then the already-compressed shards.
@@ -1203,6 +1281,7 @@ pub async fn annotate_to_vcf(
                 tempdir.path().to_path_buf(),
                 header_blocks,
                 contig_done_rx,
+                Arc::clone(&finalize),
             )
         } else {
             // Plain/Gzip: write the header to the temp writer; the assembler
@@ -1220,6 +1299,7 @@ pub async fn annotate_to_vcf(
                 temp_output.clone(),
                 tempdir.path().to_path_buf(),
                 contig_done_rx,
+                Arc::clone(&finalize),
             )
         };
 
@@ -1233,7 +1313,7 @@ pub async fn annotate_to_vcf(
             rows_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             contig_done_tx,
         });
-        drive_sharded_vcf_annotation(
+        let drive_result = drive_sharded_vcf_annotation(
             &ctx,
             vcf_table,
             cache_source,
@@ -1247,14 +1327,25 @@ pub async fn annotate_to_vcf(
             config,
             total_input,
         )
-        .await?;
+        .await;
+        // Signal the assembler whether to finalize BEFORE closing the channel, so
+        // a mid-run error never renames a partial file into the output path.
+        if drive_result.is_ok() {
+            finalize.store(true, std::sync::atomic::Ordering::Release);
+        }
         // Drop the last sender (the one held on shard_ctx) so the assembler sees
-        // the channel close and finalizes. Any per-contig senders were already
-        // sent-and-dropped by the stream.
+        // the channel close. Any per-contig senders were already sent-and-dropped
+        // by the stream.
         drop(shard_ctx);
-        total_rows = assembler
+        // ALWAYS join the assembler (even on error) so the thread is never detached
+        // and its cleanup/result is observed. Propagate the drive error first (the
+        // assembler has already discarded its partial temp on failure), then any
+        // assembler error.
+        let assembled = assembler
             .join()
-            .map_err(|_| DataFusionError::Execution("assembler thread panicked".to_string()))??;
+            .map_err(|_| DataFusionError::Execution("assembler thread panicked".to_string()))?;
+        drive_result?;
+        total_rows = assembled?;
         // tempdir (and any leftover shard files) removed on drop here.
         drop(tempdir);
     } else {
@@ -1413,7 +1504,14 @@ mod tests {
         let tmp = dir.join("out.vcf.part");
         let writer = VcfLocalWriter::with_compression(&tmp, VcfCompressionType::Plain).unwrap();
         let (tx, rx) = std::sync::mpsc::channel();
-        let h = run_assembler_thread(writer, out.clone(), tmp, dir.clone(), rx);
+        let h = run_assembler_thread(
+            writer,
+            out.clone(),
+            tmp,
+            dir.clone(),
+            rx,
+            Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        );
         tx.send(ContigShardRange {
             first_shard_id: 0,
             end_shard_id: 2,
@@ -1479,7 +1577,14 @@ mod tests {
         let out = dir.join("out.vcf.gz");
         let tmp = dir.join("out.vcf.gz.part");
         let (tx, rx) = std::sync::mpsc::channel();
-        let h = run_assembler_thread_bgzf(tmp.clone(), out.clone(), dir.clone(), header_blocks, rx);
+        let h = run_assembler_thread_bgzf(
+            tmp.clone(),
+            out.clone(),
+            dir.clone(),
+            header_blocks,
+            rx,
+            Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        );
         tx.send(ContigShardRange {
             first_shard_id: 0,
             end_shard_id: 1,
@@ -1496,6 +1601,78 @@ mod tests {
         let total = h.join().unwrap().unwrap();
         assert_eq!(total, 3);
         assert_eq!(gunzip_to_string(&out), "##header\n#CHROM\na\nb\nc\n");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn assembler_discards_partial_output_when_not_finalized() {
+        // On a mid-run failure the driver never sets `finalize`; the assembler must
+        // NOT finish/rename its partial temp into the final output path — it must
+        // discard the temp and produce no output file.
+        use std::io::Write;
+        let dir = unique_dir("asm_nofinal");
+        let mut f = std::fs::File::create(dir.join("partition_0000.vcf.body")).unwrap();
+        f.write_all(b"a\nb\n").unwrap();
+        let out = dir.join("out.vcf");
+        let tmp = dir.join("out.vcf.part");
+        let writer = VcfLocalWriter::with_compression(&tmp, VcfCompressionType::Plain).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = run_assembler_thread(
+            writer,
+            out.clone(),
+            tmp.clone(),
+            dir.clone(),
+            rx,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)), // driver "failed"
+        );
+        tx.send(ContigShardRange {
+            first_shard_id: 0,
+            end_shard_id: 1,
+            output_lines: 2,
+        })
+        .unwrap();
+        drop(tx); // channel closes, but finalize == false
+        let total = h.join().unwrap().unwrap();
+        assert_eq!(total, 0, "no rows finalized on failure");
+        assert!(!out.exists(), "final output must NOT be created on failure");
+        assert!(!tmp.exists(), "temp .part must be cleaned up on failure");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn assembler_bgzf_errors_on_shard_missing_eof_marker() {
+        // A shard that does not end with the canonical 28-byte BGZF EOF marker must
+        // produce a runtime error (not silent truncation) — the check must hold in
+        // release builds too, so it cannot be a debug_assert.
+        use std::io::Write;
+        let dir = unique_dir("asm_bgzf_badeof");
+        let mut f = std::fs::File::create(dir.join("partition_0000.vcf.body")).unwrap();
+        f.write_all(b"this shard does not end with the bgzf eof marker")
+            .unwrap();
+        let out = dir.join("out.vcf.gz");
+        let tmp = dir.join("out.vcf.gz.part");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = run_assembler_thread_bgzf(
+            tmp,
+            out.clone(),
+            dir.clone(),
+            Vec::new(),
+            rx,
+            Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        );
+        tx.send(ContigShardRange {
+            first_shard_id: 0,
+            end_shard_id: 1,
+            output_lines: 1,
+        })
+        .unwrap();
+        drop(tx);
+        let res = h.join().unwrap();
+        assert!(
+            res.is_err(),
+            "must error on a shard without the canonical EOF marker"
+        );
+        assert!(!out.exists(), "no output file on error");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -147,6 +147,16 @@ fn vcf_lines_to_body_chunk(lines: Vec<VcfRecordLine>) -> (Vec<u8>, usize) {
     (bytes, line_count)
 }
 
+/// Published by `ContigAnnotationStream` the instant a contig's shard workers
+/// all finish (shards flushed). The assembler thread appends the id range
+/// `[first_shard_id, end_shard_id)` — which is contiguous and equals final-VCF
+/// position order — and adds `output_lines` to the running body-line total.
+pub(crate) struct ContigShardRange {
+    pub(crate) first_shard_id: usize,
+    pub(crate) end_shard_id: usize,
+    pub(crate) output_lines: usize,
+}
+
 /// Formatter context + tempdir threaded into the `threads>1` engine workers so
 /// each fused worker can serialize its annotated batches directly into its own
 /// VCF body shard (`format_vcf_body_chunk` + `BufWriter<File>`), removing the
@@ -160,11 +170,18 @@ pub(crate) struct VcfShardContext {
     pub(crate) sample_names: Arc<Vec<String>>,
     pub(crate) coordinate_zero_based: bool,
     pub(crate) tempdir: PathBuf,
+    /// Output compression for the per-worker shard files. Only ever `Bgzf`
+    /// (bgzf output → parallel per-worker compression + raw block concat) or
+    /// `Plain` (plain/gzip output → text shards).
+    pub(crate) shard_compression: VcfCompressionType,
     /// Running count of input rows annotated across all shard workers. Polled by
     /// `drive_sharded_vcf_annotation` to drive the progress bar / callback
     /// incrementally during annotation (shards are written concurrently and only
     /// concatenated at the end, so this is the only live progress signal).
     pub(crate) rows_done: Arc<std::sync::atomic::AtomicUsize>,
+    /// One message per completed contig, in completion (= ascending id) order.
+    /// Dropped when annotation finishes, which signals the assembler to finalize.
+    pub(crate) contig_done_tx: std::sync::mpsc::Sender<ContigShardRange>,
 }
 
 fn format_vcf_body_chunk(
@@ -271,37 +288,17 @@ fn drain_ready_vcf_chunks(
     Ok(())
 }
 
-fn copy_body_file_to_writer(path: &Path, writer: &mut VcfLocalWriter) -> Result<Duration> {
-    let started = Instant::now();
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        DataFusionError::Execution(format!(
-            "Failed to open VCF body shard {}: {e}",
-            path.display()
-        ))
-    })?;
-    let mut buffer = vec![0u8; 8 * 1024 * 1024];
-    loop {
-        let bytes = file.read(&mut buffer).map_err(|e| {
-            DataFusionError::Execution(format!(
-                "Failed to read VCF body shard {}: {e}",
-                path.display()
-            ))
-        })?;
-        if bytes == 0 {
-            break;
-        }
-        write_vcf_body_chunk(writer, &buffer[..bytes])?;
-    }
-    Ok(started.elapsed())
-}
-
 /// Reusable streaming VCF body shard writer: owns a `BufWriter<File>` + the
 /// per-batch formatter context, and streams formatted batches into one shard
 /// file with no buffering of the batch. Used by the `workers>1` engine workers
 /// (which call the sync [`write_batch`](Self::write_batch) inside
 /// `block_in_place`).
 pub(crate) struct VcfBodyShardWriter {
-    writer: std::io::BufWriter<std::fs::File>,
+    /// Owns the shard's output sink. `Plain` for text shards (plain/gzip output),
+    /// `Bgzf` for bgzf output — workers compress their own shard in parallel; the
+    /// assembler then does a raw block concat. Reuses the bio-formats writer enum
+    /// so no direct `noodles-bgzf` dependency is needed here.
+    writer: VcfLocalWriter,
     vcf_info_fields: Arc<Vec<String>>,
     unique_format_tags: Arc<Vec<String>>,
     sample_names: Arc<Vec<String>>,
@@ -319,15 +316,11 @@ impl VcfBodyShardWriter {
         unique_format_tags: Arc<Vec<String>>,
         sample_names: Arc<Vec<String>>,
         coordinate_zero_based: bool,
+        compression: VcfCompressionType,
     ) -> Result<Self> {
-        let file = std::fs::File::create(path).map_err(|e| {
-            DataFusionError::Execution(format!(
-                "Failed to create VCF body shard {}: {e}",
-                path.display()
-            ))
-        })?;
+        let writer = VcfLocalWriter::with_compression(path, compression)?;
         Ok(Self {
-            writer: std::io::BufWriter::new(file),
+            writer,
             vcf_info_fields,
             unique_format_tags,
             sample_names,
@@ -368,9 +361,7 @@ impl VcfBodyShardWriter {
     /// [`write_vcf_partition_body`] which formats via `spawn_blocking`.
     fn write_formatted(&mut self, formatted: &FormattedVcfBatch) -> Result<Duration> {
         let started = Instant::now();
-        self.writer.write_all(&formatted.bytes).map_err(|e| {
-            DataFusionError::Execution(format!("Failed to write VCF body shard: {e}"))
-        })?;
+        write_vcf_body_chunk(&mut self.writer, &formatted.bytes)?;
         let elapsed = started.elapsed();
         self.lines += formatted.lines;
         self.input_rows += formatted.input_rows;
@@ -378,10 +369,11 @@ impl VcfBodyShardWriter {
         Ok(elapsed)
     }
 
-    pub(crate) fn finish(mut self) -> Result<()> {
-        self.writer
-            .flush()
-            .map_err(|e| DataFusionError::Execution(format!("Failed to flush VCF body shard: {e}")))
+    pub(crate) fn finish(self) -> Result<()> {
+        // Consumes the writer: flushes (Plain) or writes the final BGZF block +
+        // 28-byte EOF marker (Bgzf). The assembler strips that trailing EOF when
+        // concatenating bgzf shards.
+        self.writer.finish()
     }
 }
 
@@ -656,54 +648,135 @@ fn csq_header_description(
     format!("Consequence annotations from annotate_vep. Format: {format_list}")
 }
 
-/// Annotate a VCF file and write results to an output VCF.
-///
-/// Handles everything in a single call:
-/// 1. Reads the input VCF (all INFO/FORMAT fields preserved)
-/// 2. Creates a session, registers VEP functions and the VCF table
-/// 3. Runs annotation and streams results to the output VCF
-///
-/// The 87 structured annotation columns plus `most_severe_consequence`
-/// are NOT written to the VCF — only core VCF columns, original INFO/FORMAT
-/// fields, and the `csq` annotation are included.
-///
-/// Cache source mode is read from Arrow schema metadata on the selected cache
-/// backend's variation table.
-///
-/// # Returns
-///
-/// The number of rows written.
-/// Copy one VCF body shard into `writer`, returning the number of body lines
-/// (each ends in `\n`, so the newline count is the line count). Used to assemble
-/// the sharded `threads>1` output, where shard line counts are not carried in a
-/// descriptor (the bodies live only as files in the shard tempdir).
-fn copy_body_file_counting_lines(path: &Path, writer: &mut VcfLocalWriter) -> Result<usize> {
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        DataFusionError::Execution(format!(
-            "Failed to open VCF body shard {}: {e}",
-            path.display()
-        ))
+/// Canonical 28-byte BGZF end-of-file marker (an empty BGZF block, SAM spec).
+/// Every finished bgzf file (`VcfLocalWriter::Bgzf::finish()`) ends with exactly
+/// these bytes. Written once, at the very end of an assembled BGZF file; stripped
+/// from each shard/header piece before concatenation.
+const BGZF_EOF: [u8; 28] = [
+    0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43, 0x02, 0x00,
+    0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+/// Read a finished bgzf file and return its bytes with the trailing 28-byte EOF
+/// marker removed, ready for raw concatenation into a larger bgzf stream.
+fn bgzf_blocks_no_eof(path: &Path) -> Result<Vec<u8>> {
+    let mut bytes = std::fs::read(path).map_err(|e| {
+        DataFusionError::Execution(format!("read bgzf shard {}: {e}", path.display()))
     })?;
-    let mut buffer = vec![0u8; 8 * 1024 * 1024];
-    let mut lines = 0usize;
-    loop {
-        let bytes = file.read(&mut buffer).map_err(|e| {
-            DataFusionError::Execution(format!(
-                "Failed to read VCF body shard {}: {e}",
-                path.display()
-            ))
-        })?;
-        if bytes == 0 {
-            break;
-        }
-        lines += bytecount(&buffer[..bytes], b'\n');
-        write_vcf_body_chunk(writer, &buffer[..bytes])?;
-    }
-    Ok(lines)
+    debug_assert!(
+        bytes.len() >= BGZF_EOF.len() && bytes[bytes.len() - BGZF_EOF.len()..] == BGZF_EOF,
+        "bgzf file {} does not end with the canonical EOF marker",
+        path.display()
+    );
+    let keep = bytes.len().saturating_sub(BGZF_EOF.len());
+    bytes.truncate(keep);
+    Ok(bytes)
 }
 
-fn bytecount(haystack: &[u8], needle: u8) -> usize {
-    haystack.iter().filter(|&&b| b == needle).count()
+/// Dedicated assembler thread for Plain/Gzip output. Owns the header-primed
+/// `VcfLocalWriter` (targeting `temp_output`) and appends each completed contig's
+/// shard range — in arrival (= ascending id = position) order — as raw body
+/// bytes (Plain = byte copy; Gzip = compress-on-append). Runs concurrently with
+/// the next contig's prepare + annotation, so the copy overlaps rather than
+/// tailing after 100%. On channel close (annotation finished, no error) it
+/// finalizes the writer and atomically renames `temp_output` → `final_output`.
+/// Returns the total body-line count (summed from worker-reported `output_lines`,
+/// so no re-scan). Never advances the progress bar (already driven by rows_done).
+fn run_assembler_thread(
+    mut writer: VcfLocalWriter,
+    final_output: PathBuf,
+    temp_output: PathBuf,
+    tempdir: PathBuf,
+    rx: std::sync::mpsc::Receiver<ContigShardRange>,
+) -> std::thread::JoinHandle<Result<usize>> {
+    std::thread::spawn(move || -> Result<usize> {
+        let mut total_lines = 0usize;
+        let mut buffer = vec![0u8; 8 * 1024 * 1024];
+        while let Ok(range) = rx.recv() {
+            for id in range.first_shard_id..range.end_shard_id {
+                let path = tempdir.join(format!("partition_{id:04}.vcf.body"));
+                let mut f = std::fs::File::open(&path).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "assembler open shard {}: {e}",
+                        path.display()
+                    ))
+                })?;
+                loop {
+                    let n = f.read(&mut buffer).map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "assembler read shard {}: {e}",
+                            path.display()
+                        ))
+                    })?;
+                    if n == 0 {
+                        break;
+                    }
+                    write_vcf_body_chunk(&mut writer, &buffer[..n])?;
+                }
+                let _ = std::fs::remove_file(&path);
+            }
+            total_lines += range.output_lines;
+        }
+        // Sender dropped == annotation finished with no error.
+        writer.finish()?;
+        std::fs::rename(&temp_output, &final_output).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "assembler rename {} -> {}: {e}",
+                temp_output.display(),
+                final_output.display()
+            ))
+        })?;
+        Ok(total_lines)
+    })
+}
+
+/// Dedicated assembler thread for BGZF output. Shards are already bgzf-compressed
+/// (by the workers, in parallel), so this owns a RAW `BufWriter<File>` — it must
+/// NOT re-compress. It writes the pre-compressed `header_blocks`, then for each
+/// completed contig range raw-appends every shard minus its trailing 28-byte EOF
+/// marker, then writes one canonical `BGZF_EOF`, flushes, and atomically renames.
+/// Returns the total body-line count (worker-reported). Concurrent with the next
+/// contig's prepare + annotation, exactly like the Plain assembler.
+fn run_assembler_thread_bgzf(
+    temp_output: PathBuf,
+    final_output: PathBuf,
+    tempdir: PathBuf,
+    header_blocks: Vec<u8>,
+    rx: std::sync::mpsc::Receiver<ContigShardRange>,
+) -> std::thread::JoinHandle<Result<usize>> {
+    std::thread::spawn(move || -> Result<usize> {
+        let file = std::fs::File::create(&temp_output).map_err(|e| {
+            DataFusionError::Execution(format!("assembler create {}: {e}", temp_output.display()))
+        })?;
+        let mut out = std::io::BufWriter::new(file);
+        out.write_all(&header_blocks)
+            .map_err(|e| DataFusionError::Execution(format!("assembler write header: {e}")))?;
+        let mut total_lines = 0usize;
+        while let Ok(range) = rx.recv() {
+            for id in range.first_shard_id..range.end_shard_id {
+                let path = tempdir.join(format!("partition_{id:04}.vcf.body"));
+                let blocks = bgzf_blocks_no_eof(&path)?;
+                out.write_all(&blocks).map_err(|e| {
+                    DataFusionError::Execution(format!("assembler write shard: {e}"))
+                })?;
+                let _ = std::fs::remove_file(&path);
+            }
+            total_lines += range.output_lines;
+        }
+        out.write_all(&BGZF_EOF)
+            .map_err(|e| DataFusionError::Execution(format!("assembler write EOF: {e}")))?;
+        out.flush()
+            .map_err(|e| DataFusionError::Execution(format!("assembler flush: {e}")))?;
+        drop(out);
+        std::fs::rename(&temp_output, &final_output).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "assembler rename {} -> {}: {e}",
+                temp_output.display(),
+                final_output.display()
+            ))
+        })?;
+        Ok(total_lines)
+    })
 }
 
 /// Drive the `threads>1` sharded-VCF-output path: build the annotation plan
@@ -722,11 +795,10 @@ async fn drive_sharded_vcf_annotation(
     vcf_schema: &Arc<datafusion::arrow::datatypes::Schema>,
     projection_names: &[String],
     shard_ctx: Arc<VcfShardContext>,
-    writer: &mut VcfLocalWriter,
     pb: &ProgressBar,
     config: &AnnotateVcfConfig,
     total_input: usize,
-) -> Result<usize> {
+) -> Result<()> {
     use crate::annotate_provider::AnnotateProvider;
     use crate::annotation_store::AnnotationBackend;
     use datafusion::physical_plan::ExecutionPlan;
@@ -832,41 +904,11 @@ async fn drive_sharded_vcf_annotation(
     // Final flush: report any rows annotated since the poller's last tick.
     report(shard_ctx.rows_done.load(Relaxed));
 
-    // Assemble: concat the body shards in ascending (= position) id order.
-    let mut shards: Vec<(usize, PathBuf)> = Vec::new();
-    for entry in std::fs::read_dir(&shard_ctx.tempdir).map_err(|e| {
-        DataFusionError::Execution(format!(
-            "Failed to read VCF shard tempdir {}: {e}",
-            shard_ctx.tempdir.display()
-        ))
-    })? {
-        let path = entry
-            .map_err(|e| {
-                DataFusionError::Execution(format!("Failed to read VCF shard dir entry: {e}"))
-            })?
-            .path();
-        let id = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .and_then(|name| name.strip_prefix("partition_"))
-            .and_then(|name| name.strip_suffix(".vcf.body"))
-            .and_then(|name| name.parse::<usize>().ok());
-        if let Some(id) = id {
-            shards.push((id, path));
-        }
-    }
-    shards.sort_by_key(|(id, _)| *id);
-
-    // Concat is just byte-copy assembly; progress was already reported during
-    // annotation above, so don't advance the bar / callback again here (the
-    // input-row count would otherwise be double-counted against output lines).
-    let mut total_rows = 0usize;
-    for (_, path) in shards {
-        let lines = copy_body_file_counting_lines(&path, writer)?;
-        let _ = std::fs::remove_file(&path);
-        total_rows += lines;
-    }
-    Ok(total_rows)
+    // Shard assembly no longer happens here: each contig's shard range is
+    // published (annotate_provider) and concatenated by the dedicated assembler
+    // thread spawned in `annotate_to_vcf`, concurrently with the next contig's
+    // prepare + annotation. This function only drives annotation + progress.
+    Ok(())
 }
 
 pub async fn annotate_to_vcf(
@@ -1106,13 +1148,6 @@ pub async fn annotate_to_vcf(
 
     // 6. Stream annotated batches to VCF file.
     let output_path = Path::new(output_vcf);
-    let mut writer = VcfLocalWriter::with_compression(output_path, config.compression)?;
-    writer.write_header(
-        &write_schema,
-        &vcf_info_fields,
-        &unique_format_tags,
-        &sample_names,
-    )?;
 
     let coordinate_zero_based = vcf_schema
         .metadata()
@@ -1125,18 +1160,80 @@ pub async fn annotate_to_vcf(
     if config.workers > 1 {
         // Sharded VCF output: bypass the SQL/DataFrame execution and drive the
         // annotation plan directly with a VcfShardContext, so each fused worker
-        // streams its own VCF body shard. The header was already written above;
-        // here we drive the shards to completion then concat them in order.
+        // streams its own position-ordered VCF body shard. A dedicated assembler
+        // thread concatenates each contig's shards the instant that contig
+        // finishes — concurrently with the next contig's prepare + annotation —
+        // then atomically renames the temp output into place.
         let tempdir = VcfBodyTempDir::new()?;
+        // Temp assembly path in the SAME directory as the output (so the final
+        // rename is atomic on one filesystem).
+        let mut temp_os = output_path.as_os_str().to_owned();
+        temp_os.push(".part");
+        let temp_output = PathBuf::from(temp_os);
+
+        let (contig_done_tx, contig_done_rx) = std::sync::mpsc::channel::<ContigShardRange>();
+        // bgzf output → parallel per-worker bgzf shards + raw block concat;
+        // plain/gzip → plain text shards + re-copy/compress at the assembler.
+        let shard_compression = if config.compression == VcfCompressionType::Bgzf {
+            VcfCompressionType::Bgzf
+        } else {
+            VcfCompressionType::Plain
+        };
+
+        // Spawn the assembler (owns the output writer); its mode matches the
+        // output compression. Header is written BEFORE the field vecs are moved
+        // into the shard context.
+        let assembler = if config.compression == VcfCompressionType::Bgzf {
+            // Pre-compress the header into bgzf blocks (strip its EOF); the raw
+            // assembler writes those, then the already-compressed shards.
+            let header_tmp = tempdir.path().join("header.bgz");
+            let mut hw = VcfLocalWriter::with_compression(&header_tmp, VcfCompressionType::Bgzf)?;
+            hw.write_header(
+                &write_schema,
+                &vcf_info_fields,
+                &unique_format_tags,
+                &sample_names,
+            )?;
+            hw.finish()?;
+            let header_blocks = bgzf_blocks_no_eof(&header_tmp)?;
+            let _ = std::fs::remove_file(&header_tmp);
+            run_assembler_thread_bgzf(
+                temp_output.clone(),
+                output_path.to_path_buf(),
+                tempdir.path().to_path_buf(),
+                header_blocks,
+                contig_done_rx,
+            )
+        } else {
+            // Plain/Gzip: write the header to the temp writer; the assembler
+            // owns it, appends shard bodies, finishes, and renames.
+            let mut writer = VcfLocalWriter::with_compression(&temp_output, config.compression)?;
+            writer.write_header(
+                &write_schema,
+                &vcf_info_fields,
+                &unique_format_tags,
+                &sample_names,
+            )?;
+            run_assembler_thread(
+                writer,
+                output_path.to_path_buf(),
+                temp_output.clone(),
+                tempdir.path().to_path_buf(),
+                contig_done_rx,
+            )
+        };
+
         let shard_ctx = Arc::new(VcfShardContext {
             vcf_info_fields: Arc::new(vcf_info_fields),
             unique_format_tags: Arc::new(unique_format_tags),
             sample_names: Arc::new(sample_names),
             coordinate_zero_based,
+            shard_compression,
             tempdir: tempdir.path().to_path_buf(),
             rows_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            contig_done_tx,
         });
-        total_rows = drive_sharded_vcf_annotation(
+        drive_sharded_vcf_annotation(
             &ctx,
             vcf_table,
             cache_source,
@@ -1145,16 +1242,29 @@ pub async fn annotate_to_vcf(
             options_json.clone(),
             &vcf_schema,
             &projection_names,
-            shard_ctx,
-            &mut writer,
+            Arc::clone(&shard_ctx),
             &pb,
             config,
             total_input,
         )
         .await?;
+        // Drop the last sender (the one held on shard_ctx) so the assembler sees
+        // the channel close and finalizes. Any per-contig senders were already
+        // sent-and-dropped by the stream.
+        drop(shard_ctx);
+        total_rows = assembler
+            .join()
+            .map_err(|_| DataFusionError::Execution("assembler thread panicked".to_string()))??;
         // tempdir (and any leftover shard files) removed on drop here.
         drop(tempdir);
     } else {
+        let mut writer = VcfLocalWriter::with_compression(output_path, config.compression)?;
+        writer.write_header(
+            &write_schema,
+            &vcf_info_fields,
+            &unique_format_tags,
+            &sample_names,
+        )?;
         use futures::StreamExt;
         let mut stream = df.execute_stream().await?;
         let mut next_serial_batch_id = 0usize;
@@ -1236,13 +1346,13 @@ pub async fn annotate_to_vcf(
                 cb(lines.len(), total_rows, total_input);
             }
         }
+        let finish_started = Instant::now();
+        writer.finish()?;
+        if let Some(profile) = sink_profile.as_mut() {
+            profile.writer_finish += finish_started.elapsed();
+        }
     }
 
-    let finish_started = Instant::now();
-    writer.finish()?;
-    if let Some(profile) = sink_profile.as_mut() {
-        profile.writer_finish += finish_started.elapsed();
-    }
     pb.finish_and_clear();
     if let Some(profile) = sink_profile {
         eprintln!("{}", profile.summary_line());
@@ -1256,6 +1366,138 @@ mod tests {
     use super::*;
     use std::pin::Pin;
     use std::task::{Context, Poll};
+
+    // bgzf is a stream of concatenated gzip members; flate2's MultiGzDecoder
+    // decodes it without needing an external bgzip binary.
+    fn gunzip_to_string(path: &Path) -> String {
+        use std::io::Read;
+        let f = std::fs::File::open(path).unwrap();
+        let mut d = flate2::read::MultiGzDecoder::new(f);
+        let mut s = String::new();
+        d.read_to_string(&mut s).unwrap();
+        s
+    }
+
+    fn unique_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("{tag}_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn contig_shard_range_is_contiguous_and_sums() {
+        let a = ContigShardRange {
+            first_shard_id: 0,
+            end_shard_id: 3,
+            output_lines: 10,
+        };
+        let b = ContigShardRange {
+            first_shard_id: 3,
+            end_shard_id: 5,
+            output_lines: 4,
+        };
+        assert_eq!(a.end_shard_id, b.first_shard_id); // contiguous, no gaps/overlap
+        assert_eq!(a.output_lines + b.output_lines, 14);
+    }
+
+    #[test]
+    fn assembler_plain_appends_ranges_in_order_and_counts_lines() {
+        use std::io::Write;
+        let dir = unique_dir("asm_plain");
+        for (id, body) in [(0usize, "a\nb\n"), (1, "c\n"), (2, "d\ne\nf\n")] {
+            let mut f =
+                std::fs::File::create(dir.join(format!("partition_{id:04}.vcf.body"))).unwrap();
+            f.write_all(body.as_bytes()).unwrap();
+        }
+        let out = dir.join("out.vcf");
+        let tmp = dir.join("out.vcf.part");
+        let writer = VcfLocalWriter::with_compression(&tmp, VcfCompressionType::Plain).unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = run_assembler_thread(writer, out.clone(), tmp, dir.clone(), rx);
+        tx.send(ContigShardRange {
+            first_shard_id: 0,
+            end_shard_id: 2,
+            output_lines: 3,
+        })
+        .unwrap();
+        tx.send(ContigShardRange {
+            first_shard_id: 2,
+            end_shard_id: 3,
+            output_lines: 3,
+        })
+        .unwrap();
+        drop(tx);
+        let total = h.join().unwrap().unwrap();
+        assert_eq!(total, 6);
+        assert_eq!(std::fs::read_to_string(&out).unwrap(), "a\nb\nc\nd\ne\nf\n");
+        assert!(
+            !dir.join("partition_0000.vcf.body").exists(),
+            "shards removed after copy"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn shard_writer_bgzf_empty_shard_is_decodable() {
+        let dir = unique_dir("shard_bgzf");
+        let path = dir.join("partition_0000.vcf.body");
+        let w = VcfBodyShardWriter::create(
+            &path,
+            Arc::new(vec![]),
+            Arc::new(vec![]),
+            Arc::new(vec![]),
+            false,
+            VcfCompressionType::Bgzf,
+        )
+        .unwrap();
+        let lines = w.lines;
+        w.finish().unwrap(); // flushes bgzf blocks + EOF
+        assert_eq!(lines, 0);
+        assert_eq!(gunzip_to_string(&path), "");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn assembler_bgzf_raw_concat_decodes_in_order() {
+        let dir = unique_dir("asm_bgzf");
+        // Produce bgzf shards exactly as VcfBodyShardWriter(Bgzf) does: body
+        // through a VcfLocalWriter::Bgzf, finish() (appends EOF).
+        let write_bgzf = |path: &Path, body: &str| {
+            let mut w = VcfLocalWriter::with_compression(path, VcfCompressionType::Bgzf).unwrap();
+            write_vcf_body_chunk(&mut w, body.as_bytes()).unwrap();
+            w.finish().unwrap();
+        };
+        for (id, body) in [(0usize, "a\nb\n"), (1usize, "c\n")] {
+            write_bgzf(&dir.join(format!("partition_{id:04}.vcf.body")), body);
+        }
+        // Header blocks: compress "##header\n#CHROM\n" and strip its EOF.
+        let hpath = dir.join("hdr.bgz");
+        write_bgzf(&hpath, "##header\n#CHROM\n");
+        let header_blocks = bgzf_blocks_no_eof(&hpath).unwrap();
+        std::fs::remove_file(&hpath).ok();
+
+        let out = dir.join("out.vcf.gz");
+        let tmp = dir.join("out.vcf.gz.part");
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = run_assembler_thread_bgzf(tmp.clone(), out.clone(), dir.clone(), header_blocks, rx);
+        tx.send(ContigShardRange {
+            first_shard_id: 0,
+            end_shard_id: 1,
+            output_lines: 2,
+        })
+        .unwrap();
+        tx.send(ContigShardRange {
+            first_shard_id: 1,
+            end_shard_id: 2,
+            output_lines: 1,
+        })
+        .unwrap();
+        drop(tx);
+        let total = h.join().unwrap().unwrap();
+        assert_eq!(total, 3);
+        assert_eq!(gunzip_to_string(&out), "##header\n#CHROM\na\nb\nc\n");
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn test_to_options_json_emits_pick_flags() {

--- a/docs/superpowers/plans/2026-07-05-pipelined-shard-assembler-both-modes.md
+++ b/docs/superpowers/plans/2026-07-05-pipelined-shard-assembler-both-modes.md
@@ -1,0 +1,862 @@
+# Pipelined Per-Contig Shard Assembler (Plain + BGZF) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the single-threaded post-100% shard-merge tail (~13s on WGS) by assembling each contig's VCF body shards on a dedicated thread that runs *concurrently* with the next contig's context-prepare + annotation, and — for `.vcf.gz`/bgzf output — move compression off the serial tail onto the parallel workers via raw BGZF block concatenation.
+
+**Architecture:** Today `drive_sharded_vcf_annotation` (vcf_sink.rs:713) drives the whole-genome annotation stream to completion, then serially concatenates every `partition_NNNN.vcf.body` shard into the output writer in one terminal pass (vcf_sink.rs:835–869). The progress bar hits 100% when annotation finishes (`shard_ctx.rows_done == total_input`), so the concat is invisible tail. We replace the terminal concat with a **dedicated OS assembler thread** that owns the output writer and consumes per-contig "shard range complete" messages published by `ContigAnnotationStream` the instant each contig's workers finish (annotate_provider.rs:11697). Because shard ids are contig-major/worker-minor and equal final-VCF position order (annotate_provider.rs:11580–11587), the assembler appends each contig's contiguous id range in arrival order → identical bytes, but the copy now overlaps the next contig's `prepare_contig_context` + annotation. Stage 1 delivers this for Plain/Gzip output (text shards, re-copy/re-compress at the assembler — byte-identical). Stage 2 adds BGZF output: workers write BGZF shards (parallel compression) and the assembler does a raw block concat (strip each shard's 28-byte EOF, write one canonical EOF at the end).
+
+**Tech Stack:** Rust 2024, DataFusion 53 / Arrow 58, tokio (current-thread + multi-thread), `std::sync::mpsc` (assembler channel), `std::thread` (assembler), bio-format-vcf's existing `VcfLocalWriter` (the `Bgzf` variant is backed by `noodles-bgzf` internally — bio-functions never depends on `noodles-bgzf` directly), indicatif (progress). **Entirely single-repo (`datafusion-bio-functions`): no bio-formats change, no dependency bump.**
+
+## Global Constraints
+
+- **Byte-identical output is the acceptance gate.** For a fixed input + `workers` + compression, the assembled VCF must be byte-for-byte identical to the pre-change output (Plain/Gzip) or decompress to byte-identical body (BGZF). The memory-noted invariant is "chr4/chr2 w{1,4} 0 HGNC mism, byte-identical" — do not regress it.
+- **Shard id ordering is the ordering contract.** Ids are assigned `contig-major, worker-minor` at annotate_provider.rs:11583; ascending id == final VCF position order. Never reorder; only slice along contig boundaries.
+- **Single-repo, no dependency bump.** Both stages live entirely in `datafusion-bio-functions`. BGZF compression reuses the existing `VcfLocalWriter::Bgzf` from the `datafusion-bio-format-vcf` git dep (tag `v1.8.7`, unchanged); the 28-byte BGZF EOF marker is a fixed spec constant hardcoded locally in `vcf_sink.rs`. Do **not** add a `noodles-bgzf` dependency and do **not** modify bio-formats.
+- **No behavioral change for `workers == 1`.** The serial path (vcf_sink.rs:1157–1239) is untouched; assembler applies only to `workers > 1`.
+- **Assembler is single-writer.** Exactly one thread ever touches the output `File`. Contig ranges are appended strictly in arrival (= id) order. Never write from two threads.
+- **Progress accounting unchanged.** The bar is driven by `rows_done` during annotation (vcf_sink.rs:777–793); the assembler must NOT advance the bar or the callback (that would double-count input vs output lines — see vcf_sink.rs:860–862).
+- **Error contract.** On any worker/stream error the partially-assembled output must not be presented as a valid result. Assemble into a temp path and atomically rename on full success (both stages); on error, drop the temp file.
+
+---
+
+## File Structure
+
+**Stage 1 (datafusion-bio-functions only):**
+- Modify `datafusion/bio-function-vep/src/vcf_sink.rs`
+  - New `ContigShardRange` message type + `contig_done_tx` field on `VcfShardContext`.
+  - New `run_assembler_thread(...)` (owns writer, consumes ranges, appends, finish, atomic rename).
+  - Rewrite `drive_sharded_vcf_annotation` to spawn the assembler, drive the stream, drop the sender, join the assembler.
+  - Delete the terminal concat loop + `copy_body_file_counting_lines`/`bytecount` (replaced by assembler append + worker-reported line counts).
+- Modify `datafusion/bio-function-vep/src/annotate_provider.rs`
+  - `spawn_annotation_from_lookup_sharded` returns `ShardResult { input_rows, output_lines }`.
+  - `ParallelContigState` gains `contig_first_shard_id`; capture before the worker loop; publish `ContigShardRange` on completion (11697).
+
+**Stage 2 (datafusion-bio-functions only):**
+- Modify `datafusion/bio-function-vep/src/vcf_sink.rs`
+  - Refactor `VcfBodyShardWriter` to own a `VcfLocalWriter` (Plain for text shards, Bgzf for bgzf shards) instead of a raw `BufWriter<File>` — workers compress their own shard via the existing enum; no new API.
+  - Hardcode the 28-byte `BGZF_EOF` constant locally.
+  - Assembler grows a `RawBgzf` mode: pre-compress the header via `VcfLocalWriter::Bgzf` (strip its EOF), raw-append each shard minus its trailing 28-byte EOF, write one final `BGZF_EOF`.
+  - Shard/assembler mode selection keyed on `config.compression` (Bgzf → bgzf shards; else Plain text shards).
+
+**Tests:**
+- `datafusion/bio-function-vep/src/vcf_sink.rs` `#[cfg(test)]` — assembler unit tests with synthetic shard files (Plain + BGZF), ordering, BGZF raw-concat round-trip, atomic rename.
+- e2e parity: `vepyr/e2e-testing/scripts/run_annotation_fast.py` (unchanged) as the oracle.
+
+---
+
+## Stage 1 — Dedicated assembler thread, incremental per-contig concat (Plain/Gzip)
+
+### Task 1: `ContigShardRange` message + wire it onto `VcfShardContext`
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/vcf_sink.rs:156-168` (add field), new type near line 148
+- Test: `datafusion/bio-function-vep/tests/shard_assembler.rs` (create)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub(crate) struct ContigShardRange {
+      pub(crate) first_shard_id: usize,   // inclusive
+      pub(crate) end_shard_id: usize,     // exclusive
+      pub(crate) output_lines: usize,     // sum of this contig's shards' body lines
+  }
+  ```
+  and a new field `pub(crate) contig_done_tx: std::sync::mpsc::Sender<ContigShardRange>` on `VcfShardContext`.
+
+- [ ] **Step 1: Write the failing test** (`tests/shard_assembler.rs`)
+
+```rust
+use datafusion_bio_function_vep::vcf_sink::ContigShardRange; // pub(crate) → test lives in-crate; see Step 3 note
+// NOTE: because VcfShardContext/ContigShardRange are pub(crate), put this test as a
+// `#[cfg(test)] mod` at the bottom of vcf_sink.rs instead of an external integration
+// test. Move the assert there:
+#[test]
+fn contig_shard_range_is_constructible_and_ordered() {
+    let a = ContigShardRange { first_shard_id: 0, end_shard_id: 3, output_lines: 10 };
+    let b = ContigShardRange { first_shard_id: 3, end_shard_id: 5, output_lines: 4 };
+    assert_eq!(a.end_shard_id, b.first_shard_id); // contiguous, no gaps/overlap
+    assert_eq!(a.output_lines + b.output_lines, 14);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep contig_shard_range_is_constructible -- --nocapture`
+Expected: FAIL — `ContigShardRange` not found.
+
+- [ ] **Step 3: Add the type + field**
+
+In `vcf_sink.rs` just above `VcfShardContext` (line 156):
+```rust
+/// Published by `ContigAnnotationStream` the instant a contig's shard workers
+/// all finish (shards flushed). The assembler thread appends the id range
+/// `[first_shard_id, end_shard_id)` — which is contiguous and equals final-VCF
+/// position order — and adds `output_lines` to the running body-line total.
+pub(crate) struct ContigShardRange {
+    pub(crate) first_shard_id: usize,
+    pub(crate) end_shard_id: usize,
+    pub(crate) output_lines: usize,
+}
+```
+Add to `VcfShardContext` (after `rows_done`, line 167):
+```rust
+    /// One message per completed contig, in completion (= ascending id) order.
+    /// Dropped when annotation finishes, which signals the assembler to finalize.
+    pub(crate) contig_done_tx: std::sync::mpsc::Sender<ContigShardRange>,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p datafusion-bio-function-vep contig_shard_range_is_constructible -- --nocapture`
+Expected: PASS. (The `VcfShardContext` construction site at vcf_sink.rs:1131 will now fail to compile — that's fixed in Task 4; if doing strict per-task compiles, temporarily add `contig_done_tx: std::sync::mpsc::channel().0` there and remove in Task 4.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/vcf_sink.rs
+git commit -m "feat(vep): add ContigShardRange message + contig_done_tx on VcfShardContext"
+```
+
+---
+
+### Task 2: Worker returns output line count (`ShardResult`)
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs:9904-9913` (signature/return), `:10042-10045` (return value)
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs:11571,11624-11638` (join_fut sums both)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub(crate) struct ShardResult { pub(crate) input_rows: usize, pub(crate) output_lines: usize }
+  ```
+  `spawn_annotation_from_lookup_sharded(...) -> tokio::task::JoinHandle<Result<ShardResult>>`.
+- Consumes: `VcfBodyShardWriter.input_rows` and `.lines` (vcf_sink.rs:310-311, already `pub(crate)`).
+
+- [ ] **Step 1: Write the failing test**
+
+Unit-testing the async worker in isolation is impractical (needs a live lookup stream); assert the *type contract* instead, in `annotate_provider.rs` `#[cfg(test)]`:
+```rust
+#[test]
+fn shard_result_carries_input_and_output_counts() {
+    let r = super::ShardResult { input_rows: 5000, output_lines: 18234 };
+    assert_eq!(r.input_rows, 5000);
+    assert_eq!(r.output_lines, 18234);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep shard_result_carries -- --nocapture`
+Expected: FAIL — `ShardResult` not found.
+
+- [ ] **Step 3: Implement**
+
+Define near `spawn_annotation_from_lookup_sharded` (annotate_provider.rs:~9903):
+```rust
+pub(crate) struct ShardResult {
+    pub(crate) input_rows: usize,
+    pub(crate) output_lines: usize,
+}
+```
+Change the return type at 9913 to `-> tokio::task::JoinHandle<Result<ShardResult>>`.
+Replace the tail at 10042–10045:
+```rust
+        let input_rows = shard.input_rows;
+        let output_lines = shard.lines;
+        let _ = (emit_start, emit_end, global_row);
+        shard.finish()?;
+        Ok(ShardResult { input_rows, output_lines })
+```
+Update `shard_handles` element type at 11571:
+```rust
+                            let mut shard_handles: Vec<tokio::task::JoinHandle<Result<ShardResult>>> =
+```
+Update `join_fut` (11624–11638) to sum both and return them:
+```rust
+                            let join_fut: ShardJoinFuture = Box::pin(async move {
+                                let mut input_rows = 0usize;
+                                let mut output_lines = 0usize;
+                                for h in shard_handles {
+                                    match h.await {
+                                        Ok(Ok(r)) => { input_rows += r.input_rows; output_lines += r.output_lines; }
+                                        Ok(Err(e)) => return Err(e),
+                                        Err(join_err) => {
+                                            return Err(DataFusionError::External(Box::new(join_err)));
+                                        }
+                                    }
+                                }
+                                Ok((input_rows, output_lines))
+                            });
+```
+Update the `ShardJoinFuture` type alias (search `type ShardJoinFuture`) to yield `Result<(usize, usize)>`, and the `AnnotatingParallel` `Ready(Ok(...))` arm at 11697 to bind `(contig_rows, contig_lines)` — `contig_lines` is used in Task 3; keep `contig_rows` for the existing profile string at 11705.
+
+- [ ] **Step 4: Run test + build**
+
+Run: `cargo test -p datafusion-bio-function-vep shard_result_carries -- --nocapture && cargo build -p datafusion-bio-function-vep`
+Expected: PASS + clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "feat(vep): shard workers report output line count via ShardResult"
+```
+
+---
+
+### Task 3: Publish `ContigShardRange` on contig completion
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs` — `ParallelContigState` struct (search `struct ParallelContigState`), setup at `:11575`, completion at `:11697-11713`
+
+**Interfaces:**
+- Consumes: `ContigShardRange`, `VcfShardContext.contig_done_tx` (Task 1); `(contig_rows, contig_lines)` (Task 2).
+- Produces: one `ContigShardRange` sent per completed contig.
+
+- [ ] **Step 1: Write the failing test**
+
+Ordering/id-range logic is what can break; assert the range arithmetic in `#[cfg(test)]`:
+```rust
+#[test]
+fn contig_range_is_first_to_next_global_id() {
+    // Simulate: contig starts at global id 4, spawns 3 workers → ids 4,5,6.
+    let first = 4usize;
+    let mut next = first;
+    for _ in 0..3 { next += 1; }
+    let range = crate::vcf_sink::ContigShardRange { first_shard_id: first, end_shard_id: next, output_lines: 0 };
+    assert_eq!((range.first_shard_id, range.end_shard_id), (4, 7));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep contig_range_is_first_to_next -- --nocapture`
+Expected: FAIL until the module path/type resolves (it will pass once Task 1 compiled; if so, this is a guard test — keep it).
+
+- [ ] **Step 3: Implement**
+
+Add field to `ParallelContigState`:
+```rust
+    contig_first_shard_id: usize,
+```
+At annotate_provider.rs:11575, immediately before `for mut handle in handles {`:
+```rust
+                            let contig_first_shard_id = self.next_global_shard_id;
+```
+Set it when building `ParallelContigState` (near 11639):
+```rust
+                                contig_first_shard_id,
+```
+In the `AnnotatingParallel` `Poll::Ready(Ok((contig_rows, contig_lines)))` arm (11697), before building the cleanup future (11708), publish the range. `end` is the current `next_global_shard_id` (workers for later contigs have not been allocated yet, so it is exactly this contig's exclusive end):
+```rust
+                        Poll::Ready(Ok((contig_rows, contig_lines))) => {
+                            for h in &state.lookup_join { h.abort(); }
+                            if let Some(shard_ctx) = state.config.vcf_shard_ctx.clone() {
+                                // Send is best-effort: if the assembler has gone
+                                // away (error path already tearing down), ignore.
+                                let _ = shard_ctx.contig_done_tx.send(crate::vcf_sink::ContigShardRange {
+                                    first_shard_id: state.contig_first_shard_id,
+                                    end_shard_id: self.next_global_shard_id,
+                                    output_lines: contig_lines,
+                                });
+                            }
+                            profile_end!(
+                                &format!("{}: TOTAL", state.chrom),
+                                state.t_contig,
+                                format!("{contig_rows} rows")
+                            );
+                            emit_contig_pipeline_profile(&state.shared.profile, &state.chrom);
+                            let fut = make_cleanup_future(
+                                Arc::clone(&state.session),
+                                std::mem::take(&mut state.ephemeral_tables),
+                            );
+                            self.state = StreamState::CleaningUp(fut);
+                            continue;
+                        }
+```
+
+- [ ] **Step 4: Run test + build**
+
+Run: `cargo test -p datafusion-bio-function-vep contig_range_is_first_to_next -- --nocapture && cargo build -p datafusion-bio-function-vep`
+Expected: PASS + clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "feat(vep): publish per-contig shard range on completion"
+```
+
+---
+
+### Task 4: Assembler thread (Plain/Gzip append), replacing the terminal concat
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/vcf_sink.rs` — new `run_assembler_thread`, rewrite `drive_sharded_vcf_annotation` (713–870), construct `contig_done_tx` at 1131, move header/writer ownership.
+- Delete: `copy_body_file_counting_lines` (680), `bytecount` (705) — superseded.
+- Test: `tests/shard_assembler.rs` (in-crate `#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `ContigShardRange` (Task 1), `VcfLocalWriter` (bio-formats), shard files `partition_{id:04}.vcf.body` in `tempdir`.
+- Produces:
+  ```rust
+  // Runs on a dedicated OS thread; owns `writer`. Returns total body lines written.
+  fn run_assembler_thread(
+      mut writer: VcfLocalWriter,
+      final_output: PathBuf,      // real destination; writer currently targets a temp path
+      temp_output: PathBuf,
+      tempdir: PathBuf,
+      rx: std::sync::mpsc::Receiver<ContigShardRange>,
+  ) -> std::thread::JoinHandle<Result<usize>>
+  ```
+
+- [ ] **Step 1: Write the failing test** (`vcf_sink.rs` `#[cfg(test)]`)
+
+```rust
+#[test]
+fn assembler_appends_ranges_in_order_and_counts_lines() {
+    use std::io::Write;
+    let dir = std::env::temp_dir().join(format!("asm_test_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    // three shards: contig0 = [0,2), contig1 = [2,3)
+    for (id, body) in [(0usize, "a\nb\n"), (1, "c\n"), (2, "d\ne\nf\n")] {
+        let mut f = std::fs::File::create(dir.join(format!("partition_{id:04}.vcf.body"))).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+    let out = dir.join("out.vcf");
+    let tmp = dir.join("out.vcf.tmp");
+    let writer = VcfLocalWriter::with_compression(&tmp, VcfCompressionType::Plain).unwrap();
+    let (tx, rx) = std::sync::mpsc::channel();
+    let h = run_assembler_thread(writer, out.clone(), tmp, dir.clone(), rx);
+    tx.send(ContigShardRange { first_shard_id: 0, end_shard_id: 2, output_lines: 3 }).unwrap();
+    tx.send(ContigShardRange { first_shard_id: 2, end_shard_id: 3, output_lines: 3 }).unwrap();
+    drop(tx);
+    let total = h.join().unwrap().unwrap();
+    assert_eq!(total, 6);
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "a\nb\nc\nd\ne\nf\n");
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep assembler_appends_ranges_in_order -- --nocapture`
+Expected: FAIL — `run_assembler_thread` not found.
+
+- [ ] **Step 3: Implement `run_assembler_thread`**
+
+Add to `vcf_sink.rs` (near the deleted concat helpers). It appends shard files raw through the writer (Plain = byte copy; Gzip = compress-on-append), counts `output_lines` from the message (no re-scan), removes each shard after copy, then `writer.finish()` and atomic-rename temp→final:
+```rust
+fn run_assembler_thread(
+    mut writer: VcfLocalWriter,
+    final_output: PathBuf,
+    temp_output: PathBuf,
+    tempdir: PathBuf,
+    rx: std::sync::mpsc::Receiver<ContigShardRange>,
+) -> std::thread::JoinHandle<Result<usize>> {
+    std::thread::spawn(move || -> Result<usize> {
+        let mut total_lines = 0usize;
+        let mut buffer = vec![0u8; 8 * 1024 * 1024];
+        while let Ok(range) = rx.recv() {
+            for id in range.first_shard_id..range.end_shard_id {
+                let path = tempdir.join(format!("partition_{id:04}.vcf.body"));
+                let mut f = std::fs::File::open(&path).map_err(|e| {
+                    DataFusionError::Execution(format!("assembler open shard {}: {e}", path.display()))
+                })?;
+                loop {
+                    let n = f.read(&mut buffer).map_err(|e| {
+                        DataFusionError::Execution(format!("assembler read shard {}: {e}", path.display()))
+                    })?;
+                    if n == 0 { break; }
+                    write_vcf_body_chunk(&mut writer, &buffer[..n])?;
+                }
+                let _ = std::fs::remove_file(&path);
+            }
+            total_lines += range.output_lines;
+        }
+        // Sender dropped == annotation finished with no error.
+        writer.finish()?;
+        std::fs::rename(&temp_output, &final_output).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "assembler rename {} -> {}: {e}",
+                temp_output.display(), final_output.display()
+            ))
+        })?;
+        Ok(total_lines)
+    })
+}
+```
+
+- [ ] **Step 4: Run the assembler unit test**
+
+Run: `cargo test -p datafusion-bio-function-vep assembler_appends_ranges_in_order -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 5: Rewire `annotate_to_vcf` + `drive_sharded_vcf_annotation`**
+
+In `annotate_to_vcf` (vcf_sink.rs:1107–1156): the writer must target a **temp path** and be owned by the assembler. Replace the writer creation (1108–1115) so, for `workers > 1`, we write the header to a temp-path writer, hand ownership to the assembler, and the header for `workers == 1` stays as-is. Concretely, keep header-writing on `writer` (1110), then in the `workers > 1` branch:
+```rust
+    if config.workers > 1 {
+        let tempdir = VcfBodyTempDir::new()?;
+        let (contig_done_tx, contig_done_rx) = std::sync::mpsc::channel::<ContigShardRange>();
+        let shard_ctx = Arc::new(VcfShardContext {
+            vcf_info_fields: Arc::new(vcf_info_fields),
+            unique_format_tags: Arc::new(unique_format_tags),
+            sample_names: Arc::new(sample_names),
+            coordinate_zero_based,
+            tempdir: tempdir.path().to_path_buf(),
+            rows_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            contig_done_tx,
+        });
+        // `writer` already has the header; it targets `temp_output`. Move it to
+        // the assembler thread, which finalizes + renames to `output_vcf`.
+        let assembler = run_assembler_thread(
+            writer,
+            Path::new(output_vcf).to_path_buf(),
+            temp_output.clone(),
+            tempdir.path().to_path_buf(),
+            contig_done_rx,
+        );
+        // Drive the annotation stream (drops shard_ctx.contig_done_tx clones as
+        // contigs complete; the ORIGINAL tx lives on shard_ctx, dropped below).
+        drive_sharded_vcf_annotation(
+            &ctx, vcf_table, cache_source, backend, cache_source_type,
+            options_json.clone(), &vcf_schema, &projection_names,
+            Arc::clone(&shard_ctx), &pb, config, total_input,
+        ).await?;
+        // Drop the last sender so the assembler sees channel close → finalize.
+        drop(shard_ctx);
+        total_rows = assembler.join().map_err(|_| {
+            DataFusionError::Execution("assembler thread panicked".to_string())
+        })??;
+        drop(tempdir);
+    } else { /* unchanged serial path */ }
+```
+Where `temp_output` is computed just before the writer is created:
+```rust
+    let output_path = Path::new(output_vcf);
+    let temp_output = output_path.with_extension(format!(
+        "{}.part",
+        output_path.extension().and_then(|s| s.to_str()).unwrap_or("vcf")
+    ));
+    let mut writer = VcfLocalWriter::with_compression(&temp_output, config.compression)?;
+```
+Change `drive_sharded_vcf_annotation`'s signature: drop the `writer: &mut VcfLocalWriter` param and its `-> Result<usize>` concat return; it now returns `Result<()>` and its body is **only** the plan-drive + progress-poller loop (current lines 730–833), deleting everything from line 835 (`// Assemble:`) onward. The `report(shard_ctx.rows_done...)` final flush at 833 stays.
+Delete `copy_body_file_counting_lines` (680–703) and `bytecount` (705–707). Update the terminal `writer.finish()` at 1241–1245 so it runs **only** in the serial (`workers == 1`) branch (the assembler already finished the parallel writer). Guard it:
+```rust
+    if config.workers <= 1 {
+        let finish_started = Instant::now();
+        writer.finish()?;
+        if let Some(profile) = sink_profile.as_mut() { profile.writer_finish += finish_started.elapsed(); }
+    }
+```
+(Move `writer` into the assembler for `workers > 1`; the serial branch keeps ownership, so this compiles — but the `let mut writer` binding is consumed by the `if` branch. Restructure so `writer` is declared and, in the parallel branch, `writer` is moved into `run_assembler_thread` while the serial branch owns it to the end. Use the branch structure above where the parallel branch fully consumes `writer` and returns early-ish; the serial branch owns it through `finish()`.)
+
+- [ ] **Step 6: Build + run the full vep test suite**
+
+Run: `cargo test -p datafusion-bio-function-vep -- --nocapture`
+Expected: PASS (including `vcf_output_roundtrip.rs` and the new assembler test).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/vcf_sink.rs datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "feat(vep): pipelined per-contig shard assembler thread (plain/gzip)"
+```
+
+---
+
+### Task 5: Stage 1 byte-identical e2e parity gate
+
+**Files:**
+- No source changes; verification only. Uses `vepyr/e2e-testing/scripts/run_annotation_fast.py`.
+
+- [ ] **Step 1: Capture a pre-change baseline** (from the commit BEFORE Task 1; do this once, up front, or check out the parent)
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+python e2e-testing/scripts/run_annotation_fast.py chr4 --cache merged --workers 4 --force --skip-compare
+cp "$(ls -t /path/to/work/vepyr_*_chr4_merged.vcf | head -1)" /tmp/baseline_chr4_w4.vcf
+```
+
+- [ ] **Step 2: Build the changed engine + rerun**
+
+Run:
+```bash
+cd /Users/mwiewior/research/git/datafusion-bio-functions && cargo build --release -p datafusion-bio-function-vep
+cd /Users/mwiewior/research/git/vepyr && maturin develop --release   # rebuild vepyr against new engine
+python e2e-testing/scripts/run_annotation_fast.py chr4 --cache merged --workers 4 --force --skip-compare
+```
+
+- [ ] **Step 3: Assert byte-identical**
+
+Run: `cmp /tmp/baseline_chr4_w4.vcf "$(ls -t /path/to/work/vepyr_*_chr4_merged.vcf | head -1)" && echo "BYTE-IDENTICAL OK"`
+Expected: `BYTE-IDENTICAL OK` (no output from `cmp`).
+
+- [ ] **Step 4: Assert the tail shrank** (profiling sanity, not a hard gate)
+
+Run: `VEP_PROFILE=1 python e2e-testing/scripts/run_annotation_fast.py chr1 --cache merged --workers 8 --force --skip-compare 2>&1 | grep -E "VEP_PROGRESS|vcf_sink_profile"`
+Expected: `writer_finish` collapses toward ~0 for the parallel path (assembler overlapped); wall-clock gap between last `[VEP_PROGRESS] annotated N/N` and process exit is materially smaller than the pre-change ~13s.
+
+- [ ] **Step 5: Commit the verification note**
+
+```bash
+git commit --allow-empty -m "test(vep): Stage 1 chr4 w4 byte-identical + tail-overlap verified"
+```
+
+---
+
+## Stage 2 — BGZF shards + raw block concat (parallel compression)
+
+> Prereq: Stage 1 merged. Entirely within `datafusion-bio-functions` — no bio-formats change, no dependency bump. BGZF compression reuses the existing `VcfLocalWriter::Bgzf`; the EOF marker is hardcoded.
+
+### Task 6: `VcfBodyShardWriter` owns a `VcfLocalWriter` (enables BGZF shards)
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/vcf_sink.rs` — `VcfBodyShardWriter` (303–386); `VcfShardContext` (add `shard_compression`); construction at 1131
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs:9916` — pass compression to `create`
+
+**Interfaces:**
+- Consumes: `VcfLocalWriter`, `VcfCompressionType`, `write_vcf_body_chunk` (all already in scope in vcf_sink.rs).
+- Produces:
+  - `VcfShardContext` gains `pub(crate) shard_compression: VcfCompressionType` (only ever `Bgzf` or `Plain`).
+  - `VcfBodyShardWriter::create(path, info, tags, samples, zero_based, compression: VcfCompressionType) -> Result<Self>`, internally owning a `VcfLocalWriter`.
+  - For `Bgzf`, `.bytes`/`.lines`/`.input_rows` still count *uncompressed* body; the file holds BGZF blocks + a trailing 28-byte EOF from `VcfLocalWriter::finish()` (stripped by the assembler in Task 7).
+
+- [ ] **Step 1: Write the failing test** (`vcf_sink.rs` `#[cfg(test)]`)
+
+```rust
+#[test]
+fn shard_writer_bgzf_file_is_decodable() {
+    use std::io::Read;
+    let dir = std::env::temp_dir().join(format!("shard_bgzf_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("partition_0000.vcf.body");
+    let w = VcfBodyShardWriter::create(
+        &path, Arc::new(vec![]), Arc::new(vec![]), Arc::new(vec![]), false,
+        VcfCompressionType::Bgzf,
+    ).unwrap();
+    let lines = w.lines;               // 0 — no batches written
+    w.finish().unwrap();               // flushes bgzf blocks + EOF
+    // The empty bgzf shard is a valid, decodable bgzf file (EOF-only).
+    let mut reader = noodles_bgzf::Reader::new(std::fs::File::open(&path).unwrap());
+    let mut s = String::new();
+    reader.read_to_string(&mut s).unwrap();
+    assert_eq!(s, "");
+    assert_eq!(lines, 0);
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+NOTE: the test references `noodles_bgzf::Reader` only for *reading* in the test; it is not a crate dependency of the shipped code. If `noodles-bgzf` is not resolvable from the test target, decode instead via `bgzip -dc` in a `std::process::Command` and assert the stdout, or gate this assertion behind a helper. The shipped code never names `noodles-bgzf`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep shard_writer_bgzf_file_is_decodable -- --nocapture`
+Expected: FAIL — `create` arity (compression arg) not found.
+
+- [ ] **Step 3: Implement**
+
+Change `VcfBodyShardWriter.writer` from `std::io::BufWriter<std::fs::File>` to `VcfLocalWriter`:
+```rust
+pub(crate) struct VcfBodyShardWriter {
+    writer: VcfLocalWriter,
+    vcf_info_fields: Arc<Vec<String>>,
+    unique_format_tags: Arc<Vec<String>>,
+    sample_names: Arc<Vec<String>>,
+    coordinate_zero_based: bool,
+    batch_id: usize,
+    pub(crate) lines: usize,
+    pub(crate) input_rows: usize,
+    pub(crate) bytes: usize,
+}
+```
+`create` takes `compression: VcfCompressionType` and builds the sink via the existing bio-formats constructor:
+```rust
+    pub(crate) fn create(
+        path: &Path,
+        vcf_info_fields: Arc<Vec<String>>,
+        unique_format_tags: Arc<Vec<String>>,
+        sample_names: Arc<Vec<String>>,
+        coordinate_zero_based: bool,
+        compression: VcfCompressionType,
+    ) -> Result<Self> {
+        let writer = VcfLocalWriter::with_compression(path, compression)?;
+        Ok(Self { writer, vcf_info_fields, unique_format_tags, sample_names,
+                  coordinate_zero_based, batch_id: 0, lines: 0, input_rows: 0, bytes: 0 })
+    }
+```
+`write_formatted` writes through the existing chunk helper (keeps counters + returns IO duration):
+```rust
+    fn write_formatted(&mut self, formatted: &FormattedVcfBatch) -> Result<Duration> {
+        let started = Instant::now();
+        write_vcf_body_chunk(&mut self.writer, &formatted.bytes)?;
+        let elapsed = started.elapsed();
+        self.lines += formatted.lines;
+        self.input_rows += formatted.input_rows;
+        self.bytes += formatted.bytes.len();
+        Ok(elapsed)
+    }
+```
+`finish` consumes the `VcfLocalWriter` (for `Bgzf` this appends the EOF marker):
+```rust
+    pub(crate) fn finish(self) -> Result<()> { self.writer.finish() }
+```
+
+- [ ] **Step 4: Thread compression through `VcfShardContext` + the worker**
+
+Add `pub(crate) shard_compression: VcfCompressionType` to `VcfShardContext`. In `annotate_to_vcf`'s `workers>1` branch, set it (only two possibilities — bgzf shards for bgzf output, else plain text shards):
+```rust
+            shard_compression: if config.compression == VcfCompressionType::Bgzf {
+                VcfCompressionType::Bgzf
+            } else {
+                VcfCompressionType::Plain
+            },
+```
+At annotate_provider.rs:9916, pass `shard_ctx.shard_compression` as the new `create` arg (a `Copy` field on the `Arc<VcfShardContext>`).
+
+- [ ] **Step 5: Run test + build**
+
+Run: `cargo test -p datafusion-bio-function-vep shard_writer_bgzf -- --nocapture && cargo build -p datafusion-bio-function-vep`
+Expected: PASS + clean build. (Plain output still works: `VcfLocalWriter::Plain` byte path is identical to the old raw `BufWriter`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/vcf_sink.rs datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "feat(vep): VcfBodyShardWriter owns VcfLocalWriter (BGZF shards via existing enum)"
+```
+
+---
+
+### Task 7: Raw-BGZF assembler mode + mode selection
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/vcf_sink.rs` — hardcode `BGZF_EOF`; add `run_assembler_thread_bgzf`; BGZF header pre-compression; select mode from `config.compression`.
+
+**Interfaces:**
+- Consumes: local `const BGZF_EOF: [u8; 28]`; `VcfLocalWriter::Bgzf` (for header compression); BGZF shard files (Task 6).
+- Produces:
+  ```rust
+  const BGZF_EOF: [u8; 28];   // canonical BGZF end-of-file marker (SAM spec)
+  fn bgzf_blocks_no_eof(path: &Path) -> Result<Vec<u8>>;  // read a finished bgzf file, strip trailing EOF
+  fn run_assembler_thread_bgzf(
+      temp_output: PathBuf, final_output: PathBuf, tempdir: PathBuf,
+      header_blocks: Vec<u8>, rx: std::sync::mpsc::Receiver<ContigShardRange>,
+  ) -> std::thread::JoinHandle<Result<usize>>;
+  ```
+- Behavior: For BGZF output the assembler owns a raw `BufWriter<File>` (NOT a `VcfLocalWriter::Bgzf` — shards are already compressed and must not be re-compressed). It writes the pre-compressed `header_blocks`, then raw-appends each shard **minus its trailing 28-byte EOF**, then writes one `BGZF_EOF`, flushes, renames.
+
+- [ ] **Step 1: Write the failing test** (`vcf_sink.rs` `#[cfg(test)]`)
+
+```rust
+#[test]
+fn assembler_bgzf_raw_concat_decodes_in_order() {
+    use std::io::{Read, Write};
+    let dir = std::env::temp_dir().join(format!("asm_bgzf_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    // Produce bgzf shards exactly as VcfBodyShardWriter (bgzf) does: write body
+    // through a VcfLocalWriter::Bgzf, finish() (appends EOF), leave file on disk.
+    let write_bgzf = |path: &std::path::Path, body: &str| {
+        let mut w = VcfLocalWriter::with_compression(path, VcfCompressionType::Bgzf).unwrap();
+        write_vcf_body_chunk(&mut w, body.as_bytes()).unwrap();
+        w.finish().unwrap();
+    };
+    for (id, body) in [(0usize, "a\nb\n"), (1usize, "c\n")] {
+        write_bgzf(&dir.join(format!("partition_{id:04}.vcf.body")), body);
+    }
+    // Header blocks: compress "##header\n#CHROM\n" and strip its EOF.
+    let hpath = dir.join("hdr.bgz");
+    write_bgzf(&hpath, "##header\n#CHROM\n");
+    let header_blocks = bgzf_blocks_no_eof(&hpath).unwrap();
+
+    let out = dir.join("out.vcf.gz");
+    let tmp = dir.join("out.vcf.gz.part");
+    let (tx, rx) = std::sync::mpsc::channel();
+    let h = run_assembler_thread_bgzf(tmp.clone(), out.clone(), dir.clone(), header_blocks, rx);
+    tx.send(ContigShardRange { first_shard_id: 0, end_shard_id: 1, output_lines: 2 }).unwrap();
+    tx.send(ContigShardRange { first_shard_id: 1, end_shard_id: 2, output_lines: 1 }).unwrap();
+    drop(tx);
+    let total = h.join().unwrap().unwrap();
+    assert_eq!(total, 3);
+    // Decode the assembled file (bgzip is available in the e2e toolchain).
+    let decoded = std::process::Command::new("bgzip").arg("-dc").arg(&out).output().unwrap();
+    assert_eq!(String::from_utf8_lossy(&decoded.stdout), "##header\n#CHROM\na\nb\nc\n");
+    std::fs::remove_dir_all(&dir).ok();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep assembler_bgzf_raw_concat -- --nocapture`
+Expected: FAIL — `BGZF_EOF` / `bgzf_blocks_no_eof` / `run_assembler_thread_bgzf` not found.
+
+- [ ] **Step 3: Implement the constant + helpers + assembler**
+
+Hardcode the marker (SAM-spec fixed 28 bytes — identical across htslib/samtools/noodles) in `vcf_sink.rs`:
+```rust
+/// Canonical 28-byte BGZF end-of-file marker (an empty BGZF block). Written
+/// exactly once, at the very end of an assembled BGZF file. Every finished bgzf
+/// file (`VcfLocalWriter::Bgzf::finish()`) ends with these exact bytes.
+const BGZF_EOF: [u8; 28] = [
+    0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x06, 0x00, 0x42, 0x43,
+    0x02, 0x00, 0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+/// Read a finished bgzf file and return its bytes with the trailing 28-byte EOF
+/// marker removed, ready for raw concatenation into a larger bgzf stream.
+fn bgzf_blocks_no_eof(path: &Path) -> Result<Vec<u8>> {
+    let mut bytes = std::fs::read(path).map_err(|e| {
+        DataFusionError::Execution(format!("read bgzf shard {}: {e}", path.display()))
+    })?;
+    debug_assert!(bytes.len() >= BGZF_EOF.len() && bytes[bytes.len() - BGZF_EOF.len()..] == BGZF_EOF);
+    let keep = bytes.len().saturating_sub(BGZF_EOF.len());
+    bytes.truncate(keep);
+    Ok(bytes)
+}
+```
+The assembler owns a raw file writer (shards carry their own compression):
+```rust
+fn run_assembler_thread_bgzf(
+    temp_output: PathBuf,
+    final_output: PathBuf,
+    tempdir: PathBuf,
+    header_blocks: Vec<u8>,
+    rx: std::sync::mpsc::Receiver<ContigShardRange>,
+) -> std::thread::JoinHandle<Result<usize>> {
+    std::thread::spawn(move || -> Result<usize> {
+        let file = std::fs::File::create(&temp_output).map_err(|e| {
+            DataFusionError::Execution(format!("assembler create {}: {e}", temp_output.display()))
+        })?;
+        let mut out = std::io::BufWriter::new(file);
+        out.write_all(&header_blocks)
+            .map_err(|e| DataFusionError::Execution(format!("assembler write header: {e}")))?;
+        let mut total_lines = 0usize;
+        while let Ok(range) = rx.recv() {
+            for id in range.first_shard_id..range.end_shard_id {
+                let path = tempdir.join(format!("partition_{id:04}.vcf.body"));
+                let blocks = bgzf_blocks_no_eof(&path)?;
+                out.write_all(&blocks)
+                    .map_err(|e| DataFusionError::Execution(format!("assembler write shard: {e}")))?;
+                let _ = std::fs::remove_file(&path);
+            }
+            total_lines += range.output_lines;
+        }
+        out.write_all(&BGZF_EOF)
+            .map_err(|e| DataFusionError::Execution(format!("assembler write EOF: {e}")))?;
+        out.flush()
+            .map_err(|e| DataFusionError::Execution(format!("assembler flush: {e}")))?;
+        drop(out);
+        std::fs::rename(&temp_output, &final_output).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "assembler rename {} -> {}: {e}", temp_output.display(), final_output.display()
+            ))
+        })?;
+        Ok(total_lines)
+    })
+}
+```
+
+- [ ] **Step 4: Mode selection + BGZF header pre-compression in `annotate_to_vcf`**
+
+In the `workers>1` branch, branch on compression. For BGZF, compress the header into its own temp bgzf file via the existing writer, strip the EOF, and hand the blocks to the bgzf assembler (do NOT write the header to the main temp writer):
+```rust
+        if config.compression == VcfCompressionType::Bgzf {
+            let header_tmp = tempdir.path().join("header.bgz");
+            let mut hw = VcfLocalWriter::with_compression(&header_tmp, VcfCompressionType::Bgzf)?;
+            hw.write_header(&write_schema, &vcf_info_fields_for_header, &unique_format_tags_for_header, &sample_names_for_header)?;
+            hw.finish()?;
+            let header_blocks = bgzf_blocks_no_eof(&header_tmp)?;
+            let _ = std::fs::remove_file(&header_tmp);
+            let assembler = run_assembler_thread_bgzf(
+                temp_output.clone(), Path::new(output_vcf).to_path_buf(),
+                tempdir.path().to_path_buf(), header_blocks, contig_done_rx,
+            );
+            /* drive stream; drop(shard_ctx); total_rows = assembler.join()??; */
+        } else {
+            // Plain/Gzip: header already written to `writer` (temp path); Task 4 assembler.
+            let assembler = run_assembler_thread(
+                writer, Path::new(output_vcf).to_path_buf(), temp_output.clone(),
+                tempdir.path().to_path_buf(), contig_done_rx,
+            );
+            /* drive stream; drop(shard_ctx); total_rows = assembler.join()??; */
+        }
+```
+NOTE: capture the header field slices (`vcf_info_fields`, `unique_format_tags`, `sample_names`) BEFORE they are moved into `VcfShardContext` at construction (clone the `Vec`s or reorder so the header write happens first), since the shard ctx takes ownership via `Arc::new(...)`. For Plain/Gzip, `writer` already holds the header (written at vcf_sink.rs:1110) and is moved into the assembler as in Task 4 — do not double-write it. Set `shard_compression` on `VcfShardContext` as in Task 6 Step 4.
+
+- [ ] **Step 5: Run test + full suite**
+
+Run: `cargo test -p datafusion-bio-function-vep -- --nocapture`
+Expected: PASS (assembler_bgzf test + all Stage 1 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/vcf_sink.rs
+git commit -m "feat(vep): raw-BGZF assembler mode + shard/assembler compression selection"
+```
+
+---
+
+### Task 8: Stage 2 BGZF parity + parallel-compression gate
+
+**Files:**
+- Verification only.
+
+- [ ] **Step 1: Content parity — BGZF output decompresses to the Plain output**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr && maturin develop --release
+python e2e-testing/scripts/run_annotation_fast.py chr4 --cache merged --workers 4 --force --skip-compare        # plain .vcf
+# force bgzf by writing a .vcf.gz target (via vepyr compression="bgzf" or a .gz output path)
+python e2e-testing/scripts/run_annotation_fast.py chr4 --cache merged --workers 4 --force --skip-compare --bgzf  # add flag or set output .vcf.gz
+```
+Then:
+```bash
+PLAIN=$(ls -t /path/work/vepyr_*_chr4_merged.vcf | head -1)
+BGZF=$(ls -t /path/work/vepyr_*_chr4_merged.vcf.gz | head -1)
+cmp <(grep -v '^##' "$PLAIN") <(bgzip -dc "$BGZF" | grep -v '^##') && echo "BGZF BODY BYTE-IDENTICAL"
+bgzip -t "$BGZF" && echo "BGZF EOF/INTEGRITY OK"           # asserts exactly one valid EOF
+tabix -p vcf "$BGZF" && echo "TABIX INDEX OK"              # asserts block/vpos integrity
+```
+Expected: all three OK.
+
+- [ ] **Step 2: Confirm compression parallelized (tail + CPU)**
+
+Run: `VEP_PROFILE=1 python e2e-testing/scripts/run_annotation_fast.py chr1 --cache merged --workers 8 --force --skip-compare --bgzf 2>&1 | grep -E "VEP_PROGRESS|vcf_sink_profile"`
+Expected: BGZF wall-clock tail after 100% is comparable to the Plain assembler tail (compression no longer serial); not the pre-change single-threaded-gzip tail.
+
+- [ ] **Step 3: Golden merged suite still green**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && pytest tests/test_golden_merged.py tests/test_run_annotation_fast.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: Commit verification note**
+
+```bash
+git commit --allow-empty -m "test(vep): Stage 2 BGZF body-identical + tabix-valid + parallel compression verified"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Overlap contig N concat with contig N+1 prep" → Tasks 1–4 (assembler thread + per-contig range publish; the async stream keeps polling `prepare_contig_context` while the assembler copies on its own thread).
+- "Incremental append, not re-merge" → Task 4 assembler appends each range once, in order; O(total bytes), no re-copy.
+- "Cover both modes" → Stage 1 Plain/Gzip (text shards + recopy), Stage 2 BGZF (parallel-compressed shards + raw block concat).
+- "Single writer / ordering safe" → Global Constraints + Task 4 (one thread, arrival-order ranges).
+- "Line counting without re-scan" → Task 2 (worker-reported `output_lines`) feeds Task 4/8 totals; `copy_body_file_counting_lines`/`bytecount` deleted.
+- "Error = no partial output" → temp path + atomic rename (Tasks 4, 8); `_ = send()` best-effort so an assembler-gone error path doesn't panic the stream.
+- "BGZF EOF correctness" → Task 7 (`bgzf_blocks_no_eof` strips each piece's trailing EOF, one hardcoded canonical `BGZF_EOF` written at the very end), Task 8 (`bgzip -t` + `tabix` gates).
+- "No bio-formats change / no new dep" → Stage 2 reuses `VcfLocalWriter::Bgzf` (Task 6) and hardcodes `BGZF_EOF` locally (Task 7); nothing outside `datafusion-bio-functions` is touched.
+
+**Placeholder scan:** No TODO/TBD; every code step shows code; verification steps show exact commands + expected output. Paths that vary by machine (`/path/work/...`) are the vepyr work dir — resolve via `ls -t` as shown.
+
+**Type consistency:** `ContigShardRange{first_shard_id,end_shard_id,output_lines}` used identically in Tasks 1/3/4/7. `ShardResult{input_rows,output_lines}` in Task 2 consumed by Task 3's `(contig_rows, contig_lines)` binding. `VcfBodyShardWriter::create(..., compression: VcfCompressionType)` and `VcfShardContext.shard_compression: VcfCompressionType` (only `Bgzf`/`Plain`) in Tasks 6/7. `BGZF_EOF` hardcoded in Task 7, used by `bgzf_blocks_no_eof` (Task 7). `run_assembler_thread` (Plain/Gzip, Task 4) vs `run_assembler_thread_bgzf` (BGZF, Task 7) — distinct names, selected in Task 7 Step 4.
+
+**Known friction to watch during execution:**
+- Moving `VcfLocalWriter` into the assembler thread for `workers>1` while the serial branch keeps ownership — structure the `if config.workers > 1 { ... } else { ... }` so exactly one branch consumes `writer`. The parallel branch moves it into `run_assembler_thread`; guard the terminal `writer.finish()` behind `workers <= 1` (Task 4 Step 5).
+- `drive_sharded_vcf_annotation` signature change (drop `writer`, return `Result<()>`) — update its single call site (vcf_sink.rs:1139).
+- The `_ = shard_ctx.contig_done_tx.send(...)` in annotate_provider must clone `contig_done_tx` (it's `Sender`, `Clone`) — `VcfShardContext` derives `Clone`, and `std::sync::mpsc::Sender: Clone`, so `shard_ctx.contig_done_tx.clone()` is implied by the `Arc<VcfShardContext>` deref; ensure the ORIGINAL non-cloned sender lives on the `shard_ctx` dropped in `annotate_to_vcf` after the drive completes, so channel-close fires exactly once.


### PR DESCRIPTION
## Summary

Two changes to the VEP VCF output path (each its own commit):

### 1. Pipelined per-contig shard assembler (`feat`, 25d6943)
Replaces the single-threaded post-100%-progress shard-merge tail (~13s on WGS) with a **dedicated assembler thread** that concatenates each contig's VCF body shards the instant that contig's workers finish — *concurrently* with the next contig's `prepare_contig_context` + annotation — then atomically renames the assembled temp file into place.

- `ContigAnnotationStream` publishes each contig's completed `[first, end)` shard-id range (contig-major/worker-minor == final VCF position order) on completion.
- Shard workers report output line counts (`ShardResult`) so the assembler needs **no merge-time re-scan** (deletes `copy_body_file_counting_lines` + `bytecount`).
- **Plain/Gzip:** text shards, assembler re-copies via `VcfLocalWriter`.
- **Bgzf:** `VcfBodyShardWriter` now owns a `VcfLocalWriter`, so workers bgzf-compress their own shard **in parallel**; the assembler raw-concats blocks minus each 28-byte EOF and writes one canonical `BGZF_EOF`. **No new deps, no bio-formats change** — reuses the existing `VcfLocalWriter::Bgzf`.

### 2. Serial (`workers=1`) truncation fix (`fix`, cdf9743)
Pre-existing race in the `AnnotatingContig` state machine, **independent** of the assembler work (the `workers>1` path uses `recv().await` and is structurally immune). When `poll_lookup_partitions` grabbed ≥1 lookup batch then the lookup stalled (`Poll::Pending`) with a sub-window buffer and nothing in flight, it returned `Poll::Ready(Ok(()))` **without arming a waker**; the outer loop misread that as "contig done" and aborted the still-running lookup, silently dropping the rest of the contig. Timing race → ~half of contigs lost their tail on a whole-genome run (chr22 emitted 5,000/50,861 rows).

Fix: only yield a partial buffer when there is in-flight work to drain; otherwise park (`start_lookup_waits` + `Poll::Pending`). Extracted as `may_yield_partial_buffer(made_progress, has_inflight)` with a regression unit test.

## Verification

- **782 lib tests** pass (4 new assembler tests: plain ordering + line counts, bgzf raw-concat decode, bgzf shard decode; + the truncation regression test).
- **Whole-genome (HG002 chr1–22, merged/parquet), workers=1 vs workers=4:**
  - Total body rows **4,096,123 = 4,096,123**; **all 22 contigs identical row counts, 0 mismatches**.
  - workers=4 completed in ~91s vs workers=1 ~228s.
  - Serial fix confirmed: chr22 workers=1 now emits all 50,861 rows (was 5,000).
- **bgzf whole-genome (workers=4):** `bgzip -t` OK (one valid EOF across the full 1.5 GB file), `tabix` OK (all 22 contigs), decompressed body **4,096,123 lines = exact match**; ~16.5× compression (1.5 GB vs 25 GB).
- Full byte-identical body `cmp`s (plain w1-vs-w4, bgzf-vs-plain) were running at PR-open time; per-contig counts + integrity already confirm completeness.

## Notes
- Plan: `docs/superpowers/plans/2026-07-05-pipelined-shard-assembler-both-modes.md`.
- **Out of scope / separate finding:** `##FORMAT`/`##INFO` header lines emit in run-to-run non-deterministic order (a HashMap iteration in bio-formats `build_vcf_header_lines`). Cosmetic, body unaffected — compare bodies (not raw bytes) for byte-identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)