### PR TITLE
fix(vep): cfg-gate peak_rss_mb() so bio-function-vep builds on Windows (#187)

### DIFF
--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -16,7 +16,6 @@ bytes = "1"
 log.workspace = true
 async-trait = "0.1.88"
 chrono = "0.4"
-libc = "0.2"
 ahash = { version = "0.8.6", optional = true }
 hashbrown = { version = "0.16.1", optional = true }
 nohash-hasher = { version = "0.2.0", optional = true }
@@ -32,6 +31,11 @@ parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
 datafusion-bio-format-vcf ={ git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8", optional = true }
 indicatif = "0.18.4"
+
+# `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here
+# keeps it out of Windows/MSVC builds, where those symbols don't exist.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 mimalloc = "0.1"

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -8630,6 +8630,7 @@ impl ContigPipelineProfile {
 
 /// Process peak resident set size in MB (`getrusage` `ru_maxrss`, monotonic
 /// high-water mark). macOS reports bytes; Linux reports kilobytes.
+#[cfg(unix)]
 fn peak_rss_mb() -> u64 {
     let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
     if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } != 0 {
@@ -8644,6 +8645,19 @@ fn peak_rss_mb() -> u64 {
     {
         max / 1024
     }
+}
+
+/// Peak-RSS reporting is not implemented on non-UNIX targets (no `getrusage`).
+/// Warns once so the `0` values in profiling output aren't mistaken for real
+/// measurements.
+#[cfg(not(unix))]
+fn peak_rss_mb() -> u64 {
+    use std::sync::Once;
+    static WARN_ONCE: Once = Once::new();
+    WARN_ONCE.call_once(|| {
+        log::warn!("peak_rss_mb() is not implemented on this platform; reporting 0");
+    });
+    0
 }
 
 /// Log the current peak RSS at a phase boundary (VEP_PROFILE only). Because


### PR DESCRIPTION
## Problem

`peak_rss_mb()` in `datafusion/bio-function-vep/src/annotate_provider.rs` used UNIX-only `libc` APIs (`rusage` / `getrusage` / `RUSAGE_SELF`) with no platform gating, so **Windows/MSVC builds fail to compile**:

```
error[E0412]: cannot find type `rusage` in crate `libc`
error[E0425]: cannot find function `getrusage` in crate `libc`
error[E0425]: cannot find value `RUSAGE_SELF` in crate `libc`
```

Surfaced by [vepyr](https://github.com/biodatageeks)'s `windows (x64)` wheel CI (maturin), which depends on this crate. Linux/macOS are unaffected.

## Fix

- Gate the `getrusage` implementation behind `#[cfg(unix)]` — macOS (bytes) / Linux (kB) math is unchanged.
- Add a `#[cfg(not(unix))]` fallback that returns `0` and emits a **single** `log::warn!` (via `std::sync::Once`) so the `0` isn't mistaken for a real measurement.
- Move `libc = "0.2"` to `[target.'cfg(unix)'.dependencies]` so it isn't even a direct dependency on Windows.

This is a diagnostics-only code path (`VEP_PROFILE`); there is **no behavior change on macOS/Linux**.

> A real Windows peak-RSS impl via `GetProcessMemoryInfo`/`PeakWorkingSetSize` could be added later if wanted — deliberately out of scope here.

## Verification

- `cargo build -p datafusion-bio-function-vep` (unix) — Finished, unchanged behavior
- `cargo clippy -p datafusion-bio-function-vep` — no warnings
- `libc` is no longer a **direct** dep on `x86_64-pc-windows-msvc` (only transitive, via crates that gate their own usage)
- The exact gated function typechecks for `x86_64-pc-windows-gnu` (`cargo check --target x86_64-pc-windows-gnu`), confirming the `not(unix)` branch is valid Windows Rust and pulls no `libc`

Full downstream MSVC wheel build isn't runnable locally (a transitive dep, `aws-lc-sys`, needs a mingw C toolchain to cross-compile), so the definitive end-to-end gate is vepyr's `windows (x64)` CI.

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)