### PR TITLE
docs: VEP plugin port factory — spec + Plan A (engine)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-plugin-factory-engine.md
+++ b/docs/superpowers/plans/2026-07-13-plugin-factory-engine.md
@@ -33,7 +33,7 @@ behind." **That was wrong.** The branches diverged at `v0.10.0` and both moved:
 
 - `master` took `a6e19ad` — *Lance-only cache, grid-aligned parallel annotation, SIFT v2 + AF
   zero-copy, engine-redundancy trims (#181)* — which rewrote `annotate_provider.rs`
-  (**+6907/−2446**) and **deleted** `variant_lookup_exec.rs`.
+  (**+7130/−2576**) and **deleted** `variant_lookup_exec.rs`.
 - `dev-test` has **45 commits** of its own, including a real engine feature that exists **nowhere
   else**: multi-ALT CSQ per-allele expansion (`PerAltCtx`, `vcf_to_vep_allele_multi`). `master` still
   treats `alt` as a single allele (`annotate_provider.rs:5325`).
@@ -396,10 +396,18 @@ type = "Float32"
 ```
 
 > **The reader has no `pos` column.** Its core schema is `chrom, start, end, id, ref, alt, qual,
-> filter, <INFO…>`; VCF POS is exposed as **`start`** (1-based, `UInt32`), with a matching `end`.
+> filter, <INFO…>`; VCF POS is exposed as **`start`** (1-based, `UInt32`). `end` equals `start` only
+> for a plain single-ALT SNV — for indels and MNVs the reader reports `POS + len(REF) - 1`.
 > Every VCF-sourced manifest's `ingest_sql` must select `start`/`end`. This was confirmed against
 > `bio-format-vcf` v1.8.8 (`header_builder.rs:364-372`) while implementing this task — the original
 > draft of this plan said `pos`, and was wrong.
+>
+> **The reader also pipe-joins multi-allelic ALTs into one value** (`A → G,T` yields `alt = "G|T"`).
+> So the natural `concat(ref, '/', alt) AS allele_string` stores `A/G|T`, which can never equal the
+> runtime probe key (`A/G`) — the rows build clean and are dead forever. `ingest_sql` must split the
+> ALTs so each is its own row (e.g. `unnest(string_to_array(alt, '|'))`). The engine now rejects a
+> pipe-joined `allele_string` at build time rather than letting it through silently, but the manifest
+> author still has to write the split.
 >
 > The `coordinate_system_zero_based = false` argument is what makes `start` the true 1-based POS;
 > passing `true` yields `22893741`. The assertion above is the guard against that off-by-one — do not
@@ -838,7 +846,7 @@ cargo fmt --check
 ```
 Expected: all green. Fix anything that is not before proceeding — do not open the PR on a red suite.
 
-- [ ] **Step 3: Commit and open the PR into `dev-test`**
+- [ ] **Step 3: Commit and open the PR into `master-sitekwb`**
 
 ```bash
 git add datafusion/bio-function-vep/examples/build_plugin.rs

--- a/docs/superpowers/plans/2026-07-13-plugin-factory-engine.md
+++ b/docs/superpowers/plans/2026-07-13-plugin-factory-engine.md
@@ -375,7 +375,7 @@ type = "Float32"
 
         // INFO columns are bare, case-sensitive keys -> must be backticked.
         let batches = ctx
-            .sql("SELECT chrom, pos, `SCORE` FROM plugin_demo_src ORDER BY pos")
+            .sql("SELECT chrom, `start`, `SCORE` FROM plugin_demo_src ORDER BY `start`")
             .await
             .unwrap()
             .collect()
@@ -386,17 +386,24 @@ type = "Float32"
         assert_eq!(rows, 2, "both VCF records must be visible");
 
         // The reader must report 1-based POS (22893742), matching the cache's 1-based start.
-        let pos = batches[0]
+        let start = batches[0]
             .column(1)
             .as_any()
             .downcast_ref::<datafusion::arrow::array::UInt32Array>()
-            .expect("pos is UInt32");
-        assert_eq!(pos.value(0), 22_893_742);
+            .expect("start is UInt32");
+        assert_eq!(start.value(0), 22_893_742);
     }
 ```
 
-> If `pos` turns out to be a different integer width, the downcast panics with a message naming the
-> actual type — fix the `downcast_ref` to that type and keep the value assertion. Do not weaken the
+> **The reader has no `pos` column.** Its core schema is `chrom, start, end, id, ref, alt, qual,
+> filter, <INFO…>`; VCF POS is exposed as **`start`** (1-based, `UInt32`), with a matching `end`.
+> Every VCF-sourced manifest's `ingest_sql` must select `start`/`end`. This was confirmed against
+> `bio-format-vcf` v1.8.8 (`header_builder.rs:364-372`) while implementing this task — the original
+> draft of this plan said `pos`, and was wrong.
+>
+> The `coordinate_system_zero_based = false` argument is what makes `start` the true 1-based POS;
+> passing `true` yields `22893741`. The assertion above is the guard against that off-by-one — do not
+> weaken the
 > assertion to "some number".
 
 - [ ] **Step 2: Run it and watch it fail**
@@ -435,8 +442,10 @@ with these two arms. The surrounding loop already binds `let table = spec.table_
             ProviderKind::Vcf => {
                 let info_fields = spec.vcf.as_ref().and_then(|v| v.info_fields.clone());
                 // ObjectStorageOptions::default() sets compression_type = AUTO, which is what
-                // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. Passing `None`
-                // is NOT equivalent — the reader's own tests always pass explicit options.
+                // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. `None` would
+                // behave identically today (every consumption site in the reader does
+                // `unwrap_or_default()`), but passing the value explicitly keeps the compression
+                // policy visible at the call site.
                 //
                 // coordinate_system_zero_based = false: VCF POS is 1-based and the plugin cache
                 // stores 1-based start/end, so the reader must not shift. The manifest's

--- a/docs/superpowers/plans/2026-07-13-plugin-factory-engine.md
+++ b/docs/superpowers/plans/2026-07-13-plugin-factory-engine.md
@@ -1,0 +1,866 @@
+# Plugin Factory — Plan A: Engine (VCF provider wiring + manifest hardening)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `plugin_cache` able to ingest VCF-sourced plugins and make a malformed manifest fail loudly instead of silently, so that Wave-1 plugin ports really are "manifest only".
+
+**Architecture:** `plugin_cache` already registers CSV/TSV/Parquet sources through DataFusion's builtin providers and returns `NotImplemented` for `vcf`/`bed`. The `bio-function-vep` crate **already depends on `datafusion-bio-format-vcf`** (`Cargo.toml:33`, tag `v1.8.8`), which ships a complete `VcfTableProvider` with INFO projection and BGZF support. So this is **wiring, not implementation**. Alongside it, four correctness fixes to the manifest/driver surface that currently fail silently or lie.
+
+**Tech Stack:** Rust, DataFusion, serde/toml, `datafusion-bio-format-vcf`.
+
+**Source spec:** `docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md` (§7).
+
+---
+
+## Scope note (deviation from the spec, deliberate)
+
+Spec §7.1 says wire **both** `vcf` and `bed`. This plan wires **`vcf` only**.
+
+Reason: no Wave-0 client needs BED, and `bio-format-bed` is **not** currently a dependency of
+`bio-function-vep` (only `bio-format-vcf` is), so wiring it means adding a dependency for zero
+callers. YAGNI. `Bed` keeps returning `NotImplemented`, but Task 4 makes that error honest.
+When a BED-sourced plugin appears (Wave 2), wiring it is a copy of Task 3.
+
+---
+
+## Prerequisite 0 — sync `dev-test` with `master` (blocks everything)
+
+**RESOLVED — this prerequisite is obsolete. Read it anyway: it explains why the base branch is what
+it is.**
+
+The original plan said "sync `dev-test` with `master`; expect no conflicts, `dev-test` is strictly
+behind." **That was wrong.** The branches diverged at `v0.10.0` and both moved:
+
+- `master` took `a6e19ad` — *Lance-only cache, grid-aligned parallel annotation, SIFT v2 + AF
+  zero-copy, engine-redundancy trims (#181)* — which rewrote `annotate_provider.rs`
+  (**+6907/−2446**) and **deleted** `variant_lookup_exec.rs`.
+- `dev-test` has **45 commits** of its own, including a real engine feature that exists **nowhere
+  else**: multi-ALT CSQ per-allele expansion (`PerAltCtx`, `vcf_to_vep_allele_multi`). `master` still
+  treats `alt` as a single allele (`annotate_provider.rs:5325`).
+
+So merging them is not conflict resolution — it is **porting a feature into a rewritten hot path**.
+149 files merge cleanly; the 5 conflicting hunks are all CSQ per-allele assembly. Get it wrong and
+nothing crashes: every multi-allelic variant is just silently mis-annotated. That deserves its own PR
+and its own parity test on multi-allelic sites, and it has **nothing to do with the plugin factory**.
+
+**Decision (2026-07-13): decouple.**
+
+- Base branch for all factory work is **`master-sitekwb`** — cut from `master`, so it already
+  contains `plugin_cache` (14 files). It is treated as our `main`: every PR targets it.
+- **Never commit to `master` or `main`.**
+- The multi-ALT port from `dev-test` is tracked separately and does not block anything here.
+
+---
+
+## Working branch for Tasks 1–7
+
+```bash
+cd /Users/wojtek/Documents/vepyr/datafusion-bio-functions
+git fetch origin
+git worktree add ../datafusion-bio-functions-worktrees/plugin-engine \
+  -b feat/plugin-cache-vcf-provider origin/master-sitekwb
+cd ../datafusion-bio-functions-worktrees/plugin-engine
+```
+
+Every PR in this plan targets `master-sitekwb` (`gh pr create --base master-sitekwb ...`).
+
+All paths below are relative to that worktree.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs` | The TOML manifest schema — the contract with `vepyr-plugins` | Modify: `deny_unknown_fields`, new `VcfParams`, new `SourceSpec.vcf` field |
+| `datafusion/bio-function-vep/src/plugin_cache/provider.rs` | Registers each source as a DataFusion table | Modify: wire `ProviderKind::Vcf`; sharpen the `Bed` error |
+| `datafusion/bio-function-vep/src/plugin_cache/builder.rs` | Per-chrom build loop, manifest UPSERT | Modify: make `overwrite` mean something |
+| `datafusion/bio-function-vep/examples/build_plugin.rs` | The build driver | Modify: `--source-path` for all sources, repeatable `--chrom` |
+| `datafusion/bio-function-vep/Cargo.toml` | Deps | Modify: add `datafusion-bio-format-core` (for `ObjectStorageOptions`) |
+
+---
+
+### Task 1: Make an unknown manifest key a hard error
+
+Today `SourceManifest` has no `deny_unknown_fields`. A typo, or the `[tier]` block that the design
+docs still show and the struct does not have, is **silently ignored** — the manifest "works" and
+quietly does something other than what it says. Proof that this already bit us: the existing test in
+`provider.rs:173-174` carries a live `[tier]` block that does nothing.
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs`
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/provider.rs:146-177` (test fixture)
+- Test: same files (`#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block at the bottom of `source_manifest.rs`:
+
+```rust
+    #[test]
+    fn rejects_unknown_key_instead_of_ignoring_it() {
+        // `[tier]` is documented in old handoffs but does not exist in SourceManifest.
+        // Before deny_unknown_fields this parsed happily and did nothing.
+        let src = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "csv"
+path = "/tmp/x.tsv"
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+
+[tier]
+threshold = 0.01
+"##;
+        let err = toml::from_str::<SourceManifest>(src)
+            .expect_err("unknown key [tier] must be rejected");
+        assert!(
+            err.to_string().contains("tier"),
+            "the error must name the offending key, got: {err}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache \
+  plugin_cache::source_manifest::tests::rejects_unknown_key_instead_of_ignoring_it
+```
+Expected: FAIL — `unknown key [tier] must be rejected` (the parse currently succeeds).
+
+- [ ] **Step 3: Add `deny_unknown_fields` to every manifest struct**
+
+In `source_manifest.rs`, add the attribute to each of these six structs (keep all existing
+attributes; just add one line under the `#[derive(...)]`):
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SchemaField { /* unchanged */ }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CsvParams { /* unchanged */ }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSpec { /* unchanged */ }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValueColumn { /* unchanged */ }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MatchColumn { /* unchanged */ }
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceManifest { /* unchanged */ }
+```
+
+- [ ] **Step 4: Run the new test — it passes, and one old test now fails**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache plugin_cache
+```
+Expected: `rejects_unknown_key_instead_of_ignoring_it` PASSES, and
+`provider::tests::registers_csv_source_with_declared_schema` now **FAILS** on `unknown field 'tier'`.
+That failure is the point: it proves the dead block was being silently swallowed.
+
+- [ ] **Step 5: Delete the dead `[tier]` block from the provider test fixture**
+
+In `provider.rs`, inside `registers_csv_source_with_declared_schema`, remove these two lines from the
+TOML literal (they sit after the `[[value_columns]]` block):
+
+```toml
+[tier]
+threshold = 0.01
+```
+
+- [ ] **Step 6: Run the whole plugin_cache suite green**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache plugin_cache
+```
+Expected: PASS, all tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs \
+        datafusion/bio-function-vep/src/plugin_cache/provider.rs
+git commit -m "fix(plugin_cache): reject unknown manifest keys instead of silently ignoring them
+
+A typo — or the [tier] block that the design docs still show and SourceManifest
+never had — parsed happily and did nothing. The provider test fixture carried
+exactly such a dead [tier] block, which is why this went unnoticed."
+```
+
+---
+
+### Task 2: Parse `[source.vcf]` (INFO field selection)
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs`
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `source_manifest.rs`:
+
+```rust
+    #[test]
+    fn parses_vcf_source_with_selected_info_fields() {
+        let src = r##"
+plugin_name = "mastermind"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "/tmp/mastermind.vcf.gz"
+  [source.vcf]
+  info_fields = ["MMID3", "MMCNT1"]
+
+[[value_columns]]
+column = "mmid3"
+csq_field = "MM_MMID3"
+type = "Utf8"
+"##;
+        let m: SourceManifest = toml::from_str(src).unwrap();
+        assert_eq!(m.sources[0].provider, ProviderKind::Vcf);
+        let vcf = m.sources[0].vcf.as_ref().expect("[source.vcf] must parse");
+        assert_eq!(
+            vcf.info_fields.as_deref(),
+            Some(["MMID3".to_string(), "MMCNT1".to_string()].as_slice())
+        );
+    }
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache \
+  plugin_cache::source_manifest::tests::parses_vcf_source_with_selected_info_fields
+```
+Expected: FAIL — compile error, `no field 'vcf' on SourceSpec`.
+
+- [ ] **Step 3: Add `VcfParams` and the `SourceSpec.vcf` field**
+
+In `source_manifest.rs`, add after `CsvParams`/`default_delim`:
+
+```rust
+/// VCF provider parameters.
+///
+/// `info_fields` selects which INFO keys are materialized as columns; omit it to
+/// take every INFO key declared in the VCF header. NOTE: the reader exposes INFO
+/// keys as **bare, case-sensitive column names** (`AF`, `ALLELE_ID`) — not
+/// `info_af` as `bio-format-vcf`'s crate docs claim — so `ingest_sql` must
+/// backtick them: ``SELECT `AF` FROM plugin_x_src``.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VcfParams {
+    #[serde(default)]
+    pub info_fields: Option<Vec<String>>,
+}
+```
+
+and extend `SourceSpec` with one field (everything else unchanged):
+
+```rust
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSpec {
+    #[serde(default)]
+    pub part: Option<String>,
+    pub provider: ProviderKind,
+    pub path: String,
+    #[serde(default)]
+    pub csv: Option<CsvParams>,
+    #[serde(default)]
+    pub vcf: Option<VcfParams>,
+}
+```
+
+Fix the one constructor that builds `SourceSpec` literally — in the same file's tests,
+`single_source_table_name_has_no_part_suffix` must gain `vcf: None,`:
+
+```rust
+        let src = SourceSpec {
+            part: None,
+            provider: ProviderKind::Csv,
+            path: "x".into(),
+            csv: None,
+            vcf: None,
+        };
+```
+
+- [ ] **Step 4: Run it green**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache plugin_cache::source_manifest
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+git commit -m "feat(plugin_cache): parse [source.vcf] with optional info_fields selection"
+```
+
+---
+
+### Task 3: Wire `VcfTableProvider` into `register_sources`
+
+`ProviderKind::Vcf` already passes manifest validation and then explodes at build time with
+`NotImplemented` (`provider.rs:111-116`) — the worst possible ordering. The reader already exists and
+is already a dependency; this is wiring.
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/Cargo.toml` (add `datafusion-bio-format-core`)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/provider.rs`
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `provider.rs`:
+
+```rust
+    #[tokio::test(flavor = "multi_thread")]
+    async fn registers_vcf_source_and_projects_info_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("demo.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr22\t22893742\t.\tC\tG\t.\t.\tSCORE=0.9\n\
+             chr22\t22893800\t.\tA\tT\t.\t.\tSCORE=0.1\n",
+        )
+        .unwrap();
+
+        let toml_src = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "{}"
+  [source.vcf]
+  info_fields = ["SCORE"]
+
+[[value_columns]]
+column = "score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+
+        let manifest: SourceManifest = toml::from_str(&toml_src).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+
+        // INFO columns are bare, case-sensitive keys -> must be backticked.
+        let batches = ctx
+            .sql("SELECT chrom, pos, `SCORE` FROM plugin_demo_src ORDER BY pos")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 2, "both VCF records must be visible");
+
+        // The reader must report 1-based POS (22893742), matching the cache's 1-based start.
+        let pos = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt32Array>()
+            .expect("pos is UInt32");
+        assert_eq!(pos.value(0), 22_893_742);
+    }
+```
+
+> If `pos` turns out to be a different integer width, the downcast panics with a message naming the
+> actual type — fix the `downcast_ref` to that type and keep the value assertion. Do not weaken the
+> assertion to "some number".
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache \
+  plugin_cache::provider::tests::registers_vcf_source_and_projects_info_fields
+```
+Expected: FAIL — `NotImplemented: provider Vcf not wired in prototype`.
+
+- [ ] **Step 3: Add the `bio-format-core` dependency**
+
+In `datafusion/bio-function-vep/Cargo.toml`, next to the existing `datafusion-bio-format-vcf` line
+(line 33), add — **same git tag**, or the two crates will disagree on `ObjectStorageOptions`:
+
+```toml
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
+```
+
+- [ ] **Step 4: Wire the provider**
+
+In `provider.rs`, add to the imports at the top:
+
+```rust
+use std::sync::Arc;
+
+use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
+use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
+```
+
+and replace the `ProviderKind::Vcf | ProviderKind::Bed => { ... }` arm (currently `provider.rs:111-116`)
+with these two arms. The surrounding loop already binds `let table = spec.table_name(&manifest.plugin_name);`
+(a `String`), so `table.as_str()` is the table name to register under:
+
+```rust
+            ProviderKind::Vcf => {
+                let info_fields = spec.vcf.as_ref().and_then(|v| v.info_fields.clone());
+                // ObjectStorageOptions::default() sets compression_type = AUTO, which is what
+                // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. Passing `None`
+                // is NOT equivalent — the reader's own tests always pass explicit options.
+                //
+                // coordinate_system_zero_based = false: VCF POS is 1-based and the plugin cache
+                // stores 1-based start/end, so the reader must not shift. The manifest's
+                // `coordinate_system` remains the single source of truth for any shift the
+                // builder applies (see plugin_cache::build::wrap_normalization).
+                let vcf_table = VcfTableProvider::new(
+                    spec.path.clone(),
+                    info_fields,
+                    None,
+                    Some(ObjectStorageOptions::default()),
+                    false,
+                )?;
+                ctx.register_table(table.as_str(), Arc::new(vcf_table))?;
+            }
+            ProviderKind::Bed => {
+                return Err(DataFusionError::NotImplemented(format!(
+                    "provider 'bed' is not wired yet (table '{table}'); \
+                     no plugin needs it — wire datafusion-bio-format-bed the way \
+                     ProviderKind::Vcf is wired when one does"
+                )));
+            }
+```
+
+Also update the module doc comment on line 1-3, which currently claims VCF/BED "are not wired in the
+prototype":
+
+```rust
+//! Provider factory: register a source manifest's raw tables under their
+//! `plugin_<name>_src[_<part>]` names. CSV/TSV/Parquet use builtin DataFusion
+//! providers; VCF uses bio-formats' `VcfTableProvider`. BED is not wired yet
+//! (no plugin needs it).
+```
+
+- [ ] **Step 5: Run it green**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache plugin_cache::provider
+```
+Expected: PASS — both the CSV test and the new VCF test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add datafusion/bio-function-vep/Cargo.toml Cargo.lock \
+        datafusion/bio-function-vep/src/plugin_cache/provider.rs
+git commit -m "feat(plugin_cache): wire VcfTableProvider for provider = \"vcf\"
+
+Unblocks the VCF-sourced Bucket A plugins (Mastermind, gnomADMt, EVE, Geno2MP,
+SubsetVCF), which the feasibility analysis had classified as 'manifest only'
+while the provider actually returned NotImplemented."
+```
+
+---
+
+### Task 4: Make `--overwrite` mean something
+
+`builder.rs:106` reads, literally, `let _ = self.overwrite;` — the flag is plumbed through the
+builder and then dropped. A user asking for a clean rebuild silently gets an incremental one.
+
+The one thing it should control is the **preservation of prior chrom entries**: `build_all` reuses
+the previous `manifest.json`'s chroms so a filtered rebuild UPSERTs instead of dropping. With
+`overwrite = true`, start from an empty chrom list.
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/builder.rs:90-106`
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `builder.rs`. This is the exact mirror of the existing
+`filtered_rebuild_preserves_other_chroms` test (`builder.rs:280-344`) — same `write_gz` /
+`write_variation` helpers, same fixture — but asserting the opposite outcome under `--overwrite`.
+Note the builder takes chrom filters as raw labels (`"1"`, `"2"`) and canonicalises them to
+`chr1`/`chr2` in the manifest.
+
+```rust
+    // The mirror image of `filtered_rebuild_preserves_other_chroms`: with --overwrite,
+    // a filtered rebuild must NOT preserve the previously built chroms.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn overwrite_drops_chroms_from_a_previous_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.tsv.gz");
+        write_gz(&src, "chr1\t100\tA\tG\t0.9\nchr2\t200\tC\tT\t0.5\n");
+        let var_dir = dir.path().join("cache").join("variation");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        write_variation(&var_dir.join("chr1.parquet"), &[("1", 100, "A/G", 0)]);
+        write_variation(&var_dir.join("chr2.parquet"), &[("2", 200, "C/T", 1)]);
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            src.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let cache_dir = dir.path().join("cache");
+        let out = dir.path().join("out");
+
+        // Baseline: build both chroms.
+        let first = PluginCacheBuilder::new(&manifest, "demo.source.toml", &cache_dir, &out)
+            .with_chrom_filter(["1", "2"])
+            .build_all()
+            .await
+            .unwrap();
+        assert_eq!(first.chroms.len(), 2, "baseline must contain both chroms");
+
+        // Rebuild chr2 alone, with overwrite: chr1 must be gone from the manifest.
+        let second = PluginCacheBuilder::new(&manifest, "demo.source.toml", &cache_dir, &out)
+            .with_chrom_filter(["2"])
+            .with_overwrite(true)
+            .build_all()
+            .await
+            .unwrap();
+
+        let chroms: Vec<&str> = second.chroms.iter().map(|c| c.chrom.as_str()).collect();
+        assert_eq!(chroms, ["chr2"], "overwrite must not preserve chr1: {chroms:?}");
+    }
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache \
+  plugin_cache::builder::tests::overwrite_drops_chroms_from_a_previous_build
+```
+Expected: FAIL — `overwrite must not preserve chr1: ["chr1", "chr2"]`.
+
+- [ ] **Step 3: Honour the flag**
+
+In `builder.rs`, in `build_all`, replace the chrom-preservation block (currently lines ~101-106,
+ending in `let _ = self.overwrite;`) with:
+
+```rust
+        // Preserve chromosomes from a prior build (their shards remain on disk), so a
+        // filtered/incremental build UPSERTs the rebuilt chroms rather than dropping the
+        // others from the manifest that runtime discovery relies on. Two things suppress
+        // that: an explicit --overwrite (the user asked for a clean build), and a schema
+        // change (old shards would be misprojected under the new schema).
+        let mut chroms: Vec<ChromEntry> = if self.overwrite {
+            Vec::new()
+        } else {
+            std::fs::read_to_string(plugin_dir.join("manifest.json"))
+                .ok()
+                .and_then(|t| serde_json::from_str::<CacheManifest>(&t).ok())
+                .filter(|old| schema_matches(old, &cache))
+                .map(|m| m.chroms)
+                .unwrap_or_default()
+        };
+```
+
+(Delete the `let _ = self.overwrite;` line.)
+
+- [ ] **Step 4: Run it green**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache plugin_cache::builder
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/builder.rs
+git commit -m "fix(plugin_cache): --overwrite was a no-op (let _ = self.overwrite)
+
+It now drops prior chrom entries, so a clean rebuild is actually clean instead of
+silently incremental."
+```
+
+---
+
+### Task 5: `--source-path` must reach every source, not just the first
+
+`examples/build_plugin.rs:38-42` applies the override to `manifest.sources.first_mut()`. A multi-part
+manifest (`[[source]] part = "snv"` + `part = "indel"`) silently keeps the stale path for every
+source but the first — and the build then reads whatever the manifest's baked-in path points at.
+
+New semantics, explicit rather than clever:
+- `--source-path <path>` — allowed **only** when the manifest has exactly one source. With several,
+  it is an error telling you to use the part form.
+- `--source-path <part>=<path>` — repeatable; overrides the source with that `part`.
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/examples/build_plugin.rs`
+
+- [ ] **Step 1: Add a repeatable-arg helper and the override logic**
+
+Replace the `arg()` helper (lines 17-22) with `arg()` plus an `args_all()`:
+
+```rust
+fn arg(args: &[String], key: &str) -> Option<String> {
+    args.iter()
+        .position(|a| a == key)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+/// Every occurrence of `--key <value>` (the flag may repeat).
+fn args_all(args: &[String], key: &str) -> Vec<String> {
+    args.iter()
+        .enumerate()
+        .filter(|(_, a)| a.as_str() == key)
+        .filter_map(|(i, _)| args.get(i + 1).cloned())
+        .collect()
+}
+```
+
+and replace the `--source-path` block (lines 38-42) with:
+
+```rust
+    for spec in args_all(&args, "--source-path") {
+        match spec.split_once('=') {
+            // --source-path <part>=<path>
+            Some((part, path)) => {
+                let target = manifest
+                    .sources
+                    .iter_mut()
+                    .find(|s| s.part.as_deref() == Some(part))
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "--source-path '{part}=...': no [[source]] with part = \"{part}\""
+                        ))
+                    })?;
+                target.path = path.to_string();
+            }
+            // --source-path <path> — unambiguous only for a single-source manifest
+            None => {
+                if manifest.sources.len() != 1 {
+                    return Err(DataFusionError::Execution(format!(
+                        "--source-path <path> is ambiguous: the manifest has {} sources; \
+                         use --source-path <part>=<path> (parts: {})",
+                        manifest.sources.len(),
+                        manifest
+                            .sources
+                            .iter()
+                            .map(|s| s.part.as_deref().unwrap_or("<none>"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )));
+                }
+                manifest.sources[0].path = spec;
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo build -p datafusion-bio-function-vep --features parquet-cache --example build_plugin
+```
+Expected: builds clean.
+
+- [ ] **Step 3: Verify the ambiguity guard fires**
+
+Point it at the AlphaMissense manifest (single source → the bare form must be accepted) and confirm
+the run gets past argument parsing to the "variation shard not found" error, which proves the
+override was applied:
+
+```bash
+cargo run -p datafusion-bio-function-vep --features parquet-cache --example build_plugin -- \
+  --manifest /Users/wojtek/Documents/vepyr/vepyr-plugins/plugins/alphamissense/alphamissense.source.toml \
+  --source-path /tmp/does-not-exist.tsv.gz \
+  --variation-cache-dir /tmp/nonexistent-cache \
+  --out /tmp/plugin_out
+```
+Expected: it prints `Building plugin 'alphamissense' from '/tmp/does-not-exist.tsv.gz'` — the path
+override reached the source — and then fails with `variation shard not found`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add datafusion/bio-function-vep/examples/build_plugin.rs
+git commit -m "fix(build_plugin): --source-path reached only the first source
+
+Multi-part manifests silently kept their baked-in paths. Bare form is now an error
+when the manifest has several sources; use --source-path <part>=<path>."
+```
+
+---
+
+### Task 6: `--chrom` must be repeatable
+
+`arg()` returns only the first occurrence, so `--chrom 21 --chrom 22` silently builds chr21 alone —
+a filtered build that quietly does less than asked.
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/examples/build_plugin.rs:54-56`
+
+- [ ] **Step 1: Use the `args_all` helper from Task 5**
+
+Replace:
+
+```rust
+    if let Some(chrom) = arg(&args, "--chrom") {
+        builder = builder.with_chrom_filter([chrom]);
+    }
+```
+
+with:
+
+```rust
+    let chroms = args_all(&args, "--chrom");
+    if !chroms.is_empty() {
+        builder = builder.with_chrom_filter(chroms);
+    }
+```
+
+(`with_chrom_filter` already takes an `IntoIterator` and treats an empty vec as "no filter", so this
+is a straight swap.)
+
+- [ ] **Step 2: Verify it compiles and both chroms are requested**
+
+```bash
+cargo run -p datafusion-bio-function-vep --features parquet-cache --example build_plugin -- \
+  --manifest /Users/wojtek/Documents/vepyr/vepyr-plugins/plugins/alphamissense/alphamissense.source.toml \
+  --variation-cache-dir /tmp/nonexistent-cache \
+  --out /tmp/plugin_out --chrom 21 --chrom 22
+```
+Expected: fails with `variation shard not found: /tmp/nonexistent-cache/variation/chr21.parquet` —
+i.e. it resolved the *filter*, not just the first value. (Before the fix the message is identical, so
+confirm the change by also running with `--chrom 22 --chrom 21` and seeing chr22 named first.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add datafusion/bio-function-vep/examples/build_plugin.rs
+git commit -m "fix(build_plugin): --chrom now accepts repetition (only the first was read)"
+```
+
+---
+
+### Task 7: Update the driver's usage docs, then open the PR
+
+The example's header comment (lines 3-9) documents the old single-`--chrom`, first-source-only
+behaviour.
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/examples/build_plugin.rs:1-9`
+
+- [ ] **Step 1: Rewrite the doc header**
+
+```rust
+//! Build a plugin cache from a source manifest (all chroms, or a filtered set).
+//!
+//! ```text
+//! cargo run -p datafusion-bio-function-vep --features parquet-cache --example build_plugin -- \
+//!   --manifest <vepyr-plugins>/plugins/alphamissense/alphamissense.source.toml \
+//!   --source-path /tmp/AlphaMissense_hg38.tsv.gz \
+//!   --variation-cache-dir <cache root containing variation/> \
+//!   --out /tmp/plugin_cache \
+//!   [--chrom 21 --chrom 22]        # repeatable; omit to build every chrom in the cache
+//! ```
+//!
+//! `--source-path` takes a bare path only when the manifest declares a single
+//! `[[source]]`; for multi-part manifests use `--source-path <part>=<path>`, repeated.
+```
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+cargo test -p datafusion-bio-function-vep --features parquet-cache
+cargo clippy -p datafusion-bio-function-vep --features parquet-cache -- -D warnings
+cargo fmt --check
+```
+Expected: all green. Fix anything that is not before proceeding — do not open the PR on a red suite.
+
+- [ ] **Step 3: Commit and open the PR into `dev-test`**
+
+```bash
+git add datafusion/bio-function-vep/examples/build_plugin.rs
+git commit -m "docs(build_plugin): document repeatable --chrom and part-scoped --source-path"
+git push -u origin feat/plugin-cache-vcf-provider
+gh pr create --base master-sitekwb \
+  --title "feat(plugin_cache): wire VCF provider + harden the manifest surface" \
+  --body "Plan A of the plugin port factory (spec: docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md).
+
+Wires \`provider = \"vcf\"\` to bio-formats' VcfTableProvider — already a dependency, so this is wiring, not implementation. Unblocks the VCF-sourced Bucket A plugins (Mastermind, gnomADMt, EVE, Geno2MP, SubsetVCF), which the feasibility analysis had filed under 'manifest only' while the provider in fact returned NotImplemented.
+
+Plus four fixes to things that failed silently:
+- unknown manifest keys were ignored (a live, dead \`[tier]\` block in our own test fixture proved it)
+- \`--overwrite\` was literally \`let _ = self.overwrite;\`
+- \`--source-path\` reached only the first source, so multi-part manifests kept stale paths
+- \`--chrom\` read only its first occurrence
+
+BED stays NotImplemented on purpose: no plugin needs it and it is not a dependency. The error now says so."
+```
+
+---
+
+## What this plan does NOT do (and which plan does)
+
+- `vepyr.build_plugin_cache` binding, the `vepyr.parity` comparator, the mini-cache slicer →
+  **Plan B (toolkit)**.
+- The parity harness, `parity.toml`, CI, and the three clients (AlphaMissense / REVEL /
+  Mastermind-or-gnomADMt) → **Plan C (catalogue)**, which depends on A and B.
+- Gene-keyed lookup, interval lookup, `match_column` fallback, wider `ValueType`, bigwig →
+  out of scope by §3 and §9 of the spec.
+
+**A VCF provider with no client is an unproven provider.** Task 3's unit test shows the reader
+registers and projects; only Plan C's parity gate on a real VCF-sourced plugin proves it end-to-end.
+That is exactly why the spec makes one VCF plugin part of the Wave-0 definition of done.

--- a/docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md
+++ b/docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md
@@ -1,0 +1,304 @@
+# VEP Plugin Port Factory (Wave 0) — Design
+
+**Date:** 2026-07-13
+**Status:** Design, approved in brainstorming; not yet implemented
+**Supersedes the runbook in:** `HANDOFF veppluginsport.md` (2026-07-12) — see §1, several of its
+premises are false against the code.
+**Builds on:**
+- `docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md` (engine design)
+- `docs/superpowers/specs/2026-07-06-vepyr-plugin-cache-integration-design.md`
+- `docs/superpowers/specs/2026-07-10-vep-plugins-systematic-port-feasibility.md` (bucket analysis;
+  on branch `dev-test-plugins-feasibility`)
+
+---
+
+## 0. Summary
+
+The feasibility analysis concluded that ~30 of the 78 in-scope VEP plugins are a genuine assembly
+line: porting one means authoring a TOML manifest, not writing Rust. That conclusion holds. What
+does *not* exist yet is the assembly line itself — the thing that makes plugin #2 cost a day
+instead of a week.
+
+This spec designs **Wave 0: the factory**. Four components:
+
+1. **A region-sliced mini-cache fixture** — because the real cache is 34 GB and CI cannot hold it.
+2. **A parity harness** with a blame-attribution rule — the decisive gate, reusable across every
+   plugin as configuration rather than code.
+3. **Engine work** — wiring the already-existing VCF/BED readers into `plugin_cache` (they are
+   `NotImplemented` today) plus four small hardening fixes.
+4. **A manifest scaffolder skill**.
+
+**Definition of done:** `parity --check` passes for three clients, each proving a different axis —
+AlphaMissense (the harness is correct), REVEL (a newcomer can port a TSV plugin from a manifest
+alone), and one VCF-sourced plugin (the new provider wiring works end-to-end).
+
+---
+
+## 1. Corrections to the prior handoff
+
+The 2026-07-12 handoff proposed a copy-paste runbook. Four of its premises are false against the
+code, and following it would waste a session:
+
+| Handoff claim | Reality |
+|---|---|
+| `vepyr-plugins` is inaccessible; the blocker is repo access (§5) | It is cloned locally and public to us. It has a **working AlphaMissense manifest on `master`** — a real, parity-passed reference. |
+| "Python surface (already shipped): `vepyr.build_plugin_cache(...)`" (§2) | **Does not exist.** `grep -r plugin_cache` in the `vepyr` repo returns nothing. The builder is `PluginCacheBuilder` (Rust) driven by `cargo run --example build_plugin --features parquet-cache`. |
+| Seed manifests for REVEL/PrimateAI (§6.2–6.3), to be pasted in | Written blind. They use `has_header = true` with no `schema` block; the only working manifest uses `has_header = false` + an explicit `schema`. They also carry a `[tier]` block that **does not exist in `SourceManifest`** and is silently ignored. Discard them; regenerate from the AlphaMissense pattern. |
+| Bucket A is "framework READY, port = manifest only" | Only for `csv`/`tsv`/`parquet`. `provider.rs:111-116` returns `NotImplemented` for **`vcf`** and **`bed`**, and roughly a third of Bucket A's sources are tabix VCF (EVE, Mastermind, Geno2MP, gnomADMt, SubsetVCF). |
+
+Two facts the handoff missed, both favourable:
+
+- **A reference Ensembl VEP is already installed** (`ensembl-vep/`, cache v115, GRCh38 FASTA). The
+  feasibility spec called standing this up "the true gating cost of systematic testing". It is
+  largely paid.
+- **The format readers already exist.** `datafusion-bio-formats` ships `bio-format-vcf` (TableProvider
+  with INFO projection, indexed read, projection pushdown), `bio-format-bed`, and `bio-format-bbi`
+  (bigWig/bigBed). So the missing providers are a **wiring** job, not a format-implementation job.
+  This also cheapens Bucket C, which the feasibility spec priced as MEDIUM on the assumption that a
+  bigwig provider had to be built.
+
+---
+
+## 2. Prerequisite 0 — `dev-test` does not contain `plugin_cache`
+
+Branch policy for this work is: **branch off `dev-test`, PR back into `dev-test`, never touch
+`master`.** But `plugin_cache` lives only on `master` (14 files); `origin/dev-test` is 14 commits
+behind and has **zero** of them.
+
+So the first PR of this effort is mechanical and independent: **sync `dev-test` with `master`.**
+Nothing else in this spec can be built until it lands. It is called out here because it is invisible
+until you try to compile.
+
+---
+
+## 3. Goals / non-goals
+
+**Goals.** Make porting a Bucket A/B plugin cost a manifest plus a config row. Make the parity gate
+executable and reproducible by someone who is not the engine's author. Make a failing gate say
+*which* thing is broken.
+
+**Non-goals for this spec** (each is a separate project; recorded in §9 with the plugins that will
+demand them):
+- Gene/transcript-ID-keyed lookup (Bucket D).
+- Interval/overlap lookup — the cache is point-lookup only; `end` is stored but never read.
+- `match_column` OR/fallback semantics.
+- Widening `ValueType` beyond `Utf8`/`Float32`/`Int32`.
+- The bigwig provider (no client in Wave 0; wiring is now known to be cheap — Wave 2).
+
+---
+
+## 4. Architecture: three repos, three roles
+
+Ownership today is smeared across repos: the CSQ comparator lives in `vepyr/e2e-testing/scripts/`,
+the builder is a cargo example in `datafusion-bio-functions`, and the manifests live in
+`vepyr-plugins`. A PR adding a plugin is therefore not testable by itself. The fix:
+
+- **`datafusion-bio-functions` — the engine.** Mechanisms only: providers, builder, lookup, template.
+  It knows nothing about any specific plugin. Tests are per-mechanism unit tests.
+- **`vepyr` — the toolkit.** Exposes the two things the handoff *assumed* existed:
+  - `vepyr.build_plugin_cache(...)` — a PyO3 binding over `PluginCacheBuilder`.
+  - `vepyr.parity` — the CSQ comparator, lifted out of
+    `e2e-testing/scripts/run_annotation_fast.py:384` (`compare_vcfs`) into an importable module.
+    One comparator, two consumers: the WGS e2e suite and plugin parity. It already handles the hard
+    parts (merge-join on the variant key, CSQ entry-count and entry-order semantics, per-field
+    mismatch counts with examples).
+- **`vepyr-plugins` — the catalogue.** Data and configuration; no engine code. Per plugin: manifest,
+  source slice, golden, parity declaration. Its CI depends on `pip install vepyr` plus the
+  mini-cache. **It never compiles Rust.**
+
+---
+
+## 5. Component 1 — the mini-cache fixture
+
+The full cache is 34 GB; `variation/chr22.parquet` alone is 541 MB and the FASTA is 2.9 GB. Hosted
+CI cannot rebuild the vepyr side, and none of it is committable. So slice once, narrowly.
+
+- **Region: `chr22:22,000,000–23,500,000`** (1.5 Mb). Not arbitrary — it contains the locus on which
+  AlphaMissense parity was manually confirmed (`chr22:22,893,742 C>G`), so the regression in §8 is
+  meaningful.
+- **Slicer:** `scripts/slice_cache.py` in `vepyr`. Filters **every** cache table (`variation`,
+  `transcript`, `exon`, `translation_core`, `translation_sift`, `motif`, `regulatory`) to the region
+  and cuts the matching FASTA window. Expected output: **tens of MB** (order 50–100 MB).
+- **Distribution: a GitHub release asset**, restored in CI via `actions/cache`. Not git-lfs, not a
+  private bucket.
+- **Input VCF:** the HG002 benchmark sliced to the region — a few hundred variants, tens of KB,
+  **committed** to `vepyr-plugins`.
+
+**Stated honestly:** the "1,912/1,912" figure from the manual AlphaMissense parity **cannot** be
+reproduced in CI — that was full chr22. What CI reproduces is *parity on the mini-cache region*. The
+full-chr22 run remains a nightly/manual check on a machine with the 34 GB cache.
+
+---
+
+## 6. Component 2 — the parity harness
+
+One tool, parameterised per plugin by `plugins/<name>/parity.toml`. Two modes:
+
+**`--refresh-golden` (local; needs Perl + the plugin's data).** Runs the **real Ensembl VEP** with
+`--plugin <X>` over the region and writes `plugins/<name>/golden/<name>.vcf`. This is the *only*
+place Perl is required, and it runs when the plugin or its data version changes — not per PR.
+
+**`--check` (CI; hermetic).** Takes the committed golden, builds the plugin cache with
+`vepyr.build_plugin_cache` against the mini-cache, annotates the committed input VCF, and diffs with
+`vepyr.parity`.
+
+### 6.1 The gate, and the blame-attribution rule
+
+A naive diff conflates three failure sources, because plugin fields are *derived from engine
+attributes*: the AlphaMissense discriminator is `{ref_aa}{Protein_position}{alt_aa}`, so if vepyr's
+core annotation disagrees with VEP about the transcript or the amino-acid change, the plugin field
+comes out empty or different — and a naive harness reports "REVEL fails parity" when REVEL's manifest
+is perfect and the core is at fault. The predictable consequence is someone "fixing" parity by
+loosening the gate.
+
+This is not hypothetical: `e2e-testing/reports/` contains `mismatches_parquet_vs_vep_classified.tsv`
+and `issue88_remaining_unresolved.md` — the core *has* known divergences from VEP.
+
+So from the same pair of files (golden VEP-with-plugin ↔ vepyr-with-plugin-cache), and with no extra
+runs, compute two independent verdicts:
+
+1. **Core agreement.** Diff the CSQ fields the discriminator depends on: `Feature`, `Consequence`,
+   `Amino_acids`, `Protein_position`, `ref`/`alt`. This is *not* the gate — it is a property of the
+   core, guarded by the existing e2e suite. Here it only determines the set of lines on which vepyr
+   and VEP already agree.
+2. **The port gate.** Diff the plugin's CSQ fields **restricted to that agreed subset**. If core and
+   VEP agree about the transcript and the amino-acid change, then a plugin-field mismatch is
+   unambiguously the manifest's or `plugin_cache`'s fault. Nothing else.
+
+**Pass criteria:** 100% agreement on the plugin's fields over the agreed subset; **zero
+over-emission** (vepyr must not populate a field where VEP left it empty — one of the two bugs the
+manual AlphaMissense e2e caught that unit tests did not); and **w1-vs-w4 body-identity** (free, and
+it catches races in the lookup).
+
+Lines excluded for core drift are reported **loudly and separately** (`excluded: core drift, N
+lines`) — never silently folded into zero. A rising exclusion rate is a signal about the core.
+
+A `--strict` flag makes core drift fail the build too; that is the mode for PRs against the engine.
+
+### 6.2 One harness, two subjects under test
+
+The same tool tests different things depending on what changed:
+
+- **PR in `vepyr-plugins` (a new manifest)** → the subject is the **manifest**. Engine and vepyr are
+  pinned; run that one plugin.
+- **PR in `datafusion-bio-functions` (an engine change)** → the subject is the **engine**. Manifests
+  are pinned; run the **whole plugin corpus** as a regression net.
+
+The corpus, built once for the plugins' sake, becomes a free safety net for the engine.
+
+### 6.3 Redistribution
+
+Source slices are often not redistributable (REVEL is non-commercial; AlphaMissense is CC-BY-NC).
+`parity.toml` therefore carries `redistributable = true|false`. When `false`, the plugin's test is
+**skipped in public CI with an explicit, visible message** — never silently — and runs only in the
+nightly job on a machine that holds the data. Without this field the factory would either violate a
+licence or quietly go green on empty tests.
+
+---
+
+## 7. Component 3 — engine changes
+
+### 7.1 Provider wiring (not implementation)
+
+`ProviderKind` (`plugin_cache/source_manifest.rs:21-29`) already *declares* `vcf`, `csv`, `tsv`,
+`parquet`, `bed` — so a manifest with `provider = "vcf"` passes validation today and only explodes at
+build time, in `provider.rs:111-116`, with `NotImplemented`.
+
+Wire `bio-format-vcf` under `ProviderKind::Vcf` and `bio-format-bed` under `Bed`. The manifest gains
+a `[source.vcf]` block declaring which INFO fields to project — exactly analogous to the existing
+`[source.csv].schema`. INFO arrays (per-allele values) are handled in `ingest_sql` via the existing
+`unnest` escape hatch.
+
+### 7.2 Manifest hardening
+
+Four small fixes, each of which saves hours of debugging:
+
+- **`#[serde(deny_unknown_fields)]` on `SourceManifest`.** Today a typo — or the `[tier]` block that
+  the handoff still documents and the code does not have — is **silently ignored**. The manifest
+  "works" and quietly does something else.
+- **`--overwrite` stops being a no-op** (`builder.rs:106` literally reads `let _ = self.overwrite;`).
+- **`--source-path` applies to all sources**, not just `sources.first_mut()` — required for
+  multi-part sources.
+- **`--chrom` accepts repetition** (today only the first occurrence is read).
+
+---
+
+## 8. Component 4 — the scaffolder, and the repo layout
+
+**Scaffolder:** a `vep-add-plugin` **skill**, not a CLI — because half the work is *reading the
+`.pm` header and deciding which bucket the plugin belongs to*, which is model work, not parser work.
+Input: plugin name + data URL. Output: a `<name>.source.toml` stub on the AlphaMissense pattern, a
+`parity.toml`, an empty `golden/`, and the §4 playbook checklist. It mechanically enforces exactly
+what the handoff's blind seeds got wrong: an explicit `schema` instead of `has_header`, the TOML
+scalar-ordering trap (top-level keys must precede any `[[table]]` header), and a `path` that the
+build driver overrides.
+
+**Layout in `vepyr-plugins`:**
+
+```
+plugins/<name>/
+  <name>.source.toml     # manifest (exists today for alphamissense)
+  parity.toml            # csq_fields, region, Perl plugin version, redistributable
+  fixtures/<name>.slice  # source slice for the region (if redistributable)
+  golden/<name>.vcf      # real VEP --plugin <X> output (written by --refresh-golden)
+```
+
+---
+
+## 9. Known engine limits (deliberately out of scope, with their future clients)
+
+Recording these so they are not rediscovered painfully:
+
+- **`ValueType` has only `Utf8`/`Float32`/`Int32`** — no Int64/Float64. Will bite any plugin needing
+  double precision.
+- **`match_column` supports multiple columns but only conjunctive exact match** — no OR/fallback, so
+  VEP's "match on transcript_id, else on aa-change" cannot be expressed. Also: the multi-column path
+  has **no test**, and transcript matching is bare string equality with **no version normalisation**
+  (`ENST00000123.4` ≠ `ENST00000123`).
+- **Point lookup only.** `end` is in the shard schema but never read; `PluginLookup` pages on `start`
+  alone. Bucket C interval plugins need real overlap support.
+- **The probe keys on `input_start` (VCF POS)**, which may be wrong for indels. AlphaMissense is
+  SNV-only, so this has never been exercised.
+
+---
+
+## 10. Acceptance criteria
+
+Wave 0 is done when `parity --check` passes for three clients, each proving a different axis:
+
+1. **AlphaMissense** — the harness reproduces parity on the mini-cache region. This proves *the
+   harness is correct* (we have an independently confirmed result to reproduce). Its manifest is
+   **not touched** — it is owned elsewhere; we use it strictly as a fixture.
+2. **REVEL** — the first new client, TSV source. This proves the thesis "a port is just a manifest"
+   holds for someone who did not write the engine.
+3. **Mastermind or gnomADMt** — VCF source. This proves the newly wired provider works end-to-end
+   rather than merely compiling.
+
+---
+
+## 11. Sequencing
+
+0. Sync `dev-test` with `master` (§2). Blocks everything.
+1. Engine: provider wiring + hardening (§7). PR → `dev-test`.
+2. `vepyr`: `build_plugin_cache` binding + `vepyr.parity` module + `slice_cache.py`; publish the
+   mini-cache release asset (§5).
+3. `vepyr-plugins`: harness `--check`/`--refresh-golden`, `parity.toml`, CI (§6).
+4. The three clients (§10). AlphaMissense first — it is the harness's own test.
+5. Only then Wave 1 (the ~20 Bucket A/B scoring plugins) as pure manifest work.
+
+---
+
+## 12. Risks
+
+- **The mini-cache slicer must be consistent across tables.** A transcript sliced away while its
+  variants remain would produce phantom core drift and poison the attribution rule. The slicer needs
+  its own test: annotate the region with the mini-cache and with the full cache, and require
+  identical output.
+- **Licence-gated sources cap how hermetic CI can be.** Mitigated by `redistributable = false` +
+  loud skips, but it means the public CI corpus will be a subset of the real one.
+- **Parity may not reach 100% on allele edge cases** (multi-allelic, MNV, spanning deletion, indel
+  left-alignment) even in the easy class. The attribution rule keeps these honest instead of letting
+  them be papered over.
+- **The scaffolder can encode today's manifest shape and then rot.** It must be regenerated from the
+  `SourceManifest` struct, not from a copied example — otherwise it will keep emitting `[tier]`-style
+  ghosts.

--- a/docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md
+++ b/docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md
@@ -43,7 +43,7 @@ code, and following it would waste a session:
 |---|---|
 | `vepyr-plugins` is inaccessible; the blocker is repo access (§5) | It is cloned locally and public to us. It has a **working AlphaMissense manifest on `master`** — a real, parity-passed reference. |
 | "Python surface (already shipped): `vepyr.build_plugin_cache(...)`" (§2) | **Does not exist.** `grep -r plugin_cache` in the `vepyr` repo returns nothing. The builder is `PluginCacheBuilder` (Rust) driven by `cargo run --example build_plugin --features parquet-cache`. |
-| Seed manifests for REVEL/PrimateAI (§6.2–6.3), to be pasted in | Written blind. They use `has_header = true` with no `schema` block; the only working manifest uses `has_header = false` + an explicit `schema`. They also carry a `[tier]` block that **does not exist in `SourceManifest`** and is silently ignored. Discard them; regenerate from the AlphaMissense pattern. |
+| Seed manifests for REVEL/PrimateAI (§6.2–6.3), to be pasted in | Written blind. They declare `has_header = true` and **no `schema` block** — but `provider.rs::csv_schema` builds the Arrow schema *solely* from `[source.csv].schema`, so an absent block yields a zero-field schema. The only working manifest (AlphaMissense) uses `has_header = false` + an explicit `schema`. Discard the seeds; regenerate from that pattern. |
 | Bucket A is "framework READY, port = manifest only" | Only for `csv`/`tsv`/`parquet`. `provider.rs:111-116` returns `NotImplemented` for **`vcf`** and **`bed`**, and roughly a third of Bucket A's sources are tabix VCF (EVE, Mastermind, Geno2MP, gnomADMt, SubsetVCF). |
 
 Two facts the handoff missed, both favourable:
@@ -59,15 +59,29 @@ Two facts the handoff missed, both favourable:
 
 ---
 
-## 2. Prerequisite 0 — `dev-test` does not contain `plugin_cache`
+## 2. Base branch — `master-sitekwb` (and why it is not `dev-test`)
 
-Branch policy for this work is: **branch off `dev-test`, PR back into `dev-test`, never touch
-`master`.** But `plugin_cache` lives only on `master` (14 files); `origin/dev-test` is 14 commits
-behind and has **zero** of them.
+`plugin_cache` lives only on `master` (14 files). `dev-test` has **zero** of them, so nothing in this
+spec compiles there.
 
-So the first PR of this effort is mechanical and independent: **sync `dev-test` with `master`.**
-Nothing else in this spec can be built until it lands. It is called out here because it is invisible
-until you try to compile.
+The obvious move — "sync `dev-test` with `master`" — is **not** the mechanical merge it looks like.
+The branches diverged at `v0.10.0` and both moved:
+
+- `master` took `a6e19ad` (#181, *Lance-only cache, grid-aligned parallel annotation*), which rewrote
+  `annotate_provider.rs` (**+7130/−2576**) and **deleted** `variant_lookup_exec.rs`.
+- `dev-test` has **45 commits** of its own, including an engine feature that exists nowhere else:
+  multi-ALT CSQ per-allele expansion (`PerAltCtx`, `vcf_to_vep_allele_multi`). `master` still treats
+  `alt` as a single allele.
+
+So merging them means **porting a feature into a rewritten hot path**: 149 files merge cleanly, and
+the 5 conflicting hunks are all CSQ per-allele assembly. Get it wrong and nothing crashes — every
+multi-allelic variant is just silently mis-annotated. That deserves its own PR and its own parity
+test, and it has **nothing to do with the plugin factory**.
+
+**Decision (2026-07-13): decouple.** All factory work is based on **`master-sitekwb`** (cut from
+`master`, so it already has `plugin_cache`). It is treated as our `main`: every PR targets it, and
+**`master`/`main` are never committed to**. The multi-ALT port from `dev-test` is tracked separately
+and blocks nothing here.
 
 ---
 
@@ -278,8 +292,8 @@ Wave 0 is done when `parity --check` passes for three clients, each proving a di
 
 ## 11. Sequencing
 
-0. Sync `dev-test` with `master` (§2). Blocks everything.
-1. Engine: provider wiring + hardening (§7). PR → `dev-test`.
+0. Cut `master-sitekwb` from `master` (§2). Every PR below targets it.
+1. Engine: provider wiring + hardening (§7). PR → `master-sitekwb`.
 2. `vepyr`: `build_plugin_cache` binding + `vepyr.parity` module + `slice_cache.py`; publish the
    mini-cache release asset (§5).
 3. `vepyr-plugins`: harness `--check`/`--refresh-golden`, `parity.toml`, CI (§6).


### PR DESCRIPTION
Spec and first execution plan for the plugin port factory (Wave 0). Docs only, no code.

Rebased onto `master-sitekwb`, which replaces PR #193 (that one was cut from `dev-test` and would have dragged 45 unrelated commits along).

## Why the base branch changed

The plan originally opened with "sync `dev-test` with `master` — mechanical, expect no conflicts". That was wrong, and finding out why was the most useful thing this session did:

- `master` took #181 (Lance-only cache, grid-aligned parallel annotation), which **rewrote** `annotate_provider.rs` (+6907/−2446) and **deleted** `variant_lookup_exec.rs`.
- `dev-test` has 45 commits of its own, including an engine feature that exists nowhere else: **multi-ALT CSQ per-allele expansion** (`PerAltCtx`, `vcf_to_vep_allele_multi`). `master` still treats `alt` as one allele.

So that merge is not conflict resolution — it is porting a feature into a rewritten hot path. 149 files merge clean; the 5 conflicting hunks are all CSQ per-allele assembly, and getting them wrong doesn't crash: it silently mis-annotates every multi-allelic variant.

It also has nothing to do with the plugin factory. Hence: factory work is based on `master-sitekwb` (cut from `master`, already has `plugin_cache`), and the multi-ALT port becomes its own PR with its own parity test.

## Contents

- **Spec** — the factory: parity harness with a blame-attribution rule, region-sliced mini-cache fixture (the real cache is 34 GB), VCF provider wiring, manifest scaffolder. Done = three clients (AlphaMissense / REVEL / one VCF plugin), each proving a different axis.
- **Plan A** — the engine half, TDD, 7 tasks: wire `provider = "vcf"` to bio-formats' `VcfTableProvider` (already a dependency), and fix four things that fail silently — ignored unknown manifest keys, a no-op `--overwrite`, a `--source-path` that reaches only the first source, a `--chrom` that reads only its first occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JaQJ1j5wfA54dRxYmEtQs