### PR TITLE
feat(plugin_cache): wire VCF provider + make a wrong manifest fail loudly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "nohash-hasher",
+ "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",
  "noodles-core 0.16.0",
  "noodles-fasta",
  "noodles-vcf 0.80.0 (git+https://github.com/biodatageeks/noodles.git?rev=9b7b2c5b6531373918302d4c07410e583f1b5b5c)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
+ "datafusion-bio-format-core 1.8.8",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
  "datafusion-bio-function-ranges",

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -48,6 +48,11 @@ mimalloc = "0.1"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 datafusion-bio-function-ranges = { path = "../bio-function-ranges" }
 noodles-vcf = { git = "https://github.com/biodatageeks/noodles.git", rev = "9b7b2c5b6531373918302d4c07410e583f1b5b5c" }
+# Writes real BGZF (not plain gzip) test fixtures, so the plugin-cache VCF guards are
+# exercised against the `.vcf.gz` form every real plugin source actually ships in —
+# `get_compression_type` sniffs the BGZF `BC` extra subfield, which flate2 cannot emit.
+# Same rev as `noodles-vcf` above (already in the lockfile via its dependency tree).
+noodles-bgzf = { git = "https://github.com/biodatageeks/noodles.git", rev = "9b7b2c5b6531373918302d4c07410e583f1b5b5c" }
 env_logger = "0.11"
 tempfile = "3"
 arrow-array = "58.0.0"

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -31,6 +31,10 @@ noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
 datafusion-bio-format-vcf ={ git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
+# Must stay pinned at the SAME tag as `datafusion-bio-format-vcf`: it provides the
+# `ObjectStorageOptions` type that `VcfTableProvider::new` takes, and two different
+# tags would resolve to two incompatible copies of that type.
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8", optional = true }
 indicatif = "0.18.4"
 

--- a/datafusion/bio-function-vep/examples/build_plugin.rs
+++ b/datafusion/bio-function-vep/examples/build_plugin.rs
@@ -1,12 +1,19 @@
 //! Build a plugin cache from a source manifest (all chroms, or a filtered set).
 //!
 //! ```text
-//! cargo run -p datafusion-bio-function-vep --example build_plugin -- \
+//! cargo run -p datafusion-bio-function-vep --features parquet-cache --example build_plugin -- \
 //!   --manifest <vepyr-plugins>/plugins/alphamissense/alphamissense.source.toml \
 //!   --source-path /tmp/AlphaMissense_hg38.tsv.gz \
 //!   --variation-cache-dir <cache root containing variation/> \
-//!   --out /tmp/plugin_cache [--chrom 22]
+//!   --out /tmp/plugin_cache \
+//!   [--chrom 21 --chrom 22]        # repeatable; omit to build every chrom in the cache
 //! ```
+//!
+//! `--source-path` takes a bare path only when the manifest declares a single `[[source]]`;
+//! for multi-part manifests use `--source-path <part>=<path>`, repeated once per part.
+//!
+//! `--overwrite` starts from an empty chrom list (a clean rebuild). Without it, a filtered
+//! build UPSERTs into the previous `manifest.json`, preserving chroms it did not rebuild.
 
 use std::path::PathBuf;
 

--- a/datafusion/bio-function-vep/examples/build_plugin.rs
+++ b/datafusion/bio-function-vep/examples/build_plugin.rs
@@ -21,6 +21,15 @@ fn arg(args: &[String], key: &str) -> Option<String> {
         .cloned()
 }
 
+/// Every occurrence of `--key <value>` (the flag may repeat).
+fn args_all(args: &[String], key: &str) -> Vec<String> {
+    args.iter()
+        .enumerate()
+        .filter(|(_, a)| a.as_str() == key)
+        .filter_map(|(i, _)| args.get(i + 1).cloned())
+        .collect()
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -35,10 +44,39 @@ async fn main() -> Result<()> {
     );
 
     let mut manifest = SourceManifest::load(&PathBuf::from(&manifest_path))?;
-    if let Some(source_path) = arg(&args, "--source-path")
-        && let Some(first) = manifest.sources.first_mut()
-    {
-        first.path = source_path;
+    for spec in args_all(&args, "--source-path") {
+        match spec.split_once('=') {
+            // --source-path <part>=<path>
+            Some((part, path)) => {
+                let target = manifest
+                    .sources
+                    .iter_mut()
+                    .find(|s| s.part.as_deref() == Some(part))
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "--source-path '{part}=...': no [[source]] with part = \"{part}\""
+                        ))
+                    })?;
+                target.path = path.to_string();
+            }
+            // --source-path <path> — unambiguous only for a single-source manifest
+            None => {
+                if manifest.sources.len() != 1 {
+                    return Err(DataFusionError::Execution(format!(
+                        "--source-path <path> is ambiguous: the manifest has {} sources; \
+                         use --source-path <part>=<path> (parts: {})",
+                        manifest.sources.len(),
+                        manifest
+                            .sources
+                            .iter()
+                            .map(|s| s.part.as_deref().unwrap_or("<none>"))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )));
+                }
+                manifest.sources[0].path = spec;
+            }
+        }
     }
     let manifest_file = PathBuf::from(&manifest_path)
         .file_name()

--- a/datafusion/bio-function-vep/examples/build_plugin.rs
+++ b/datafusion/bio-function-vep/examples/build_plugin.rs
@@ -24,6 +24,19 @@ use datafusion_bio_function_vep::plugin_cache::cli::PluginBuildArgs;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
+    // The builder's diagnostics go through `log` (`build.rs` warns when a chrom builds
+    // with rows > 0 but warm == 0 — nothing joined the variation cache, the signature of
+    // a mis-declared manifest). Without a logger installed those warnings are dropped on
+    // the floor, which is exactly the silence they exist to break. The sibling cache-build
+    // examples all do this; this one did not.
+    //
+    // Default to `warn` rather than env_logger's `error`, so the warning is LOUD by
+    // default; `parse_default_env` still lets RUST_LOG turn it up (or off).
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Warn)
+        .parse_default_env()
+        .try_init();
+
     let argv: Vec<String> = std::env::args().skip(1).collect();
     let args = PluginBuildArgs::parse(&argv)?;
     let manifest = args.load_manifest()?;

--- a/datafusion/bio-function-vep/examples/build_plugin.rs
+++ b/datafusion/bio-function-vep/examples/build_plugin.rs
@@ -89,8 +89,9 @@ async fn main() -> Result<()> {
     );
     let mut builder =
         PluginCacheBuilder::new(&manifest, &manifest_file, &variation_cache_dir, &out);
-    if let Some(chrom) = arg(&args, "--chrom") {
-        builder = builder.with_chrom_filter([chrom]);
+    let chroms = args_all(&args, "--chrom");
+    if !chroms.is_empty() {
+        builder = builder.with_chrom_filter(chroms);
     }
     let cache = builder.build_all().await?;
     for c in &cache.chroms {

--- a/datafusion/bio-function-vep/examples/build_plugin.rs
+++ b/datafusion/bio-function-vep/examples/build_plugin.rs
@@ -7,6 +7,7 @@
 //!   --variation-cache-dir <cache root containing variation/> \
 //!   --out /tmp/plugin_cache \
 //!   [--chrom 21 --chrom 22]        # repeatable; omit to build every chrom in the cache
+//!   [--overwrite]                  # clean rebuild instead of an UPSERT
 //! ```
 //!
 //! `--source-path` takes a bare path only when the manifest declares a single `[[source]]`;
@@ -14,93 +15,24 @@
 //!
 //! `--overwrite` starts from an empty chrom list (a clean rebuild). Without it, a filtered
 //! build UPSERTs into the previous `manifest.json`, preserving chroms it did not rebuild.
+//!
+//! This example is deliberately thin: all argv handling lives in
+//! `plugin_cache::cli::PluginBuildArgs`, where it is unit-tested.
 
-use std::path::PathBuf;
-
-use datafusion::common::{DataFusionError, Result};
-use datafusion_bio_function_vep::plugin_cache::builder::PluginCacheBuilder;
-use datafusion_bio_function_vep::plugin_cache::source_manifest::SourceManifest;
-
-fn arg(args: &[String], key: &str) -> Option<String> {
-    args.iter()
-        .position(|a| a == key)
-        .and_then(|i| args.get(i + 1))
-        .cloned()
-}
-
-/// Every occurrence of `--key <value>` (the flag may repeat).
-fn args_all(args: &[String], key: &str) -> Vec<String> {
-    args.iter()
-        .enumerate()
-        .filter(|(_, a)| a.as_str() == key)
-        .filter_map(|(i, _)| args.get(i + 1).cloned())
-        .collect()
-}
+use datafusion::common::Result;
+use datafusion_bio_function_vep::plugin_cache::cli::PluginBuildArgs;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-    let manifest_path = arg(&args, "--manifest")
-        .ok_or_else(|| DataFusionError::Execution("--manifest required".into()))?;
-    let variation_cache_dir = PathBuf::from(
-        arg(&args, "--variation-cache-dir")
-            .ok_or_else(|| DataFusionError::Execution("--variation-cache-dir required".into()))?,
-    );
-    let out = PathBuf::from(
-        arg(&args, "--out").ok_or_else(|| DataFusionError::Execution("--out required".into()))?,
-    );
-
-    let mut manifest = SourceManifest::load(&PathBuf::from(&manifest_path))?;
-    for spec in args_all(&args, "--source-path") {
-        match spec.split_once('=') {
-            // --source-path <part>=<path>
-            Some((part, path)) => {
-                let target = manifest
-                    .sources
-                    .iter_mut()
-                    .find(|s| s.part.as_deref() == Some(part))
-                    .ok_or_else(|| {
-                        DataFusionError::Execution(format!(
-                            "--source-path '{part}=...': no [[source]] with part = \"{part}\""
-                        ))
-                    })?;
-                target.path = path.to_string();
-            }
-            // --source-path <path> — unambiguous only for a single-source manifest
-            None => {
-                if manifest.sources.len() != 1 {
-                    return Err(DataFusionError::Execution(format!(
-                        "--source-path <path> is ambiguous: the manifest has {} sources; \
-                         use --source-path <part>=<path> (parts: {})",
-                        manifest.sources.len(),
-                        manifest
-                            .sources
-                            .iter()
-                            .map(|s| s.part.as_deref().unwrap_or("<none>"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )));
-                }
-                manifest.sources[0].path = spec;
-            }
-        }
-    }
-    let manifest_file = PathBuf::from(&manifest_path)
-        .file_name()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_else(|| manifest_path.clone());
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let args = PluginBuildArgs::parse(&argv)?;
+    let manifest = args.load_manifest()?;
 
     println!(
         "Building plugin '{}' from '{}'",
         manifest.plugin_name, manifest.sources[0].path
     );
-    let mut builder =
-        PluginCacheBuilder::new(&manifest, &manifest_file, &variation_cache_dir, &out);
-    let chroms = args_all(&args, "--chrom");
-    if !chroms.is_empty() {
-        builder = builder.with_chrom_filter(chroms);
-    }
-    let cache = builder.build_all().await?;
+    let cache = args.build(&manifest).await?;
     for c in &cache.chroms {
         println!(
             "  {} rows={} warm={} cold={}",

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, BooleanArray, Int8Array, StringArray};
 use datafusion::arrow::compute::{
-    cast, concat_batches, filter_record_batch, sort_to_indices, take,
+    CastOptions, cast_with_options, concat_batches, filter_record_batch, sort_to_indices, take,
 };
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -29,14 +29,48 @@ use crate::plugin_cache::write::{PluginShardWriter, plugin_output_schema};
 
 /// Reproject `batch` to `schema`'s column order and types (casting where needed,
 /// e.g. the normalized view's `Int64` `start`/`end` → the shard's `UInt32`).
+///
+/// The cast is DELIBERATELY unsafe (`CastOptions { safe: false }`). Arrow's default —
+/// what `arrow::compute::cast` gives you — is `safe: true`, which turns a value it
+/// cannot cast into NULL rather than an error. Applied to a manifest's declared
+/// `[[value_columns]] type`, that made a wrong type a *silent* failure, and the worst
+/// one in the build: declaring `type = "Float32"` for a categorical string column
+/// produced
+///
+/// ```text
+/// build SUCCEEDED: rows=1 warm=1 cold=0    <-- even the counts look healthy
+/// probe(100,"A/G") = Some([Null])          <-- every annotation empty
+/// ```
+///
+/// and the real AlphaMissense manifest has `am_class` (Utf8) sitting directly above
+/// `am_pathogenicity` (Float32), so swapping two adjacent `type =` lines was enough.
+///
+/// `safe: false` makes that a hard build error naming the column and the two types.
+/// It does NOT reject legitimately-null source data: a null slot is not a value that
+/// failed to cast, and arrow preserves it either way (pinned by
+/// `correct_types_and_null_source_values_still_build`).
 fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch> {
+    let strict = CastOptions {
+        safe: false,
+        ..Default::default()
+    };
     let cols = schema
         .fields()
         .iter()
         .map(|f| {
             let idx = batch.schema().index_of(f.name())?;
-            cast(batch.column(idx), f.data_type())
-                .map_err(|e| DataFusionError::Execution(format!("cast {}: {e}", f.name())))
+            let col = batch.column(idx);
+            cast_with_options(col, f.data_type(), &strict).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "plugin value column '{}' is declared type {} but the ingested data is {} \
+                     and does not fit it: {e}. Fix the column's `type` in the manifest (or make \
+                     `ingest_sql` produce the declared type) — a lenient cast would have written \
+                     NULL for every offending row and the plugin would annotate nothing.",
+                    f.name(),
+                    f.data_type(),
+                    col.data_type(),
+                ))
+            })
         })
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(Arc::clone(schema), cols)
@@ -587,6 +621,146 @@ type = "Float32"
         assert_eq!(entry.rows, 2, "one row per ALT (A/G and A/T)");
         assert_eq!(entry.warm, 1, "A/G matches the variation cache");
         assert_eq!(entry.cold, 1, "A/T does not");
+    }
+
+    /// The AlphaMissense manifest declares `am_class` (Utf8) directly above
+    /// `am_pathogenicity` (Float32). Swap the two `type =` lines and `reproject_cast`'s
+    /// arrow `cast` — whose default is `CastOptions { safe: true }` — turned every
+    /// unparseable "likely_benign" into NULL instead of erroring:
+    ///
+    /// ```text
+    /// build SUCCEEDED: rows=1 warm=1 cold=0    <-- even the counts look healthy
+    /// probe(100,"A/G") = Some([Null])          <-- every annotation empty
+    /// ```
+    ///
+    /// Worse than the multi-allelic trap, because there the row counts at least hinted
+    /// at it. A declared type the data cannot hold must be a hard build error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn value_column_type_mismatch_fails_the_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsv = dir.path().join("am.tsv.gz");
+        // The AlphaMissense column layout: a categorical class and a float score.
+        write_gz(&tsv, "chr1\t100\tA\tG\tlikely_benign\t0.0431\n");
+        let var = dir.path().join("var.parquet");
+        write_synthetic_variation(&var, &[("1", 100, "A/G", 0i8)]);
+
+        // `am_class` is declared Float32 — the swap. "likely_benign" is not a float.
+        let toml = format!(
+            r##"
+plugin_name = "am"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string,
+       am_class AS am_class,
+       CAST(score AS FLOAT) AS am_pathogenicity
+FROM plugin_am_src
+"""
+
+[[source]]
+provider = "tsv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom",    type = "Utf8" }},
+    {{ name = "pos",      type = "Utf8" }},
+    {{ name = "ref",      type = "Utf8" }},
+    {{ name = "alt",      type = "Utf8" }},
+    {{ name = "am_class", type = "Utf8" }},
+    {{ name = "score",    type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "am_class"
+csq_field = "am_class"
+type = "Float32"
+
+[[value_columns]]
+column = "am_pathogenicity"
+csq_field = "am_pathogenicity"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let err = build_plugin_chrom(&manifest, "am.source.toml", &var, &out, "1")
+            .await
+            .expect_err("a value column the declared type cannot hold must fail the build");
+        let msg = err.to_string();
+        assert!(msg.contains("am_class"), "must name the column: {msg}");
+        assert!(
+            msg.contains("Utf8") && msg.contains("Float32"),
+            "must name both types: {msg}"
+        );
+    }
+
+    /// The guard must not fire on the AlphaMissense manifest's REAL types (Utf8 class +
+    /// Float32 score), nor on a legitimately NULL source value: `safe: false` rejects
+    /// values that cannot be cast, and a null is not one of them.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn correct_types_and_null_source_values_still_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsv = dir.path().join("am.tsv.gz");
+        // Row 2 has an EMPTY score field -> a NULL Float32 after the ingest CAST.
+        write_gz(
+            &tsv,
+            "chr1\t100\tA\tG\tlikely_benign\t0.0431\nchr1\t300\tC\tT\tambiguous\t\n",
+        );
+        let var = dir.path().join("var.parquet");
+        write_synthetic_variation(&var, &[("1", 100, "A/G", 0i8)]);
+
+        let toml = format!(
+            r##"
+plugin_name = "am"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string,
+       am_class AS am_class,
+       CAST(score AS FLOAT) AS am_pathogenicity
+FROM plugin_am_src
+"""
+
+[[source]]
+provider = "tsv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom",    type = "Utf8" }},
+    {{ name = "pos",      type = "Utf8" }},
+    {{ name = "ref",      type = "Utf8" }},
+    {{ name = "alt",      type = "Utf8" }},
+    {{ name = "am_class", type = "Utf8" }},
+    {{ name = "score",    type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "am_class"
+csq_field = "am_class"
+type = "Utf8"
+
+[[value_columns]]
+column = "am_pathogenicity"
+csq_field = "am_pathogenicity"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let entry = build_plugin_chrom(&manifest, "am.source.toml", &var, &out, "1")
+            .await
+            .expect("the AlphaMissense types are legitimate and must keep building");
+        assert_eq!(entry.rows, 2);
+        assert_eq!(entry.warm, 1);
+        assert_eq!(entry.cold, 1);
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -382,7 +382,7 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use parquet::arrow::ArrowWriter;
     use std::io::Write;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     fn write_gz(path: &std::path::Path, body: &str) {
         let f = std::fs::File::create(path).unwrap();
@@ -1093,6 +1093,151 @@ type = "Float32"
             no_warm_rows_warning(&manifest.plugin_name, &entry.chrom, entry.rows, entry.warm)
                 .is_some(),
             "the all-cold chrom must be flagged: {entry:?}"
+        );
+    }
+
+    /// Every warn-level record emitted anywhere in this test binary, with its level.
+    ///
+    /// `log::set_logger` is process-global and one-shot, and `build_plugin_chrom`'s
+    /// `warn!` fires on whatever tokio worker thread happens to run the build — so a
+    /// thread-local capture (`testing_logger`) would miss it, and a second logger
+    /// (`env_logger`) could not coexist with it. One shared sink, installed once and
+    /// filtered by the emitting test's unique plugin name, is correct under `cargo test`'s
+    /// parallelism and needs no new dependency.
+    static WARN_RECORDS: Mutex<Vec<(log::Level, String)>> = Mutex::new(Vec::new());
+
+    struct CapturingLogger;
+
+    impl log::Log for CapturingLogger {
+        fn enabled(&self, meta: &log::Metadata) -> bool {
+            meta.level() <= log::Level::Warn
+        }
+
+        fn log(&self, record: &log::Record) {
+            if self.enabled(record.metadata()) {
+                WARN_RECORDS
+                    .lock()
+                    .unwrap()
+                    .push((record.level(), record.args().to_string()));
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    /// Install [`CapturingLogger`] as the process logger (idempotent, one-shot).
+    fn install_capturing_logger() {
+        static LOGGER: CapturingLogger = CapturingLogger;
+        static ONCE: std::sync::Once = std::sync::Once::new();
+        ONCE.call_once(|| {
+            log::set_logger(&LOGGER).expect("no other logger may be installed in this test binary");
+            // Without this the default max level is `Off` and `warn!` never even calls us.
+            log::set_max_level(log::LevelFilter::Warn);
+        });
+    }
+
+    /// Records emitted for one plugin — the name is unique per test, so parallel tests
+    /// (and DataFusion's own warnings) cannot be mistaken for ours.
+    fn records_for_plugin(plugin: &str) -> Vec<(log::Level, String)> {
+        let needle = format!("plugin '{plugin}'");
+        WARN_RECORDS
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(_, msg)| msg.contains(&needle))
+            .cloned()
+            .collect()
+    }
+
+    /// The warm==0 warning must actually REACH a logger — not merely be computable.
+    ///
+    /// `contig_mismatch_builds_all_cold_and_is_flagged` above covers only the pure
+    /// `no_warm_rows_warning` helper, i.e. that the string *can be produced*. Nothing
+    /// covered the `warn!` that produces it for real: delete that call and all 869 lib
+    /// tests still pass. That is not a hypothetical regression — it already happened once
+    /// on this branch, in the other half of the same path: the warning was added, no
+    /// logger was installed to receive it, it reached nobody, and it was caught only
+    /// because someone ran the binary by hand.
+    ///
+    /// A warning whose whole purpose is to break silence is worth exactly as much as its
+    /// emission path, so the emission path is what this test pins: a build with
+    /// `rows > 0 && warm == 0` emits one WARN-level record naming the plugin.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn all_cold_chrom_emits_a_warn_log_record() {
+        install_capturing_logger();
+
+        let dir = tempfile::tempdir().unwrap();
+        let tsv = dir.path().join("src.tsv.gz");
+        write_gz(&tsv, "chr1\t100\tA\tG\t0.9\nchr1\t300\tG\tA\t0.7\n");
+        let var = dir.path().join("var.parquet");
+        // Contig mismatch ("chr1" vs the canonicalized "1"): rows are written, NOT ONE
+        // joins the variation cache. The all-cold signature the warning exists to report.
+        write_synthetic_variation(&var, &[("chr1", 100, "A/G", 0i8)]);
+
+        // Unique to this test: the filter below must not pick up other tests' records.
+        let toml = format!(
+            r##"
+plugin_name = "warnemit"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_warnemit_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let entry = build_plugin_chrom(&manifest, "warnemit.source.toml", &var, &out, "1")
+            .await
+            .expect("an all-cold chrom warns, it does not fail");
+        assert_eq!(
+            (entry.rows, entry.warm),
+            (2, 0),
+            "the all-cold setup: {entry:?}"
+        );
+
+        let records = records_for_plugin("warnemit");
+        assert_eq!(
+            records.len(),
+            1,
+            "a chrom with rows > 0 and warm == 0 must EMIT exactly one log record, \
+             not merely be able to compute the text of one; captured: {records:?}"
+        );
+        let (level, msg) = &records[0];
+        assert_eq!(
+            *level,
+            log::Level::Warn,
+            "it must be a WARNING (info/debug is swallowed by every default logger): {msg}"
+        );
+        assert!(
+            msg.contains("warm = 0"),
+            "the emitted record must be the all-cold warning: {msg}"
+        );
+        assert!(
+            msg.contains("chr1"),
+            "the emitted record must name the chrom: {msg}"
         );
     }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, Int8Array};
+use datafusion::arrow::array::{Array, BooleanArray, Int8Array, StringArray};
 use datafusion::arrow::compute::{
     cast, concat_batches, filter_record_batch, sort_to_indices, take,
 };
@@ -41,6 +41,53 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(Arc::clone(schema), cols)
         .map_err(|e| DataFusionError::Execution(format!("reproject: {e}")))
+}
+
+/// Reject an `allele_string` that still carries the VCF reader's pipe-joined
+/// multi-ALT form (`A/G|T`).
+///
+/// The bio-formats VCF reader collapses a record's ALT alleles into ONE `Utf8`
+/// value joined by `|` (`chr1 100 . A G,T` → one row, `alt = "G|T"`), so the
+/// obvious — and spec-canonical — mapping `concat(ref, '/', alt) AS allele_string`
+/// stores `A/G|T`. The runtime probes one ALT at a time (`A/G`), and the variation
+/// cache's `allele_string` is likewise per-allele, so such a row matches NOTHING:
+/// the build succeeds, the shard is written, and the plugin annotates nothing,
+/// forever, without a warning. Every VCF-backed plugin this provider unblocks
+/// (Mastermind, gnomADMt, EVE, Geno2MP) is a multi-allelic source, so this is the
+/// default outcome, not an edge case.
+///
+/// One predicate kills the whole class: no `allele_string` written to a plugin
+/// shard may contain `|`. `ingest_sql` must split the ALTs into one row per
+/// allele instead (see [`VcfParams`](crate::plugin_cache::source_manifest::VcfParams)).
+///
+/// Checked on the normalized, chrom-filtered rows already materialized in memory
+/// (not by re-querying the ingest view), so the guard costs no extra pass over
+/// what can be a tens-of-GB source.
+fn reject_pipe_joined_alleles(batches: &[RecordBatch], plugin: &str) -> Result<()> {
+    for batch in batches {
+        let idx = batch.schema().index_of("allele_string")?;
+        let col = batch.column(idx);
+        // The normalized view carries `allele_string` straight through from
+        // `ingest_sql`; a non-Utf8 spelling is caught later by the shard schema.
+        let Some(strings) = col.as_any().downcast_ref::<StringArray>() else {
+            continue;
+        };
+        let Some(offender) = strings.iter().flatten().find(|allele| allele.contains('|')) else {
+            continue;
+        };
+        return Err(DataFusionError::Execution(format!(
+            "plugin '{plugin}': ingest_sql produced an allele_string containing '|' \
+             (e.g. \"{offender}\"). The VCF reader joins a multi-allelic record's ALT \
+             alleles into ONE `alt` value ('G|T'), so `concat(ref, '/', alt)` yields a key \
+             that can never equal the runtime probe key ('{{ref}}/{{alt}}', one ALT at a time) \
+             nor the variation cache's per-allele allele_string — the shard would build \
+             cleanly and annotate nothing. Split the multi-allelic ALTs in `ingest_sql` so \
+             each ALT is its own row, e.g.\n  \
+             SELECT chrom, `start`, `end`, concat(`ref`, '/', alt_one) AS allele_string, …\n  \
+             FROM (SELECT *, unnest(string_to_array(alt, '|')) AS alt_one FROM plugin_{plugin}_src)"
+        )));
+    }
+    Ok(())
 }
 
 /// Sort a batch ascending by `start` (the per-tier run order the PageDir needs).
@@ -135,6 +182,10 @@ pub async fn build_plugin_chrom(
     let deduped = dedup_keep_first(norm_stream, &match_cols).await?;
     // The source scan is done — drop the decompressed temp before the join leg.
     drop(src_temps);
+
+    // Fail LOUDLY on a pipe-joined multi-allelic allele_string before spending the
+    // (multi-GB) tier join on rows that could never match anything.
+    reject_pipe_joined_alleles(&deduped, &src.plugin_name)?;
 
     // Build context: default parallelism for the tier join over the (multi-GB)
     // variation shard + write. The deduped survivors are re-registered here as a
@@ -413,6 +464,129 @@ type = "Float32"
             PluginScalar::F32(v) => assert!((v - 0.7).abs() < 1e-6),
             ref other => panic!("{other:?}"),
         }
+    }
+
+    // The VCF reader pipe-joins a multi-allelic record's ALTs into ONE `alt`
+    // value ("G|T"), so the canonical `concat(ref, '/', alt) AS allele_string`
+    // stores "A/G|T" — a key the runtime probe ("A/G", one ALT at a time) can
+    // never produce. Before the guard this built cleanly (rows=1) and annotated
+    // nothing, forever, with no warning. It must now be a hard build error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_joined_allele_string_fails_the_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("multi.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr1\t100\t.\tA\tG,T\t.\t.\tSCORE=0.9\n",
+        )
+        .unwrap();
+        let var = dir.path().join("var.parquet");
+        write_synthetic_variation(&var, &[("1", 100, "A/G", 0i8)]);
+
+        // The naive mapping the spec's own canonical example uses.
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, `start`, `end`,
+       concat(`ref`, '/', alt) AS allele_string,
+       CAST(`SCORE` AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "vcf"
+path = "{}"
+  [source.vcf]
+  info_fields = ["SCORE"]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        manifest
+            .validate()
+            .expect("the manifest is structurally valid");
+
+        let out = dir.path().join("out");
+        let err = build_plugin_chrom(&manifest, "demo.source.toml", &var, &out, "1")
+            .await
+            .expect_err("a pipe-joined allele_string must fail the build, not build a dead shard");
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(
+            msg.contains("A/G|T"),
+            "must show an offending example value: {msg}"
+        );
+        assert!(
+            msg.contains("ingest_sql"),
+            "must tell the author where to fix it: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("split"),
+            "must tell the author to split multi-allelic ALTs: {msg}"
+        );
+    }
+
+    // The mirror: an `ingest_sql` that DOES split the pipe-joined ALTs into one
+    // row per ALT passes the guard and builds both alleles.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn splitting_multiallelic_alts_passes_the_guard() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("multi.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr1\t100\t.\tA\tG,T\t.\t.\tSCORE=0.9\n",
+        )
+        .unwrap();
+        let var = dir.path().join("var.parquet");
+        write_synthetic_variation(&var, &[("1", 100, "A/G", 0i8)]);
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, `start`, `end`,
+       concat(`ref`, '/', alt_one) AS allele_string,
+       CAST(`SCORE` AS FLOAT) AS demo_score
+FROM (
+  SELECT *, unnest(string_to_array(alt, '|')) AS alt_one FROM plugin_demo_src
+)
+"""
+
+[[source]]
+provider = "vcf"
+path = "{}"
+  [source.vcf]
+  info_fields = ["SCORE"]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let entry = build_plugin_chrom(&manifest, "demo.source.toml", &var, &out, "1")
+            .await
+            .expect("a per-ALT split must build");
+        assert_eq!(entry.rows, 2, "one row per ALT (A/G and A/T)");
+        assert_eq!(entry.warm, 1, "A/G matches the variation cache");
+        assert_eq!(entry.cold, 1, "A/T does not");
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -5,11 +5,11 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, Int8Array, StringArray};
+use datafusion::arrow::array::{Array, AsArray, BooleanArray, Int8Array};
 use datafusion::arrow::compute::{
     CastOptions, cast_with_options, concat_batches, filter_record_batch, sort_to_indices, take,
 };
-use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
@@ -98,16 +98,49 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
 /// Checked on the normalized, chrom-filtered rows already materialized in memory
 /// (not by re-querying the ingest view), so the guard costs no extra pass over
 /// what can be a tens-of-GB source.
+///
+/// # The guard must not fail OPEN
+///
+/// Which Arrow string encoding `allele_string` arrives in is DataFusion's choice, not
+/// the manifest's: a parquet source yields `Utf8View` (`schema_force_view_types` is on
+/// by default), CSV/TSV and the VCF reader yield `Utf8`, and `LargeUtf8` is reachable
+/// through an `ingest_sql` cast. The first version of this guard downcast to
+/// `StringArray` alone and `continue`d otherwise — so `provider = "parquet"` skipped the
+/// check outright and built the very shard the guard exists to prevent:
+///
+/// ```text
+/// PROBE TYPES: alt=Utf8View allele_string=Utf8View
+/// PROBE RESULT: guard SILENTLY SKIPPED — built ChromEntry { rows: 1, warm: 0, cold: 1 }
+///               with a pipe-joined allele_string
+/// ```
+///
+/// Hence: every string encoding is checked, and anything that is NOT a string is an
+/// ERROR naming the Arrow type found. "I do not recognize this column, so I will assume
+/// it is fine" is precisely the silence this whole guard is here to break.
 fn reject_pipe_joined_alleles(batches: &[RecordBatch], plugin: &str) -> Result<()> {
+    /// First non-null value containing `|`, over any of Arrow's string iterators.
+    fn first_pipe_joined<'a>(mut values: impl Iterator<Item = Option<&'a str>>) -> Option<&'a str> {
+        values.find_map(|v| v.filter(|allele| allele.contains('|')))
+    }
+
     for batch in batches {
         let idx = batch.schema().index_of("allele_string")?;
         let col = batch.column(idx);
-        // The normalized view carries `allele_string` straight through from
-        // `ingest_sql`; a non-Utf8 spelling is caught later by the shard schema.
-        let Some(strings) = col.as_any().downcast_ref::<StringArray>() else {
-            continue;
+        let offender = match col.data_type() {
+            DataType::Utf8 => first_pipe_joined(col.as_string::<i32>().iter()),
+            DataType::LargeUtf8 => first_pipe_joined(col.as_string::<i64>().iter()),
+            DataType::Utf8View => first_pipe_joined(col.as_string_view().iter()),
+            other => {
+                return Err(DataFusionError::Execution(format!(
+                    "plugin '{plugin}': ingest_sql produced an allele_string of Arrow type \
+                     {other}, but allele_string must be a string (Utf8, Utf8View or LargeUtf8) — \
+                     it is the key the runtime probes on and the variation cache joins on. Fix \
+                     the column's expression in `ingest_sql` (canonically \
+                     `concat(ref, '/', alt) AS allele_string`, one row per ALT)."
+                )));
+            }
         };
-        let Some(offender) = strings.iter().flatten().find(|allele| allele.contains('|')) else {
+        let Some(offender) = offender else {
             continue;
         };
         return Err(DataFusionError::Execution(format!(
@@ -390,6 +423,45 @@ mod tests {
         w.close().unwrap();
     }
 
+    /// A `provider = "parquet"` plugin SOURCE (chrom, pos, allele_string, score).
+    ///
+    /// Written with `Utf8` string columns — but that is NOT what the build reads back:
+    /// DataFusion's parquet reader materializes them as `Utf8View`
+    /// (`schema_force_view_types`, on by default), which is exactly the encoding the
+    /// pipe guard used to skip.
+    fn write_parquet_source(path: &std::path::Path, rows: &[(&str, u32, &str, f32)]) {
+        use datafusion::arrow::array::Float32Array;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("pos", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("score", DataType::Float32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+                )),
+                Arc::new(UInt32Array::from(
+                    rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+                )),
+                Arc::new(Float32Array::from(
+                    rows.iter().map(|r| r.3).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap();
+        let file = std::fs::File::create(path).unwrap();
+        let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn builds_tiered_shard_with_counts() {
         let dir = tempfile::tempdir().unwrap();
@@ -605,6 +677,135 @@ type = "Float32"
         assert!(
             msg.to_lowercase().contains("split"),
             "must tell the author to split multi-allelic ALTs: {msg}"
+        );
+    }
+
+    /// The guard above, but reached through a `provider = "parquet"` source — the hole
+    /// review found in it.
+    ///
+    /// DataFusion's parquet reader hands string columns back as `Utf8View`, not `Utf8`
+    /// (`schema_force_view_types` is on by default), so the guard's
+    /// `downcast_ref::<StringArray>()` returned `None` and its `else { continue }` SKIPPED
+    /// the check entirely: a pipe-joined `allele_string` sailed through and built the exact
+    /// dead shard the guard exists to prevent (`rows: 1, warm: 0, cold: 1`, annotating
+    /// nothing forever). A guard whose whole thesis is "fail LOUDLY" must not fail OPEN on
+    /// an encoding it did not anticipate.
+    ///
+    /// Pipe-joined `allele_string` values reach parquet sources for real: the VCF-derived
+    /// dumps plugins ship (and any parquet materialized from one with the naive
+    /// `concat(ref, '/', alt)`) carry `A/G|T` verbatim.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn pipe_joined_allele_string_from_a_parquet_source_fails_the_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.parquet");
+        write_parquet_source(&src, &[("chr1", 100, "A/G|T", 0.9)]);
+        let var = dir.path().join("var.parquet");
+        write_synthetic_variation(&var, &[("1", 100, "A/G", 0i8)]);
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "parquet"
+path = "{}"
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            src.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        manifest
+            .validate()
+            .expect("the manifest is structurally valid");
+
+        let out = dir.path().join("out");
+        let err = build_plugin_chrom(&manifest, "demo.source.toml", &var, &out, "1")
+            .await
+            .expect_err(
+                "a pipe-joined allele_string must fail the build whatever string encoding \
+                 DataFusion chose for it — parquet gives Utf8View, not Utf8",
+            );
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(
+            msg.contains("A/G|T"),
+            "must show an offending example value: {msg}"
+        );
+        assert!(
+            msg.contains("ingest_sql"),
+            "must tell the author where to fix it: {msg}"
+        );
+    }
+
+    /// The guard's fallback arm must be an ERROR, not a `continue`.
+    ///
+    /// An `allele_string` that is not a string at all is a broken manifest — and it is
+    /// precisely the case the guard cannot check. Skipping it silently is how the
+    /// `Utf8View` hole above stayed invisible; the build must instead say what it found.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn non_string_allele_string_fails_the_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsv = dir.path().join("src.tsv.gz");
+        write_gz(&tsv, "chr1\t100\tA\tG\t0.9\n");
+        let var = dir.path().join("var.parquet");
+        write_synthetic_variation(&var, &[("1", 100, "A/G", 0i8)]);
+
+        // `allele_string` is an INT here — a typo'd ingest_sql that names the wrong
+        // column. The shard schema would happily stringify it ("100") and the plugin
+        // would then annotate nothing.
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       CAST(pos AS INT) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let err = build_plugin_chrom(&manifest, "demo.source.toml", &var, &out, "1")
+            .await
+            .expect_err("a non-string allele_string is a broken manifest, not a check to skip");
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(msg.contains("allele_string"), "must name the column: {msg}");
+        assert!(
+            msg.contains("Int32"),
+            "must name the Arrow type actually found: {msg}"
         );
     }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -15,6 +15,7 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::StreamExt;
+use log::warn;
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
@@ -122,6 +123,37 @@ fn reject_pipe_joined_alleles(batches: &[RecordBatch], plugin: &str) -> Result<(
         )));
     }
     Ok(())
+}
+
+/// The warning text for a chrom that wrote rows of which NOT ONE joined the variation
+/// cache — or `None` when there is nothing to say.
+///
+/// `warm == 0` with `rows > 0` is the shared signature of every silent failure this
+/// build can produce: a wrong `coordinate_system` (every start off by one), a
+/// `chr1`-vs-`1` contig mismatch, an `allele_string` in the wrong shape. The variation
+/// LEFT JOIN is on `(chrom, start, allele_string)`, so if not one row of a whole
+/// chromosome matched, the probe key almost certainly does not have the shape the
+/// runtime will ask for — and the runtime will therefore find nothing either.
+///
+/// A WARNING, not an error: cold rows remain probeable, and a legitimately all-cold
+/// plugin (every variant absent from the variation cache) is conceivable. But the
+/// number was already computed and printed, and nothing acted on it. It must not be
+/// silent.
+///
+/// Returned as a value rather than logged in place so the condition is unit-testable
+/// without installing a process-global `log` sink.
+fn no_warm_rows_warning(plugin: &str, chrom: &str, rows: usize, warm: usize) -> Option<String> {
+    (rows > 0 && warm == 0).then(|| {
+        format!(
+            "plugin '{plugin}' chrom {chrom}: {rows} rows written but warm = 0 — NOT ONE row \
+             joined the variation cache on (chrom, start, allele_string). The runtime probes on \
+             that same key, so it will most likely find nothing either and this plugin will \
+             annotate nothing. Usual causes: contig naming (`chr1` vs `1`), the manifest's \
+             coordinate_system (every start off by one), or the allele_string format (it must be \
+             per-allele `{{ref}}/{{alt}}`). If this source genuinely holds no variant present in \
+             the variation cache, this warning is expected."
+        )
+    })
 }
 
 /// Sort a batch ascending by `start` (the per-tier run order the PageDir needs).
@@ -294,8 +326,14 @@ pub async fn build_plugin_chrom(
     if rows == 0 {
         let _ = std::fs::remove_file(&shard_path);
     }
+    let label = canonical_chrom_label(chrom);
+    // A shard whose every row missed the variation cache is the signature of a
+    // mis-declared manifest — say so instead of printing `warm=0` and moving on.
+    if let Some(msg) = no_warm_rows_warning(&src.plugin_name, &label, rows, warm) {
+        warn!("{msg}");
+    }
     Ok(ChromEntry {
-        chrom: canonical_chrom_label(chrom),
+        chrom: label,
         file: file_name,
         rows,
         warm,
@@ -761,6 +799,100 @@ type = "Float32"
         assert_eq!(entry.rows, 2);
         assert_eq!(entry.warm, 1);
         assert_eq!(entry.cold, 1);
+    }
+
+    /// `warm == 0` with `rows > 0` is the shared signature of EVERY silent failure in
+    /// this build — a wrong coordinate_system, a `chr1`-vs-`1` contig mismatch, a
+    /// mis-shaped allele_string: not one row joined the variation cache. The number was
+    /// already computed and printed; nothing acted on it. It must at least warn.
+    #[test]
+    fn all_cold_chrom_is_detected() {
+        assert!(
+            no_warm_rows_warning("demo", "chr1", 1_000, 0).is_some(),
+            "rows > 0 with warm == 0 must be flagged"
+        );
+        let msg = no_warm_rows_warning("demo", "chr1", 1_000, 0).unwrap();
+        assert!(msg.contains("demo") && msg.contains("chr1"), "{msg}");
+        // The usual causes, so the author has somewhere to look.
+        assert!(msg.contains("contig"), "must list contig naming: {msg}");
+        assert!(
+            msg.contains("coordinate"),
+            "must list coordinate system: {msg}"
+        );
+        assert!(
+            msg.contains("allele_string"),
+            "must list allele-string format: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_healthy_or_empty_chrom_does_not_warn() {
+        // At least one row joined -> the key format is demonstrably right.
+        assert!(no_warm_rows_warning("demo", "chr1", 1_000, 1).is_none());
+        // No rows at all -> a different (already visible) problem, not this one.
+        assert!(no_warm_rows_warning("demo", "chr1", 0, 0).is_none());
+    }
+
+    /// End-to-end: a `chr1`-vs-`1` contig mismatch in the VARIATION shard (the plugin
+    /// side is canonicalized, the variation side here is not) builds cleanly with
+    /// rows > 0 and warm == 0 — and the detector fires on the returned entry.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn contig_mismatch_builds_all_cold_and_is_flagged() {
+        let dir = tempfile::tempdir().unwrap();
+        let tsv = dir.path().join("src.tsv.gz");
+        write_gz(&tsv, "chr1\t100\tA\tG\t0.9\nchr1\t300\tG\tA\t0.7\n");
+        let var = dir.path().join("var.parquet");
+        // The variation shard spells the contig "chr1"; the plugin side canonicalizes to
+        // "1", so NOTHING joins — exactly the failure this warning exists to surface.
+        write_synthetic_variation(&var, &[("chr1", 100, "A/G", 0i8)]);
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let entry = build_plugin_chrom(&manifest, "demo.source.toml", &var, &out, "1")
+            .await
+            .expect("a contig mismatch is a warning, NOT an error: cold rows stay probeable");
+        assert_eq!(entry.rows, 2, "the rows are written");
+        assert_eq!(
+            entry.warm, 0,
+            "…but not one of them joined the variation cache"
+        );
+        assert!(
+            no_warm_rows_warning(&manifest.plugin_name, &entry.chrom, entry.rows, entry.warm)
+                .is_some(),
+            "the all-cold chrom must be flagged: {entry:?}"
+        );
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/builder.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/builder.rs
@@ -154,50 +154,7 @@ fn schema_matches(a: &CacheManifest, b: &CacheManifest) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{Int8Array, StringArray, UInt32Array};
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::arrow::record_batch::RecordBatch;
-    use parquet::arrow::ArrowWriter;
-    use std::io::Write;
-    use std::sync::Arc;
-
-    fn write_gz(path: &Path, body: &str) {
-        let f = std::fs::File::create(path).unwrap();
-        let mut enc = flate2::write::GzEncoder::new(f, flate2::Compression::default());
-        enc.write_all(body.as_bytes()).unwrap();
-        enc.finish().unwrap();
-    }
-
-    fn write_variation(path: &Path, rows: &[(&str, u32, &str, i8)]) {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("chrom", DataType::Utf8, false),
-            Field::new("start", DataType::UInt32, false),
-            Field::new("allele_string", DataType::Utf8, false),
-            Field::new("tier", DataType::Int8, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(StringArray::from(
-                    rows.iter().map(|r| r.0).collect::<Vec<_>>(),
-                )),
-                Arc::new(UInt32Array::from(
-                    rows.iter().map(|r| r.1).collect::<Vec<_>>(),
-                )),
-                Arc::new(StringArray::from(
-                    rows.iter().map(|r| r.2).collect::<Vec<_>>(),
-                )),
-                Arc::new(Int8Array::from(
-                    rows.iter().map(|r| r.3).collect::<Vec<_>>(),
-                )),
-            ],
-        )
-        .unwrap();
-        let file = std::fs::File::create(path).unwrap();
-        let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
-        w.write(&batch).unwrap();
-        w.close().unwrap();
-    }
+    use crate::plugin_cache::test_fixtures::{write_gz, write_variation};
 
     #[tokio::test(flavor = "multi_thread")]
     async fn builds_all_chroms_and_writes_manifest() {

--- a/datafusion/bio-function-vep/src/plugin_cache/builder.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/builder.rs
@@ -90,20 +90,21 @@ impl<'a> PluginCacheBuilder<'a> {
     pub async fn build_all(&self) -> Result<CacheManifest> {
         let plugin_dir = self.out.join("plugin").join(&self.manifest.plugin_name);
         let mut cache = CacheManifest::from_source(self.manifest, &self.manifest_file);
-        // Preserve chromosomes from a prior build (their shards remain on disk),
-        // so a filtered/incremental build UPSERTs the rebuilt chroms rather than
-        // dropping the others from the manifest that runtime discovery relies on.
-        // BUT only when the prior manifest's schema matches the new one — a
-        // filtered rebuild after a value/match-column change must NOT keep old
-        // shards under the new schema (that would misproject them / panic in
-        // `from_batch`); in that case we drop the stale entries.
-        let mut chroms: Vec<ChromEntry> = std::fs::read_to_string(plugin_dir.join("manifest.json"))
-            .ok()
-            .and_then(|t| serde_json::from_str::<CacheManifest>(&t).ok())
-            .filter(|old| schema_matches(old, &cache))
-            .map(|m| m.chroms)
-            .unwrap_or_default();
-        let _ = self.overwrite; // build_plugin_chrom overwrites the shard file per chrom.
+        // Preserve chromosomes from a prior build (their shards remain on disk), so a
+        // filtered/incremental build UPSERTs the rebuilt chroms rather than dropping the
+        // others from the manifest that runtime discovery relies on. Two things suppress
+        // that: an explicit --overwrite (the user asked for a clean build), and a schema
+        // change (old shards would be misprojected under the new schema).
+        let mut chroms: Vec<ChromEntry> = if self.overwrite {
+            Vec::new()
+        } else {
+            std::fs::read_to_string(plugin_dir.join("manifest.json"))
+                .ok()
+                .and_then(|t| serde_json::from_str::<CacheManifest>(&t).ok())
+                .filter(|old| schema_matches(old, &cache))
+                .map(|m| m.chroms)
+                .unwrap_or_default()
+        };
         for chrom in self.resolve_chroms()? {
             let shard = self.variation_shard(&chrom);
             if !shard.exists() {
@@ -341,6 +342,77 @@ type = "Float32"
         );
         assert!(chroms.contains(&"chr2"), "chr2 must be present: {chroms:?}");
         assert_eq!(cache.chroms.len(), 2);
+    }
+
+    // The mirror image of `filtered_rebuild_preserves_other_chroms`: with --overwrite,
+    // a filtered rebuild must NOT preserve the previously built chroms.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn overwrite_drops_chroms_from_a_previous_build() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src.tsv.gz");
+        write_gz(&src, "chr1\t100\tA\tG\t0.9\nchr2\t200\tC\tT\t0.5\n");
+        let var_dir = dir.path().join("cache").join("variation");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        write_variation(&var_dir.join("chr1.parquet"), &[("1", 100, "A/G", 0)]);
+        write_variation(&var_dir.join("chr2.parquet"), &[("2", 200, "C/T", 1)]);
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            src.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let cache_dir = dir.path().join("cache");
+        let out = dir.path().join("out");
+
+        // Build chr1 and chr2, then rebuild chr2 only with --overwrite into the
+        // same output.
+        let baseline = PluginCacheBuilder::new(&manifest, "demo.source.toml", &cache_dir, &out)
+            .with_chrom_filter(["1", "2"])
+            .build_all()
+            .await
+            .unwrap();
+        assert_eq!(baseline.chroms.len(), 2);
+
+        let cache = PluginCacheBuilder::new(&manifest, "demo.source.toml", &cache_dir, &out)
+            .with_chrom_filter(["2"])
+            .with_overwrite(true)
+            .build_all()
+            .await
+            .unwrap();
+
+        let chroms: Vec<&str> = cache.chroms.iter().map(|c| c.chrom.as_str()).collect();
+        assert_eq!(
+            chroms,
+            vec!["chr2"],
+            "overwrite must drop chr1 from the manifest: {chroms:?}"
+        );
     }
 
     // A filtered rebuild after a value/match-column change must NOT preserve old

--- a/datafusion/bio-function-vep/src/plugin_cache/cli.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cli.rs
@@ -210,7 +210,8 @@ impl PluginBuildArgs {
             self.manifest_file(),
             &self.variation_cache_dir,
             &self.out,
-        );
+        )
+        .with_overwrite(self.overwrite);
         if !self.chroms.is_empty() {
             builder = builder.with_chrom_filter(self.chroms.clone());
         }
@@ -221,6 +222,7 @@ impl PluginBuildArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugin_cache::test_fixtures::{write_gz, write_variation};
     use std::path::Path;
 
     fn argv(args: &[&str]) -> Vec<String> {
@@ -475,5 +477,144 @@ type = "Float32"
             .expect_err("an unknown part must not be silently ignored");
         let msg = err.to_string();
         assert!(msg.contains("sv"), "must name the offending part: {msg}");
+    }
+
+    /// A buildable single-source manifest over `src` (a gzipped 2-row TSV).
+    fn buildable_manifest(dir: &Path, src: &Path) -> PathBuf {
+        write_manifest(
+            dir,
+            &format!(
+                r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+                src.display()
+            ),
+        )
+    }
+
+    /// A variation cache with chr1 + chr2, and a raw source covering both.
+    fn build_env(dir: &Path) -> (PathBuf, PathBuf, PathBuf) {
+        let src = dir.join("src.tsv.gz");
+        write_gz(&src, "chr1\t100\tA\tG\t0.9\nchr2\t200\tC\tT\t0.5\n");
+        let var_dir = dir.join("cache").join("variation");
+        std::fs::create_dir_all(&var_dir).unwrap();
+        write_variation(&var_dir.join("chr1.parquet"), &[("1", 100, "A/G", 0)]);
+        write_variation(&var_dir.join("chr2.parquet"), &[("2", 200, "C/T", 1)]);
+        (
+            buildable_manifest(dir, &src),
+            dir.join("cache"),
+            dir.join("out"),
+        )
+    }
+
+    /// Args driving a real build of `chroms`, exactly as the example assembles them.
+    fn build_args(manifest: &Path, cache: &Path, out: &Path, extra: &[&str]) -> PluginBuildArgs {
+        let mut v = argv(&[
+            "--manifest",
+            manifest.to_str().unwrap(),
+            "--variation-cache-dir",
+            cache.to_str().unwrap(),
+            "--out",
+            out.to_str().unwrap(),
+        ]);
+        v.extend(argv(extra));
+        PluginBuildArgs::parse(&v).unwrap()
+    }
+
+    // `PluginCacheBuilder::with_overwrite` is honoured and unit-tested at the builder
+    // level, but the CLI never passed the flag down: `--overwrite` parsed to `true`
+    // and was then dropped on the floor, so a documented clean rebuild silently
+    // stayed an UPSERT. Drive the whole CLI path, not just the parser.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn overwrite_flag_reaches_the_builder() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manifest_path, cache, out) = build_env(dir.path());
+
+        // Seed a two-chrom build, then rebuild chr2 only, with --overwrite.
+        let seed = build_args(
+            &manifest_path,
+            &cache,
+            &out,
+            &["--chrom", "1", "--chrom", "2"],
+        );
+        let seeded = seed.build(&seed.load_manifest().unwrap()).await.unwrap();
+        assert_eq!(seeded.chroms.len(), 2, "seed must build chr1 + chr2");
+
+        let args = build_args(
+            &manifest_path,
+            &cache,
+            &out,
+            &["--chrom", "2", "--overwrite"],
+        );
+        assert!(args.overwrite, "precondition: --overwrite parsed");
+        let cache_manifest = args.build(&args.load_manifest().unwrap()).await.unwrap();
+
+        let chroms: Vec<&str> = cache_manifest
+            .chroms
+            .iter()
+            .map(|c| c.chrom.as_str())
+            .collect();
+        assert_eq!(
+            chroms,
+            ["chr2"],
+            "--overwrite must start from an empty chrom list, dropping chr1; got {chroms:?}"
+        );
+    }
+
+    // The mirror image: without --overwrite the same filtered rebuild must UPSERT,
+    // so the fix above must not turn every build into a clean one.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn without_overwrite_a_filtered_rebuild_still_upserts() {
+        let dir = tempfile::tempdir().unwrap();
+        let (manifest_path, cache, out) = build_env(dir.path());
+
+        let seed = build_args(
+            &manifest_path,
+            &cache,
+            &out,
+            &["--chrom", "1", "--chrom", "2"],
+        );
+        seed.build(&seed.load_manifest().unwrap()).await.unwrap();
+
+        let args = build_args(&manifest_path, &cache, &out, &["--chrom", "2"]);
+        assert!(!args.overwrite);
+        let cache_manifest = args.build(&args.load_manifest().unwrap()).await.unwrap();
+
+        let chroms: Vec<&str> = cache_manifest
+            .chroms
+            .iter()
+            .map(|c| c.chrom.as_str())
+            .collect();
+        assert_eq!(
+            chroms,
+            ["chr1", "chr2"],
+            "without --overwrite chr1 must be preserved; got {chroms:?}"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/cli.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cli.rs
@@ -1,0 +1,479 @@
+//! Argument handling for the `build_plugin` driver.
+//!
+//! Lives in the crate (not in `examples/build_plugin.rs`) so it is unit-testable:
+//! the example is a thin `parse → load_manifest → build → print` shell. An earlier
+//! revision kept the argv handling in the example, where nothing could exercise it —
+//! and a documented `--overwrite` flag ended up never being parsed, silently.
+//!
+//! Every malformed invocation is an error. In particular a valued flag with no
+//! value (`… --chrom` as the last argument) is rejected rather than dropped: a
+//! dangling `--chrom` would otherwise silently widen the build from one chromosome
+//! to every chromosome.
+
+use std::path::PathBuf;
+
+use datafusion::common::{DataFusionError, Result};
+
+use crate::plugin_cache::builder::PluginCacheBuilder;
+use crate::plugin_cache::cache_manifest::CacheManifest;
+use crate::plugin_cache::source_manifest::SourceManifest;
+
+/// Flags that consume the following argv token as their value.
+const VALUED_FLAGS: [&str; 5] = [
+    "--manifest",
+    "--variation-cache-dir",
+    "--out",
+    "--source-path",
+    "--chrom",
+];
+
+/// Flags that stand alone (no value).
+const BARE_FLAGS: [&str; 1] = ["--overwrite"];
+
+/// Parsed `build_plugin` command line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginBuildArgs {
+    /// `--manifest <path>`: the source manifest TOML.
+    pub manifest: PathBuf,
+    /// `--variation-cache-dir <dir>`: cache root containing `variation/`.
+    pub variation_cache_dir: PathBuf,
+    /// `--out <dir>`: output cache root; shards land in `<out>/plugin/<name>/`.
+    pub out: PathBuf,
+    /// `--source-path` values, verbatim and in order: either a bare `<path>`
+    /// (single-source manifests only) or `<part>=<path>`.
+    pub source_paths: Vec<String>,
+    /// `--chrom <c>`, repeatable. Empty = build every chrom in the variation cache.
+    pub chroms: Vec<String>,
+    /// `--overwrite`: start from an empty chrom list (a clean rebuild) instead of
+    /// UPSERTing into the previous `manifest.json`.
+    pub overwrite: bool,
+}
+
+/// Assign a single-valued flag, rejecting a second occurrence (last-wins or
+/// first-wins would silently ignore the other value).
+fn set_once(slot: &mut Option<String>, value: &str, flag: &str) -> Result<()> {
+    match slot {
+        Some(prev) => Err(DataFusionError::Execution(format!(
+            "{flag} was given twice ('{prev}' then '{value}'); it accepts a single value"
+        ))),
+        None => {
+            *slot = Some(value.to_string());
+            Ok(())
+        }
+    }
+}
+
+/// Unwrap a required flag into a path.
+fn required(slot: Option<String>, flag: &str) -> Result<PathBuf> {
+    slot.map(PathBuf::from)
+        .ok_or_else(|| DataFusionError::Execution(format!("{flag} is required")))
+}
+
+impl PluginBuildArgs {
+    /// Parse `build_plugin`'s arguments (argv **without** the program name).
+    ///
+    /// Errors on: an unrecognized flag, a valued flag with no value (it is the last
+    /// argument, or is immediately followed by another flag), a repeated
+    /// single-valued flag, and a missing required flag.
+    pub fn parse(args: &[String]) -> Result<Self> {
+        let mut manifest: Option<String> = None;
+        let mut variation_cache_dir: Option<String> = None;
+        let mut out: Option<String> = None;
+        let mut source_paths: Vec<String> = Vec::new();
+        let mut chroms: Vec<String> = Vec::new();
+        let mut overwrite = false;
+
+        let mut i = 0usize;
+        while i < args.len() {
+            let flag = args[i].as_str();
+
+            if flag == "--overwrite" {
+                overwrite = true;
+                i += 1;
+                continue;
+            }
+            if !VALUED_FLAGS.contains(&flag) {
+                return Err(DataFusionError::Execution(format!(
+                    "unrecognized argument '{flag}'; expected one of {}, {}",
+                    VALUED_FLAGS.join(", "),
+                    BARE_FLAGS.join(", ")
+                )));
+            }
+
+            // A valued flag must be followed by a value. Silently dropping a dangling
+            // flag is how a trailing `--chrom` turns a one-chromosome build into an
+            // all-chromosome build without a word of warning.
+            let value = match args.get(i + 1) {
+                None => {
+                    return Err(DataFusionError::Execution(format!(
+                        "{flag} requires a value but is the last argument"
+                    )));
+                }
+                Some(next) if next.starts_with("--") => {
+                    return Err(DataFusionError::Execution(format!(
+                        "{flag} requires a value but is followed by the flag '{next}'"
+                    )));
+                }
+                Some(v) => v.as_str(),
+            };
+
+            match flag {
+                "--manifest" => set_once(&mut manifest, value, flag)?,
+                "--variation-cache-dir" => set_once(&mut variation_cache_dir, value, flag)?,
+                "--out" => set_once(&mut out, value, flag)?,
+                "--source-path" => source_paths.push(value.to_string()),
+                "--chrom" => chroms.push(value.to_string()),
+                // Unreachable: the `VALUED_FLAGS` guard above admits nothing else.
+                other => {
+                    return Err(DataFusionError::Execution(format!(
+                        "internal: unhandled valued flag '{other}'"
+                    )));
+                }
+            }
+            i += 2;
+        }
+
+        Ok(Self {
+            manifest: required(manifest, "--manifest")?,
+            variation_cache_dir: required(variation_cache_dir, "--variation-cache-dir")?,
+            out: required(out, "--out")?,
+            source_paths,
+            chroms,
+            overwrite,
+        })
+    }
+
+    /// Redirect each `[[source]]`'s `path` from a `--source-path` override.
+    ///
+    /// A bare `--source-path <path>` is accepted only when the manifest declares a
+    /// single `[[source]]`; a multi-source manifest requires `<part>=<path>`, once
+    /// per part. An unknown part is an error (a typo'd part would otherwise leave
+    /// that source silently pointing at its manifest default).
+    pub fn apply_source_overrides(&self, manifest: &mut SourceManifest) -> Result<()> {
+        for spec in &self.source_paths {
+            match spec.split_once('=') {
+                // --source-path <part>=<path>
+                Some((part, path)) => {
+                    let target = manifest
+                        .sources
+                        .iter_mut()
+                        .find(|s| s.part.as_deref() == Some(part))
+                        .ok_or_else(|| {
+                            DataFusionError::Execution(format!(
+                                "--source-path '{part}=...': no [[source]] with part = \"{part}\""
+                            ))
+                        })?;
+                    target.path = path.to_string();
+                }
+                // --source-path <path> — unambiguous only for a single-source manifest
+                None => {
+                    if manifest.sources.len() != 1 {
+                        return Err(DataFusionError::Execution(format!(
+                            "--source-path <path> is ambiguous: the manifest has {} sources; \
+                             use --source-path <part>=<path> (parts: {})",
+                            manifest.sources.len(),
+                            manifest
+                                .sources
+                                .iter()
+                                .map(|s| s.part.as_deref().unwrap_or("<none>"))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )));
+                    }
+                    manifest.sources[0].path = spec.clone();
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Load `--manifest` (which validates it) and apply the `--source-path` overrides.
+    pub fn load_manifest(&self) -> Result<SourceManifest> {
+        let mut manifest = SourceManifest::load(&self.manifest)?;
+        self.apply_source_overrides(&mut manifest)?;
+        Ok(manifest)
+    }
+
+    /// The manifest's file name, as recorded in the built cache manifest.
+    fn manifest_file(&self) -> String {
+        self.manifest
+            .file_name()
+            .unwrap_or(self.manifest.as_os_str())
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Build every requested chromosome and write `plugin/<name>/manifest.json`.
+    pub async fn build(&self, manifest: &SourceManifest) -> Result<CacheManifest> {
+        let mut builder = PluginCacheBuilder::new(
+            manifest,
+            self.manifest_file(),
+            &self.variation_cache_dir,
+            &self.out,
+        );
+        if !self.chroms.is_empty() {
+            builder = builder.with_chrom_filter(self.chroms.clone());
+        }
+        builder.build_all().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn argv(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The three required flags, so each test can add only what it exercises.
+    fn base(extra: &[&str]) -> Vec<String> {
+        let mut v = argv(&[
+            "--manifest",
+            "/m.toml",
+            "--variation-cache-dir",
+            "/cache",
+            "--out",
+            "/out",
+        ]);
+        v.extend(argv(extra));
+        v
+    }
+
+    /// `SourceManifest::load` requires a file; tests materialize one from a string.
+    fn write_manifest(dir: &Path, body: &str) -> PathBuf {
+        let path = dir.join("demo.source.toml");
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    #[test]
+    fn parses_the_required_flags() {
+        let a = PluginBuildArgs::parse(&base(&[])).unwrap();
+        assert_eq!(a.manifest, PathBuf::from("/m.toml"));
+        assert_eq!(a.variation_cache_dir, PathBuf::from("/cache"));
+        assert_eq!(a.out, PathBuf::from("/out"));
+        assert!(a.chroms.is_empty());
+        assert!(a.source_paths.is_empty());
+        assert!(!a.overwrite);
+    }
+
+    // The regression this module exists for: `--overwrite` was documented in the
+    // example's header but never parsed, so `PluginCacheBuilder::with_overwrite`
+    // had no caller outside `#[cfg(test)]` and the flag did nothing.
+    #[test]
+    fn parses_overwrite_as_a_bare_flag() {
+        let a = PluginBuildArgs::parse(&base(&["--overwrite"])).unwrap();
+        assert!(a.overwrite, "--overwrite must be parsed");
+    }
+
+    #[test]
+    fn overwrite_defaults_to_false() {
+        assert!(!PluginBuildArgs::parse(&base(&[])).unwrap().overwrite);
+    }
+
+    // `--overwrite` takes no value, so it must not swallow the token after it.
+    #[test]
+    fn overwrite_does_not_consume_the_next_argument() {
+        let a = PluginBuildArgs::parse(&base(&["--overwrite", "--chrom", "21"])).unwrap();
+        assert!(a.overwrite);
+        assert_eq!(a.chroms, ["21"]);
+    }
+
+    #[test]
+    fn chrom_repeats_and_keeps_order() {
+        let a = PluginBuildArgs::parse(&base(&["--chrom", "21", "--chrom", "22"])).unwrap();
+        assert_eq!(
+            a.chroms,
+            ["21", "22"],
+            "every --chrom must be collected, in order"
+        );
+    }
+
+    #[test]
+    fn source_path_repeats() {
+        let a = PluginBuildArgs::parse(&base(&[
+            "--source-path",
+            "snv=/a.tsv",
+            "--source-path",
+            "indel=/b.tsv",
+        ]))
+        .unwrap();
+        assert_eq!(a.source_paths, ["snv=/a.tsv", "indel=/b.tsv"]);
+    }
+
+    // A trailing valued flag used to be silently dropped: `… --chrom` then meant
+    // "no chrom filter", i.e. build EVERY chromosome. That is a silent widening.
+    #[test]
+    fn trailing_flag_without_a_value_is_an_error() {
+        let err = PluginBuildArgs::parse(&base(&["--chrom"]))
+            .expect_err("a dangling --chrom must not be silently dropped");
+        let msg = err.to_string();
+        assert!(msg.contains("--chrom"), "must name the flag: {msg}");
+        assert!(msg.contains("last argument"), "must say why: {msg}");
+    }
+
+    #[test]
+    fn valued_flag_followed_by_another_flag_is_an_error() {
+        let err = PluginBuildArgs::parse(&base(&["--chrom", "--overwrite"]))
+            .expect_err("--chrom --overwrite must not read '--overwrite' as a chromosome");
+        assert!(err.to_string().contains("--overwrite"), "{err}");
+    }
+
+    #[test]
+    fn unrecognized_flag_is_an_error() {
+        let err = PluginBuildArgs::parse(&base(&["--chrome", "21"]))
+            .expect_err("a typo'd flag must be rejected, not ignored");
+        assert!(err.to_string().contains("--chrome"), "{err}");
+    }
+
+    #[test]
+    fn repeated_single_valued_flag_is_an_error() {
+        let err = PluginBuildArgs::parse(&base(&["--out", "/other"]))
+            .expect_err("--out twice must not silently keep just one of them");
+        assert!(err.to_string().contains("--out"), "{err}");
+    }
+
+    #[test]
+    fn missing_required_flag_is_an_error() {
+        for missing in ["--manifest", "--variation-cache-dir", "--out"] {
+            let kept: Vec<String> = base(&[])
+                .chunks(2)
+                .filter(|pair| pair[0] != missing)
+                .flat_map(<[String]>::to_vec)
+                .collect();
+            let err = PluginBuildArgs::parse(&kept).unwrap_err();
+            assert!(
+                err.to_string().contains(missing),
+                "dropping {missing} must be an error naming it, got: {err}"
+            );
+        }
+    }
+
+    const TWO_SOURCE: &str = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+part = "snv"
+provider = "csv"
+path = "snv-default.tsv"
+  [source.csv]
+  schema = [{ name = "chrom", type = "Utf8" }]
+
+[[source]]
+part = "indel"
+provider = "csv"
+path = "indel-default.tsv"
+  [source.csv]
+  schema = [{ name = "chrom", type = "Utf8" }]
+
+[[value_columns]]
+column = "s"
+csq_field = "S"
+type = "Float32"
+"##;
+
+    const ONE_SOURCE: &str = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "csv"
+path = "default.tsv"
+  [source.csv]
+  schema = [{ name = "chrom", type = "Utf8" }]
+
+[[value_columns]]
+column = "s"
+csq_field = "S"
+type = "Float32"
+"##;
+
+    /// Args for `manifest_path` plus the given extras.
+    fn args_for(manifest_path: &Path, extra: &[&str]) -> PluginBuildArgs {
+        let mut v = argv(&[
+            "--manifest",
+            manifest_path.to_str().unwrap(),
+            "--variation-cache-dir",
+            "/cache",
+            "--out",
+            "/out",
+        ]);
+        v.extend(argv(extra));
+        PluginBuildArgs::parse(&v).unwrap()
+    }
+
+    #[test]
+    fn bare_source_path_targets_the_only_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_manifest(dir.path(), ONE_SOURCE);
+        let args = args_for(&path, &["--source-path", "/real/input.tsv"]);
+        let m = args.load_manifest().unwrap();
+        assert_eq!(m.sources[0].path, "/real/input.tsv");
+    }
+
+    // A bare path cannot say WHICH source it means, so on a multi-source manifest it
+    // must fail loudly and name the parts rather than silently patching the first.
+    #[test]
+    fn bare_source_path_on_a_multi_source_manifest_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_manifest(dir.path(), TWO_SOURCE);
+        let args = args_for(&path, &["--source-path", "/real/input.tsv"]);
+        let err = args
+            .load_manifest()
+            .expect_err("a bare --source-path is ambiguous with 2 sources");
+        let msg = err.to_string();
+        assert!(msg.contains("ambiguous"), "{msg}");
+        assert!(msg.contains("snv"), "must list the parts: {msg}");
+        assert!(msg.contains("indel"), "must list the parts: {msg}");
+    }
+
+    #[test]
+    fn part_scoped_source_path_targets_the_right_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_manifest(dir.path(), TWO_SOURCE);
+        let args = args_for(&path, &["--source-path", "indel=/real/indel.tsv"]);
+        let m = args.load_manifest().unwrap();
+        assert_eq!(
+            m.sources[0].path, "snv-default.tsv",
+            "the un-targeted source must keep its manifest path"
+        );
+        assert_eq!(m.sources[1].path, "/real/indel.tsv");
+    }
+
+    // Every --source-path must land, not just the first (the pre-fix `arg()` helper
+    // read only the first occurrence).
+    #[test]
+    fn every_part_scoped_source_path_is_applied() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_manifest(dir.path(), TWO_SOURCE);
+        let args = args_for(
+            &path,
+            &[
+                "--source-path",
+                "snv=/real/snv.tsv",
+                "--source-path",
+                "indel=/real/indel.tsv",
+            ],
+        );
+        let m = args.load_manifest().unwrap();
+        assert_eq!(m.sources[0].path, "/real/snv.tsv");
+        assert_eq!(m.sources[1].path, "/real/indel.tsv");
+    }
+
+    #[test]
+    fn unknown_part_in_source_path_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_manifest(dir.path(), TWO_SOURCE);
+        let args = args_for(&path, &["--source-path", "sv=/real/sv.tsv"]);
+        let err = args
+            .load_manifest()
+            .expect_err("an unknown part must not be silently ignored");
+        let msg = err.to_string();
+        assert!(msg.contains("sv"), "must name the offending part: {msg}");
+    }
+}

--- a/datafusion/bio-function-vep/src/plugin_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mod.rs
@@ -10,6 +10,7 @@
 pub mod build;
 pub mod builder;
 pub mod cache_manifest;
+pub mod cli;
 pub mod csq;
 pub mod dedup;
 pub mod join;

--- a/datafusion/bio-function-vep/src/plugin_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mod.rs
@@ -20,4 +20,6 @@ pub mod provider;
 pub mod registry;
 pub mod source_manifest;
 pub mod template;
+#[cfg(test)]
+pub(crate) mod test_fixtures;
 pub mod write;

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -234,13 +234,17 @@ type = "Float32"
     async fn registers_vcf_source_and_projects_info_fields() {
         let dir = tempfile::tempdir().unwrap();
         let vcf = dir.path().join("demo.vcf");
+        // TWO INFO keys, of which the manifest selects one. With a single-key header
+        // every assertion below would hold identically for `info_fields = None`, and
+        // the *selection* half of this test would be vacuous.
         std::fs::write(
             &vcf,
             "##fileformat=VCFv4.2\n\
              ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             ##INFO=<ID=NOISE,Number=1,Type=Float,Description=\"an INFO key the manifest omits\">\n\
              #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
-             chr22\t22893742\t.\tC\tG\t.\t.\tSCORE=0.9\n\
-             chr22\t22893800\t.\tA\tT\t.\t.\tSCORE=0.1\n",
+             chr22\t22893742\t.\tC\tG\t.\t.\tSCORE=0.9;NOISE=1.5\n\
+             chr22\t22893800\t.\tA\tT\t.\t.\tSCORE=0.1;NOISE=2.5\n",
         )
         .unwrap();
 
@@ -267,6 +271,26 @@ type = "Float32"
         let manifest: SourceManifest = toml::from_str(&toml_src).unwrap();
         let ctx = SessionContext::new();
         let _temps = register_sources(&ctx, &manifest).await.unwrap();
+
+        // `info_fields` is a SELECTION: only the requested INFO keys become columns.
+        // NOISE is declared in the header and present in every record, so if the
+        // selection were ignored (or `info_fields` silently dropped, as a typo'd
+        // `[source.vcf]` key once caused) it would show up here.
+        let table = ctx.table("plugin_demo_src").await.unwrap();
+        let columns: Vec<&str> = table
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert!(
+            columns.contains(&"SCORE"),
+            "the selected INFO key must be materialized, got {columns:?}"
+        );
+        assert!(
+            !columns.contains(&"NOISE"),
+            "an INFO key absent from info_fields must NOT be materialized, got {columns:?}"
+        );
 
         // The reader exposes VCF POS as `start` (plus a matching `end`), NOT `pos`.
         // INFO columns are bare, case-sensitive keys -> must be backticked.

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -335,6 +335,10 @@ type = "Float32"
     /// 1. a multi-allelic record is ONE row whose `alt` is the ALTs joined by `|`
     ///    (so `concat(ref,'/',alt)` yields the un-matchable `A/G|T`);
     /// 2. `end` is `POS + len(REF) - 1` for an indel, not `start`.
+    ///
+    /// This is WHY `build::reject_pipe_joined_alleles` exists — and the tail of this
+    /// test asserts that guard actually fires on exactly the value pinned here, so the
+    /// characterization and the guard can never drift apart.
     #[tokio::test(flavor = "multi_thread")]
     async fn multiallelic_alt_is_pipe_joined_and_indel_end_extends_past_start() {
         let dir = tempfile::tempdir().unwrap();
@@ -416,6 +420,47 @@ type = "Float32"
             ends.value(1),
             203,
             "an indel's end is POS + len(REF) - 1, not start"
+        );
+
+        // …and the un-matchable "A/G|T" pinned above must now FAIL the build rather
+        // than silently produce a shard that annotates nothing. (Before the guard this
+        // returned ChromEntry { rows: 1, warm: 0, cold: 1 } and no error.)
+        let var = dir.path().join("var.parquet");
+        crate::plugin_cache::test_fixtures::write_variation(&var, &[("1", 100, "A/G", 0)]);
+        let naive = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, `start`, `end`, concat(`ref`, '/', alt) AS allele_string,
+       CAST(qual AS FLOAT) AS score
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "vcf"
+path = "{}"
+
+[[value_columns]]
+column = "score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&naive).unwrap();
+        let err = crate::plugin_cache::build::build_plugin_chrom(
+            &manifest,
+            "demo.source.toml",
+            &var,
+            &dir.path().join("out"),
+            "1",
+        )
+        .await
+        .expect_err("the pipe-joined allele_string pinned above must fail the build");
+        assert!(
+            err.to_string().contains("A/G|T"),
+            "the guard must quote the very value this test pins: {err}"
         );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -327,4 +327,95 @@ type = "Float32"
             score.value(0)
         );
     }
+
+    /// Pins the two reader behaviours `VcfParams`' docs warn manifest authors about,
+    /// so a bio-formats bump that changes either one fails here instead of silently
+    /// invalidating the documented `ingest_sql` guidance:
+    ///
+    /// 1. a multi-allelic record is ONE row whose `alt` is the ALTs joined by `|`
+    ///    (so `concat(ref,'/',alt)` yields the un-matchable `A/G|T`);
+    /// 2. `end` is `POS + len(REF) - 1` for an indel, not `start`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn multiallelic_alt_is_pipe_joined_and_indel_end_extends_past_start() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("multi.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr1\t100\t.\tA\tG,T\t.\t.\t.\n\
+             chr1\t200\t.\tACGT\tA\t.\t.\t.\n",
+        )
+        .unwrap();
+
+        let toml_src = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "{}"
+
+[[value_columns]]
+column = "score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml_src).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+
+        let batches = ctx
+            .sql(
+                "SELECT `start`, `end`, `ref`, alt, concat(`ref`, '/', alt) AS allele_string \
+                 FROM plugin_demo_src ORDER BY `start`",
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let b = &batches[0];
+        let col = |i: usize| {
+            b.column(i)
+                .as_any()
+                .downcast_ref::<datafusion::arrow::array::StringArray>()
+                .expect("Utf8 column")
+        };
+        let starts = b
+            .column(0)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt32Array>()
+            .expect("start is UInt32");
+        let ends = b
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt32Array>()
+            .expect("end is UInt32");
+
+        // Row 0: A -> G,T collapses into ONE row, alt = "G|T".
+        assert_eq!(
+            b.num_rows(),
+            2,
+            "the reader does NOT split multi-allelic records into one row per ALT"
+        );
+        assert_eq!(col(3).value(0), "G|T", "ALTs are joined with '|'");
+        assert_eq!(
+            col(4).value(0),
+            "A/G|T",
+            "so the naive concat(ref,'/',alt) yields a key that matches nothing"
+        );
+
+        // Row 1: ACGT -> A is a deletion; end extends past start (200 + 4 - 1 = 203).
+        assert_eq!(starts.value(1), 200);
+        assert_eq!(
+            ends.value(1),
+            203,
+            "an indel's end is POS + len(REF) - 1, not start"
+        );
+    }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -116,21 +116,33 @@ pub async fn register_sources(
             ProviderKind::Vcf => {
                 let info_fields = spec.vcf.as_ref().and_then(|v| v.info_fields.clone());
                 // ObjectStorageOptions::default() sets compression_type = AUTO, which is what
-                // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. Passing `None`
-                // is NOT equivalent — the reader's own tests always pass explicit options.
+                // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. `None` would
+                // behave identically today (the reader `unwrap_or_default()`s it at every use),
+                // but passing the value explicitly keeps the compression policy visible here.
                 //
                 // coordinate_system_zero_based = false: VCF POS is 1-based and the plugin cache
                 // stores 1-based start/end, so the reader must not shift. The manifest's
                 // `coordinate_system` remains the single source of truth for any shift the
                 // builder applies (see plugin_cache::build::wrap_normalization).
+                let path = &spec.path;
                 let vcf_table = VcfTableProvider::new(
                     spec.path.clone(),
                     info_fields,
                     None,
                     Some(ObjectStorageOptions::default()),
                     false,
-                )?;
-                ctx.register_table(table.as_str(), Arc::new(vcf_table))?;
+                )
+                .map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "open vcf source '{path}' for table '{table}': {e}"
+                    ))
+                })?;
+                ctx.register_table(table.as_str(), Arc::new(vcf_table))
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "register vcf table '{table}' ('{path}'): {e}"
+                        ))
+                    })?;
             }
             ProviderKind::Bed => {
                 return Err(DataFusionError::NotImplemented(format!(
@@ -148,7 +160,7 @@ pub async fn register_sources(
 mod tests {
     use super::*;
     use crate::plugin_cache::source_manifest::SourceManifest;
-    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::array::{Array, Int64Array};
     use std::io::Write;
 
     fn write_gz(path: &std::path::Path, body: &str) {
@@ -276,5 +288,19 @@ type = "Float32"
             .downcast_ref::<datafusion::arrow::array::UInt32Array>()
             .expect("start is UInt32");
         assert_eq!(pos.value(0), 22_893_742);
+
+        // The selected INFO field must actually carry its parsed value — a column that
+        // resolved by name but came back all-null would otherwise pass unnoticed.
+        let score = batches[0]
+            .column(2)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Float32Array>()
+            .expect("SCORE is Float32");
+        assert!(score.is_valid(0), "SCORE must be parsed, not null");
+        assert!(
+            (score.value(0) - 0.9).abs() < 1e-6,
+            "SCORE = {}, want 0.9",
+            score.value(0)
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -1,10 +1,15 @@
 //! Provider factory: register a source manifest's raw tables under their
 //! `plugin_<name>_src[_<part>]` names. CSV/TSV/Parquet use builtin DataFusion
-//! providers; VCF/BED (bio-formats) are not wired in the prototype.
+//! providers; VCF uses bio-formats' `VcfTableProvider`. BED is not wired yet
+//! (no plugin needs it).
+
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
+use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
+use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
 use crate::plugin_cache::source_manifest::{CsvParams, ProviderKind, SourceManifest, ValueType};
 
@@ -108,10 +113,30 @@ pub async fn register_sources(
                 ctx.register_parquet(&table, &spec.path, ParquetReadOptions::default())
                     .await?;
             }
-            ProviderKind::Vcf | ProviderKind::Bed => {
+            ProviderKind::Vcf => {
+                let info_fields = spec.vcf.as_ref().and_then(|v| v.info_fields.clone());
+                // ObjectStorageOptions::default() sets compression_type = AUTO, which is what
+                // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. Passing `None`
+                // is NOT equivalent — the reader's own tests always pass explicit options.
+                //
+                // coordinate_system_zero_based = false: VCF POS is 1-based and the plugin cache
+                // stores 1-based start/end, so the reader must not shift. The manifest's
+                // `coordinate_system` remains the single source of truth for any shift the
+                // builder applies (see plugin_cache::build::wrap_normalization).
+                let vcf_table = VcfTableProvider::new(
+                    spec.path.clone(),
+                    info_fields,
+                    None,
+                    Some(ObjectStorageOptions::default()),
+                    false,
+                )?;
+                ctx.register_table(table.as_str(), Arc::new(vcf_table))?;
+            }
+            ProviderKind::Bed => {
                 return Err(DataFusionError::NotImplemented(format!(
-                    "provider {:?} not wired in prototype (table '{table}')",
-                    spec.provider
+                    "provider 'bed' is not wired yet (table '{table}'); \
+                     no plugin needs it — wire datafusion-bio-format-bed the way \
+                     ProviderKind::Vcf is wired when one does"
                 )));
             }
         }
@@ -191,5 +216,65 @@ type = "Float32"
             .unwrap()
             .value(0);
         assert_eq!(c, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn registers_vcf_source_and_projects_info_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("demo.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr22\t22893742\t.\tC\tG\t.\t.\tSCORE=0.9\n\
+             chr22\t22893800\t.\tA\tT\t.\t.\tSCORE=0.1\n",
+        )
+        .unwrap();
+
+        let toml_src = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "{}"
+  [source.vcf]
+  info_fields = ["SCORE"]
+
+[[value_columns]]
+column = "score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+
+        let manifest: SourceManifest = toml::from_str(&toml_src).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+
+        // The reader exposes VCF POS as `start` (plus a matching `end`), NOT `pos`.
+        // INFO columns are bare, case-sensitive keys -> must be backticked.
+        let batches = ctx
+            .sql("SELECT chrom, `start`, `SCORE` FROM plugin_demo_src ORDER BY `start`")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 2, "both VCF records must be visible");
+
+        // The reader must report 1-based POS (22893742), matching the cache's 1-based start.
+        let pos = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::UInt32Array>()
+            .expect("start is UInt32");
+        assert_eq!(pos.value(0), 22_893_742);
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -9,6 +9,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
 use datafusion_bio_format_core::object_storage::ObjectStorageOptions;
+use datafusion_bio_format_vcf::storage::get_header;
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
 use crate::plugin_cache::source_manifest::{CsvParams, ProviderKind, SourceManifest, ValueType};
@@ -66,6 +67,69 @@ fn materialize_plain(path: &str, gzip: bool) -> Result<(String, Option<tempfile:
     Ok((plain, Some(temp_path)))
 }
 
+/// Reject `info_fields` keys the VCF header does not declare, BEFORE they reach
+/// `VcfTableProvider::new`.
+///
+/// The reader resolves each requested INFO key with `header.infos().get(tag).unwrap()`
+/// (`table_provider.rs:174`), so an unknown key does not return an `Err` — it PANICS:
+///
+/// ```text
+/// thread panicked at datafusion-bio-format-vcf/src/table_provider.rs:174:51:
+/// called `Option::unwrap()` on a `None` value
+/// ```
+///
+/// naming no plugin, no manifest, no key and no file. (Which is why the `.map_err(…)`
+/// wrapped around `VcfTableProvider::new` below cannot help: a panic is not an `Err`.)
+/// And this is the single most likely authoring error, because the reader exposes INFO
+/// keys as bare, CASE-SENSITIVE column names: `info_fields = ["score"]` for a header
+/// that declares `SCORE` is enough.
+///
+/// So diff the request against the header first and fail with a diagnostic that names
+/// the plugin, the file, every offending key, and the keys the header actually declares.
+/// `get_header` is the same entry point the reader itself uses, so this handles plain
+/// `.vcf`, BGZF `.vcf.gz` and remote object stores identically to the read path.
+///
+/// `info_fields = None` (take every declared key) and `info_fields = []` (take none)
+/// both request nothing that could be absent, and are left alone.
+async fn reject_undeclared_info_fields(
+    plugin: &str,
+    table: &str,
+    path: &str,
+    requested: &[String],
+) -> Result<()> {
+    if requested.is_empty() {
+        return Ok(());
+    }
+    let header = get_header(path.to_string(), Some(ObjectStorageOptions::default()))
+        .await
+        .map_err(|e| {
+            DataFusionError::Execution(format!(
+                "plugin '{plugin}': read the VCF header of '{path}' (table '{table}'): {e}"
+            ))
+        })?;
+    let declared: Vec<String> = header.infos().keys().map(ToString::to_string).collect();
+    let missing: Vec<&str> = requested
+        .iter()
+        .map(String::as_str)
+        .filter(|key| !declared.iter().any(|d| d == key))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(DataFusionError::Execution(format!(
+        "plugin '{plugin}': [source.vcf] info_fields names {} the VCF header of '{path}' does \
+         not declare: {}. INFO keys are bare and CASE-SENSITIVE — check the spelling and the \
+         case. The header declares: [{}].",
+        if missing.len() == 1 { "a key" } else { "keys" },
+        missing
+            .iter()
+            .map(|k| format!("'{k}'"))
+            .collect::<Vec<_>>()
+            .join(", "),
+        declared.join(", ")
+    )))
+}
+
 /// Register every source in `manifest` as a DataFusion table. Returns any
 /// decompressed temp files the caller must keep alive for the duration of query
 /// execution (dropping them deletes the temp — see `materialize_plain`).
@@ -115,6 +179,17 @@ pub async fn register_sources(
             }
             ProviderKind::Vcf => {
                 let info_fields = spec.vcf.as_ref().and_then(|v| v.info_fields.clone());
+                // A key the header does not declare would PANIC inside the reader with no
+                // context at all (see `reject_undeclared_info_fields`) — diff it first.
+                if let Some(requested) = info_fields.as_deref() {
+                    reject_undeclared_info_fields(
+                        &manifest.plugin_name,
+                        &table,
+                        &spec.path,
+                        requested,
+                    )
+                    .await?;
+                }
                 // ObjectStorageOptions::default() sets compression_type = AUTO, which is what
                 // lets one code path read both plain `.vcf` and BGZF `.vcf.gz`. `None` would
                 // behave identically today (the reader `unwrap_or_default()`s it at every use),
@@ -160,15 +235,8 @@ pub async fn register_sources(
 mod tests {
     use super::*;
     use crate::plugin_cache::source_manifest::SourceManifest;
+    use crate::plugin_cache::test_fixtures::{write_bgzf, write_gz};
     use datafusion::arrow::array::{Array, Int64Array};
-    use std::io::Write;
-
-    fn write_gz(path: &std::path::Path, body: &str) {
-        let f = std::fs::File::create(path).unwrap();
-        let mut enc = flate2::write::GzEncoder::new(f, flate2::Compression::default());
-        enc.write_all(body.as_bytes()).unwrap();
-        enc.finish().unwrap();
-    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn registers_csv_source_with_declared_schema() {
@@ -326,6 +394,180 @@ type = "Float32"
             "SCORE = {}, want 0.9",
             score.value(0)
         );
+    }
+
+    /// A manifest that names an INFO key the VCF header does not declare — a typo, or
+    /// (far likelier) the wrong case, since INFO keys are bare and CASE-SENSITIVE — used
+    /// to reach `VcfTableProvider::new`, where the reader does
+    /// `header_infos.get(tag).unwrap()` and PANICS:
+    ///
+    /// ```text
+    /// thread panicked at datafusion-bio-format-vcf/src/table_provider.rs:174:51:
+    /// called `Option::unwrap()` on a `None` value
+    /// ```
+    ///
+    /// No plugin, no manifest, no key, no file. (The careful `.map_err(...)` around
+    /// `VcfTableProvider::new` catches nothing: a panic is not an `Err`.) Diff the
+    /// requested keys against the header BEFORE handing them to the reader instead.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn miscased_info_field_is_rejected_with_the_header_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("demo.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             ##INFO=<ID=NOISE,Number=1,Type=Float,Description=\"noise\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr22\t22893742\t.\tC\tG\t.\t.\tSCORE=0.9;NOISE=1.5\n",
+        )
+        .unwrap();
+
+        // `score` — right key, wrong case. The single most likely authoring error.
+        let toml_src = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "{}"
+  [source.vcf]
+  info_fields = ["score"]
+
+[[value_columns]]
+column = "score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml_src).unwrap();
+        let ctx = SessionContext::new();
+        let err = register_sources(&ctx, &manifest)
+            .await
+            .expect_err("an INFO key the header does not declare must be an error, not a panic");
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(msg.contains("score"), "must name the offending key: {msg}");
+        assert!(
+            msg.contains("SCORE") && msg.contains("NOISE"),
+            "must list the INFO keys the header actually declares: {msg}"
+        );
+        assert!(
+            msg.contains(&vcf.display().to_string()),
+            "must name the file: {msg}"
+        );
+    }
+
+    /// The same guard must work on BGZF (`.vcf.gz`) — the form every real plugin source
+    /// ships in — not just plain `.vcf`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unknown_info_field_is_rejected_in_a_bgzf_vcf() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("demo.vcf.gz");
+        write_bgzf(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=MMCNT1,Number=1,Type=Integer,Description=\"mm count\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr1\t100\t.\tA\tG\t.\t.\tMMCNT1=3\n",
+        );
+
+        let toml_src = format!(
+            r##"
+plugin_name = "mastermind"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "{}"
+  [source.vcf]
+  info_fields = ["MMCNT1", "BOGUS"]
+
+[[value_columns]]
+column = "mmcnt1"
+csq_field = "MM"
+type = "Int32"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml_src).unwrap();
+        let ctx = SessionContext::new();
+        let err = register_sources(&ctx, &manifest)
+            .await
+            .expect_err("BOGUS is not declared in the BGZF header");
+        let msg = err.to_string();
+        assert!(msg.contains("BOGUS"), "must name the offending key: {msg}");
+        assert!(
+            msg.contains("MMCNT1"),
+            "must list the header's declared keys: {msg}"
+        );
+        assert!(msg.contains("mastermind"), "must name the plugin: {msg}");
+    }
+
+    /// The valid cases must keep working through the new header check:
+    /// - every requested key is declared -> registers;
+    /// - `info_fields = []` -> no INFO columns, no header complaint;
+    /// - an omitted `[source.vcf]` -> all INFO keys, header never diffed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn declared_empty_and_omitted_info_fields_all_register() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("demo.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             ##INFO=<ID=SCORE,Number=1,Type=Float,Description=\"demo score\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             chr1\t100\t.\tA\tG\t.\t.\tSCORE=0.9\n",
+        )
+        .unwrap();
+
+        let mk = |params: &str| {
+            format!(
+                r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "{}"
+{params}
+
+[[value_columns]]
+column = "score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+                vcf.display()
+            )
+        };
+
+        for (label, params, wants_score) in [
+            (
+                "exact key",
+                "  [source.vcf]\n  info_fields = [\"SCORE\"]",
+                true,
+            ),
+            (
+                "empty selection",
+                "  [source.vcf]\n  info_fields = []",
+                false,
+            ),
+            ("omitted [source.vcf]", "", true),
+        ] {
+            let manifest: SourceManifest = toml::from_str(&mk(params)).unwrap();
+            let ctx = SessionContext::new();
+            let _temps = register_sources(&ctx, &manifest)
+                .await
+                .unwrap_or_else(|e| panic!("{label} must register: {e}"));
+            let table = ctx.table("plugin_demo_src").await.unwrap();
+            let has_score = table.schema().field_with_name(None, "SCORE").is_ok();
+            assert_eq!(has_score, wants_score, "{label}: SCORE column presence");
+        }
     }
 
     /// Pins the two reader behaviours `VcfParams`' docs warn manifest authors about,

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -169,9 +169,6 @@ path = "{}"
 column = "score"
 csq_field = "DEMO"
 type = "Float32"
-
-[tier]
-threshold = 0.01
 "##,
             tsv.display()
         );

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -119,8 +119,8 @@ fn default_delim() -> String {
 /// ```
 ///
 /// yields `A/G|T`, which can never equal the runtime probe key (`{ref}/{alt}`, one
-/// ALT at a time) nor the variation cache's per-allele `allele_string`. Such rows are
-/// written to the shard and are dead forever: they match nothing, and nothing warns.
+/// ALT at a time) nor the variation cache's per-allele `allele_string`. Such a row
+/// would be dead forever: it matches nothing.
 ///
 /// `ingest_sql` must therefore split `alt` into ONE ROW PER ALT ALLELE, e.g.
 ///
@@ -132,8 +132,10 @@ fn default_delim() -> String {
 /// )
 /// ```
 ///
-/// A source whose every record is bi-allelic can skip this, but nothing enforces
-/// that — so prefer the split unless the input is known bi-allelic by construction.
+/// This is ENFORCED, not merely advised: `build::reject_pipe_joined_alleles` fails the
+/// build with a diagnostic if any `allele_string` reaching the shard contains `|`. A
+/// source whose every record is bi-allelic passes the guard unchanged, but prefer the
+/// split unless the input is known bi-allelic by construction.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VcfParams {

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -346,8 +346,8 @@ type = "Float32"
 [tier]
 threshold = 0.01
 "##;
-        let err = toml::from_str::<SourceManifest>(src)
-            .expect_err("unknown key [tier] must be rejected");
+        let err =
+            toml::from_str::<SourceManifest>(src).expect_err("unknown key [tier] must be rejected");
         assert!(
             err.to_string().contains("tier"),
             "the error must name the offending key, got: {err}"

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -244,6 +244,9 @@ impl SourceManifest {
     /// together — the ones the build would otherwise accept and silently ignore.
     ///
     /// Rules:
+    /// - at least one `[[source]]` (nothing to read otherwise — and
+    ///   `examples/build_plugin.rs` indexes `sources[0]`);
+    /// - at least one `[[value_columns]]` (a plugin that emits nothing);
     /// - a `vcf` source requires `coordinate_system = "1-based"`;
     /// - `[source.csv]` is only valid for `provider = "csv" | "tsv"`;
     /// - `[source.vcf]` is only valid for `provider = "vcf"`;
@@ -255,6 +258,25 @@ impl SourceManifest {
     /// `Deserialize` would force every one of them through validation.
     pub fn validate(&self) -> Result<()> {
         let plugin = &self.plugin_name;
+
+        // `source = []` and `value_columns = []` are legal TOML and deserialize happily
+        // into empty vectors, leaving a manifest that is structurally useless: nothing to
+        // read from, or nothing to emit. The former also panics `examples/build_plugin.rs`,
+        // which indexes `sources[0]` to announce what it is building.
+        if self.sources.is_empty() {
+            return Err(DataFusionError::Execution(format!(
+                "plugin '{plugin}': the manifest declares no [[source]]. A plugin cache needs at \
+                 least one source to ingest from."
+            )));
+        }
+        if self.value_columns.is_empty() {
+            return Err(DataFusionError::Execution(format!(
+                "plugin '{plugin}': the manifest declares no [[value_columns]]. A plugin that \
+                 emits no value column would build shards carrying only the lookup key and the \
+                 tier, and annotate nothing."
+            )));
+        }
+
         for (i, spec) in self.sources.iter().enumerate() {
             let src = spec.label(i);
             let provider = spec.provider.as_manifest_str();
@@ -629,6 +651,54 @@ type = "Float32"
         assert!(
             m.validate().is_err(),
             "the same manifest must fail an explicit validate()"
+        );
+    }
+
+    // `source = []` parses (an empty array of tables is legal TOML) and then panics in
+    // examples/build_plugin.rs, which indexes `manifest.sources[0]` to print what it is
+    // building. A manifest with nothing to read is structurally useless — say so.
+    #[test]
+    fn manifest_without_a_source_is_rejected() {
+        let src = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+source = []
+
+[[value_columns]]
+column = "s"
+csq_field = "S"
+type = "Float32"
+"##;
+        let err = load_str(src).expect_err("a manifest with no [[source]] must not load");
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(
+            msg.contains("[[source]]"),
+            "must name what is missing: {msg}"
+        );
+    }
+
+    // The mirror: no `[[value_columns]]` means a plugin that emits nothing — it would
+    // build shards whose only columns are the key and the tier.
+    #[test]
+    fn manifest_without_a_value_column_is_rejected() {
+        let src = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+value_columns = []
+
+[[source]]
+provider = "csv"
+path = "/tmp/x"
+"##;
+        let err = load_str(src).expect_err("a manifest with no [[value_columns]] must not load");
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(
+            msg.contains("[[value_columns]]"),
+            "must name what is missing: {msg}"
         );
     }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -38,6 +38,7 @@ pub enum ValueType {
 
 /// One field of an explicit input schema (headerless/typed TSV).
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SchemaField {
     pub name: String,
     #[serde(rename = "type")]
@@ -46,6 +47,7 @@ pub struct SchemaField {
 
 /// CSV/TSV provider parameters.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CsvParams {
     #[serde(default = "default_delim")]
     pub delimiter: String,
@@ -65,6 +67,7 @@ fn default_delim() -> String {
 
 /// One raw source file registered as `plugin_<name>_src[_<part>]`.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SourceSpec {
     #[serde(default)]
     pub part: Option<String>,
@@ -87,6 +90,7 @@ impl SourceSpec {
 
 /// A value column produced by `ingest_sql`, mapped to a CSQ output field.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ValueColumn {
     pub column: String,
     pub csq_field: String,
@@ -99,6 +103,7 @@ pub struct ValueColumn {
 /// discriminator built from a `template` over the engine-attribute namespace
 /// (see `plugin_cache::template`). Empty for pure per-variant plugins.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MatchColumn {
     /// Cache column name (also the column `ingest_sql` must produce).
     pub column: String,
@@ -108,6 +113,7 @@ pub struct MatchColumn {
 
 /// The full source manifest for one plugin.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SourceManifest {
     pub plugin_name: String,
     pub coordinate_system: CoordinateSystem,
@@ -212,5 +218,34 @@ type = "Float32"
             csv: None,
         };
         assert_eq!(src.table_name("cadd"), "plugin_cadd_src");
+    }
+
+    #[test]
+    fn rejects_unknown_key_instead_of_ignoring_it() {
+        // `[tier]` is documented in old handoffs but does not exist in SourceManifest.
+        // Before deny_unknown_fields this parsed happily and did nothing.
+        let src = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "csv"
+path = "/tmp/x.tsv"
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+
+[tier]
+threshold = 0.01
+"##;
+        let err = toml::from_str::<SourceManifest>(src)
+            .expect_err("unknown key [tier] must be rejected");
+        assert!(
+            err.to_string().contains("tier"),
+            "the error must name the offending key, got: {err}"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -98,8 +98,42 @@ fn default_delim() -> String {
 ///
 /// The reader's core columns are `chrom`, `start`, `end`, `id`, `ref`, `alt`, `qual`,
 /// `filter` — there is NO `pos`. VCF POS is exposed as `start` (1-based, matching the
-/// cache's coordinate system), with a matching `end`. So `ingest_sql` must select
-/// `start`/`end`, not `pos`.
+/// cache's coordinate system). So `ingest_sql` must select `start`/`end`, not `pos`.
+///
+/// # `end` is not always `start`
+///
+/// `end` equals `start` only for a plain single-ALT ACGT SNV. Otherwise the reader
+/// reports the variant end — `POS + len(REF) - 1` for indels/MNVs (and the INFO `END`
+/// for symbolic alleles). Do not assume `end = start` in `ingest_sql`.
+///
+/// # `alt` is pipe-joined for multi-allelic records — SPLIT IT
+///
+/// The reader joins a record's ALT alleles into ONE `Utf8` column separated by `|`
+/// (`physical_exec.rs`: `join_into(…, '|')`). A multi-allelic record
+/// `chr1 100 . A G,T` therefore arrives as a single row with `alt = "G|T"`.
+///
+/// This is a trap, because the obvious mapping
+///
+/// ```sql
+/// concat(ref, '/', alt) AS allele_string   -- WRONG for multi-allelic records
+/// ```
+///
+/// yields `A/G|T`, which can never equal the runtime probe key (`{ref}/{alt}`, one
+/// ALT at a time) nor the variation cache's per-allele `allele_string`. Such rows are
+/// written to the shard and are dead forever: they match nothing, and nothing warns.
+///
+/// `ingest_sql` must therefore split `alt` into ONE ROW PER ALT ALLELE, e.g.
+///
+/// ```sql
+/// SELECT chrom, `start`, `end`,
+///        concat(`ref`, '/', alt_one) AS allele_string, …
+/// FROM (
+///   SELECT *, unnest(string_to_array(alt, '|')) AS alt_one FROM plugin_x_src
+/// )
+/// ```
+///
+/// A source whose every record is bi-allelic can skip this, but nothing enforces
+/// that — so prefer the split unless the input is known bi-allelic by construction.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VcfParams {

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -72,6 +72,11 @@ fn default_delim() -> String {
 /// keys as **bare, case-sensitive column names** (`AF`, `ALLELE_ID`) — not
 /// `info_af` as `bio-format-vcf`'s crate docs claim — so `ingest_sql` must
 /// backtick them: ``SELECT `AF` FROM plugin_x_src``.
+///
+/// The reader's core columns are `chrom`, `start`, `end`, `id`, `ref`, `alt`, `qual`,
+/// `filter` — there is NO `pos`. VCF POS is exposed as `start` (1-based, matching the
+/// cache's coordinate system), with a matching `end`. So `ingest_sql` must select
+/// `start`/`end`, not `pos`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VcfParams {

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -265,6 +265,62 @@ type = "Utf8"
     }
 
     #[test]
+    fn vcf_source_without_vcf_table_takes_every_info_key() {
+        // No `[source.vcf]` at all: `vcf` stays `None`, which the provider reads as
+        // "materialize every INFO key declared in the VCF header".
+        let src = r##"
+plugin_name = "mastermind"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "/tmp/mastermind.vcf.gz"
+
+[[value_columns]]
+column = "mmid3"
+csq_field = "MM_MMID3"
+type = "Utf8"
+"##;
+        let m: SourceManifest = toml::from_str(src).unwrap();
+        assert_eq!(m.sources[0].provider, ProviderKind::Vcf);
+        assert!(
+            m.sources[0].vcf.is_none(),
+            "an omitted [source.vcf] must leave `vcf` as None (= take all INFO keys)"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_key_inside_vcf_table() {
+        // `info_field` (singular) is the plausible typo for `info_fields`. Without
+        // deny_unknown_fields on VcfParams this parses happily into `info_fields: None`,
+        // i.e. silently indistinguishable from omitting [source.vcf] entirely — the
+        // whole INFO selection would be dropped with no diagnostic.
+        let src = r##"
+plugin_name = "mastermind"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "/tmp/mastermind.vcf.gz"
+  [source.vcf]
+  info_field = ["MMID3", "MMCNT1"]
+
+[[value_columns]]
+column = "mmid3"
+csq_field = "MM_MMID3"
+type = "Utf8"
+"##;
+        let err = toml::from_str::<SourceManifest>(src)
+            .expect_err("unknown key `info_field` inside [source.vcf] must be rejected");
+        assert!(
+            err.to_string().contains("info_field"),
+            "the error must name the offending key, got: {err}"
+        );
+    }
+
+    #[test]
     fn rejects_unknown_key_instead_of_ignoring_it() {
         // `[tier]` is documented in old handoffs but does not exist in SourceManifest.
         // Before deny_unknown_fields this parsed happily and did nothing.

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -65,6 +65,20 @@ fn default_delim() -> String {
     "\t".into()
 }
 
+/// VCF provider parameters.
+///
+/// `info_fields` selects which INFO keys are materialized as columns; omit it to
+/// take every INFO key declared in the VCF header. NOTE: the reader exposes INFO
+/// keys as **bare, case-sensitive column names** (`AF`, `ALLELE_ID`) — not
+/// `info_af` as `bio-format-vcf`'s crate docs claim — so `ingest_sql` must
+/// backtick them: ``SELECT `AF` FROM plugin_x_src``.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct VcfParams {
+    #[serde(default)]
+    pub info_fields: Option<Vec<String>>,
+}
+
 /// One raw source file registered as `plugin_<name>_src[_<part>]`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -75,6 +89,8 @@ pub struct SourceSpec {
     pub path: String,
     #[serde(default)]
     pub csv: Option<CsvParams>,
+    #[serde(default)]
+    pub vcf: Option<VcfParams>,
 }
 
 impl SourceSpec {
@@ -216,8 +232,36 @@ type = "Float32"
             provider: ProviderKind::Csv,
             path: "x".into(),
             csv: None,
+            vcf: None,
         };
         assert_eq!(src.table_name("cadd"), "plugin_cadd_src");
+    }
+
+    #[test]
+    fn parses_vcf_source_with_selected_info_fields() {
+        let src = r##"
+plugin_name = "mastermind"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "vcf"
+path = "/tmp/mastermind.vcf.gz"
+  [source.vcf]
+  info_fields = ["MMID3", "MMCNT1"]
+
+[[value_columns]]
+column = "mmid3"
+csq_field = "MM_MMID3"
+type = "Utf8"
+"##;
+        let m: SourceManifest = toml::from_str(src).unwrap();
+        assert_eq!(m.sources[0].provider, ProviderKind::Vcf);
+        let vcf = m.sources[0].vcf.as_ref().expect("[source.vcf] must parse");
+        assert_eq!(
+            vcf.info_fields.as_deref(),
+            Some(["MMID3".to_string(), "MMCNT1".to_string()].as_slice())
+        );
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -8,12 +8,22 @@ use serde::Deserialize;
 
 /// Coordinate basis of the raw source. Drives the build-time `start` shift so
 /// ingested coordinates match the variation cache's 1-based `start`/`end`.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 pub enum CoordinateSystem {
     #[serde(rename = "1-based")]
     OneBased,
     #[serde(rename = "0-based-half-open")]
     ZeroBasedHalfOpen,
+}
+
+impl CoordinateSystem {
+    /// The manifest spelling, for diagnostics.
+    pub const fn as_manifest_str(self) -> &'static str {
+        match self {
+            Self::OneBased => "1-based",
+            Self::ZeroBasedHalfOpen => "0-based-half-open",
+        }
+    }
 }
 
 /// Table provider backing a raw source. `vcf`/`bed` delegate to bio-formats
@@ -26,6 +36,19 @@ pub enum ProviderKind {
     Tsv,
     Parquet,
     Bed,
+}
+
+impl ProviderKind {
+    /// The manifest spelling, for diagnostics.
+    pub const fn as_manifest_str(self) -> &'static str {
+        match self {
+            Self::Vcf => "vcf",
+            Self::Csv => "csv",
+            Self::Tsv => "tsv",
+            Self::Parquet => "parquet",
+            Self::Bed => "bed",
+        }
+    }
 }
 
 /// Arrow value type for a declared column.
@@ -107,6 +130,15 @@ impl SourceSpec {
             None => format!("plugin_{plugin_name}_src"),
         }
     }
+
+    /// How to name this source in a diagnostic: its `part` if it has one, else its
+    /// 1-based position (so an error always points at exactly one `[[source]]`).
+    fn label(&self, index: usize) -> String {
+        match &self.part {
+            Some(p) => format!("[[source]] part = \"{p}\""),
+            None => format!("[[source]] #{}", index + 1),
+        }
+    }
 }
 
 /// A value column produced by `ingest_sql`, mapped to a CSQ output field.
@@ -159,14 +191,76 @@ impl SourceManifest {
 }
 
 impl SourceManifest {
-    /// Parse a source manifest from a TOML file.
+    /// Parse a source manifest from a TOML file, then [`validate`](Self::validate) it.
     pub fn load(path: &std::path::Path) -> Result<Self> {
         let text = std::fs::read_to_string(path).map_err(|e| {
             DataFusionError::Execution(format!("read source manifest '{}': {e}", path.display()))
         })?;
-        toml::from_str(&text).map_err(|e| {
+        let manifest: Self = toml::from_str(&text).map_err(|e| {
             DataFusionError::Execution(format!("parse source manifest '{}': {e}", path.display()))
-        })
+        })?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Reject manifests whose declarations contradict each other. `deny_unknown_fields`
+    /// catches keys that do not exist; this catches keys that exist but do not belong
+    /// together — the ones the build would otherwise accept and silently ignore.
+    ///
+    /// Rules:
+    /// - a `vcf` source requires `coordinate_system = "1-based"`;
+    /// - `[source.csv]` is only valid for `provider = "csv" | "tsv"`;
+    /// - `[source.vcf]` is only valid for `provider = "vcf"`;
+    /// - hence `parquet` (and `bed`) accept neither params block.
+    ///
+    /// Called from [`load`](Self::load) — the file path every real manifest takes —
+    /// and deliberately NOT from `Deserialize`: unit tests across this crate build
+    /// manifests straight from TOML strings via `toml::from_str`, and hooking
+    /// `Deserialize` would force every one of them through validation.
+    pub fn validate(&self) -> Result<()> {
+        let plugin = &self.plugin_name;
+        for (i, spec) in self.sources.iter().enumerate() {
+            let src = spec.label(i);
+            let provider = spec.provider.as_manifest_str();
+
+            // provider.rs registers the VCF reader with coordinate_system_zero_based =
+            // false, because VCF POS is 1-based. If the manifest nonetheless claims
+            // 0-based, the builder believes the manifest and shifts every start by +1
+            // (normalize.rs). The build then succeeds, rows > 0, the cache manifest looks
+            // healthy — and every runtime key misses, so the plugin annotates nothing.
+            if spec.provider == ProviderKind::Vcf
+                && self.coordinate_system != CoordinateSystem::OneBased
+            {
+                return Err(DataFusionError::Execution(format!(
+                    "plugin '{plugin}': {src} declares provider = \"vcf\", which requires \
+                     coordinate_system = \"1-based\" (VCF POS is 1-based), but the manifest \
+                     declares coordinate_system = \"{}\". The build would shift every start \
+                     by +1, and the plugin would silently annotate nothing.",
+                    self.coordinate_system.as_manifest_str()
+                )));
+            }
+
+            // A params block that does not match its provider is read by nobody: the
+            // provider factory reaches for `spec.csv` only for csv/tsv and `spec.vcf`
+            // only for vcf. Declaring the other one is always a mistake, and silently
+            // dropping it costs (e.g.) the whole `info_fields` INFO selection.
+            if spec.csv.is_some() && !matches!(spec.provider, ProviderKind::Csv | ProviderKind::Tsv)
+            {
+                return Err(DataFusionError::Execution(format!(
+                    "plugin '{plugin}': {src} declares provider = \"{provider}\" with a \
+                     [source.csv] block. [source.csv] is only valid for provider = \"csv\" \
+                     or \"tsv\"; here it would be silently ignored."
+                )));
+            }
+            if spec.vcf.is_some() && spec.provider != ProviderKind::Vcf {
+                return Err(DataFusionError::Execution(format!(
+                    "plugin '{plugin}': {src} declares provider = \"{provider}\" with a \
+                     [source.vcf] block. [source.vcf] (e.g. info_fields) is only valid for \
+                     provider = \"vcf\"; here it would be silently ignored."
+                )));
+            }
+        }
+        Ok(())
     }
 
     /// The ingest view name: `plugin_<name>_ingest`.
@@ -322,6 +416,183 @@ type = "Utf8"
         assert!(
             err.to_string().contains("info_field"),
             "the error must name the offending key, got: {err}"
+        );
+    }
+
+    /// `validate()` runs on the file path, so these go through a real temp file.
+    fn load_str(body: &str) -> Result<SourceManifest> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("x.source.toml");
+        std::fs::write(&path, body).unwrap();
+        SourceManifest::load(&path)
+    }
+
+    /// A manifest with one `[[source]]` of the given provider, coordinate system and
+    /// optional params block.
+    fn manifest_with(provider: &str, coord: &str, params: &str) -> String {
+        format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "{coord}"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "{provider}"
+path = "/tmp/x"
+{params}
+
+[[value_columns]]
+column = "s"
+csq_field = "S"
+type = "Float32"
+"##
+        )
+    }
+
+    // provider.rs hard-wires the VCF reader to `coordinate_system_zero_based = false`
+    // because VCF POS is 1-based. Nothing stopped a manifest from ALSO declaring
+    // `0-based-half-open`, in which case the builder trusts the manifest and shifts
+    // every start by +1 (normalize.rs). The build then succeeds with rows > 0 and a
+    // healthy-looking manifest, while every key misses and the plugin annotates
+    // nothing. Total, silent failure — so it must be rejected at load.
+    #[test]
+    fn vcf_source_with_zero_based_coordinates_is_rejected() {
+        let err = load_str(&manifest_with("vcf", "0-based-half-open", ""))
+            .expect_err("vcf + 0-based-half-open must not load");
+        let msg = err.to_string();
+        assert!(msg.contains("demo"), "must name the plugin: {msg}");
+        assert!(msg.contains("vcf"), "must name the provider: {msg}");
+        assert!(
+            msg.contains("0-based-half-open"),
+            "must name the offending value: {msg}"
+        );
+        assert!(msg.contains("1-based"), "must say what is required: {msg}");
+    }
+
+    #[test]
+    fn vcf_source_with_one_based_coordinates_loads() {
+        let m = load_str(&manifest_with("vcf", "1-based", "")).expect("vcf + 1-based is valid");
+        assert_eq!(m.sources[0].provider, ProviderKind::Vcf);
+    }
+
+    // A [source.csv] block under provider = "vcf" parses fine and is then silently
+    // discarded by the provider factory. Say so instead.
+    #[test]
+    fn csv_params_on_a_vcf_source_are_rejected() {
+        let err = load_str(&manifest_with(
+            "vcf",
+            "1-based",
+            "  [source.csv]\n  delimiter = \"\\t\"",
+        ))
+        .expect_err("[source.csv] under provider = \"vcf\" must not load");
+        let msg = err.to_string();
+        assert!(msg.contains("[source.csv]"), "must name the block: {msg}");
+        assert!(msg.contains("vcf"), "must name the provider: {msg}");
+    }
+
+    // The mirror: `[source.vcf] info_fields = [...]` under provider = "csv" silently
+    // drops the INFO selection.
+    #[test]
+    fn vcf_params_on_a_csv_source_are_rejected() {
+        let err = load_str(&manifest_with(
+            "csv",
+            "1-based",
+            "  [source.vcf]\n  info_fields = [\"AF\"]",
+        ))
+        .expect_err("[source.vcf] under provider = \"csv\" must not load");
+        let msg = err.to_string();
+        assert!(msg.contains("[source.vcf]"), "must name the block: {msg}");
+        assert!(msg.contains("csv"), "must name the provider: {msg}");
+    }
+
+    #[test]
+    fn parquet_source_accepts_neither_params_block() {
+        let csv_err = load_str(&manifest_with(
+            "parquet",
+            "1-based",
+            "  [source.csv]\n  delimiter = \"\\t\"",
+        ))
+        .expect_err("parquet + [source.csv] must not load");
+        assert!(csv_err.to_string().contains("[source.csv]"), "{csv_err}");
+
+        let vcf_err = load_str(&manifest_with(
+            "parquet",
+            "1-based",
+            "  [source.vcf]\n  info_fields = [\"AF\"]",
+        ))
+        .expect_err("parquet + [source.vcf] must not load");
+        assert!(vcf_err.to_string().contains("[source.vcf]"), "{vcf_err}");
+
+        load_str(&manifest_with("parquet", "1-based", "")).expect("bare parquet source is valid");
+    }
+
+    // With several sources, a diagnostic that does not say WHICH one is nearly
+    // useless — name the offending `part`.
+    #[test]
+    fn validation_error_names_the_offending_part() {
+        let src = r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+part = "snv"
+provider = "csv"
+path = "/tmp/snv.tsv"
+  [source.csv]
+  delimiter = "\t"
+
+[[source]]
+part = "sites"
+provider = "csv"
+path = "/tmp/sites.vcf"
+  [source.vcf]
+  info_fields = ["AF"]
+
+[[value_columns]]
+column = "s"
+csq_field = "S"
+type = "Float32"
+"##;
+        let err = load_str(src).expect_err("the second source is misconfigured");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("sites"),
+            "must name the offending part, not just the plugin: {msg}"
+        );
+    }
+
+    // The shape of the real AlphaMissense manifest: tsv + [source.csv] + 1-based.
+    // It must keep loading.
+    #[test]
+    fn tsv_source_with_csv_params_stays_valid() {
+        let m = load_str(&manifest_with(
+            "tsv",
+            "1-based",
+            "  [source.csv]\n  delimiter = \"\\t\"\n  compression = \"gzip\"",
+        ))
+        .expect("tsv + [source.csv] + 1-based is the AlphaMissense shape and must stay valid");
+        assert_eq!(m.sources[0].provider, ProviderKind::Tsv);
+        assert!(m.sources[0].csv.is_some());
+    }
+
+    // A csv/tsv source may legitimately be 0-based; only `vcf` is pinned to 1-based.
+    #[test]
+    fn zero_based_is_still_allowed_for_non_vcf_providers() {
+        let m = load_str(&manifest_with("csv", "0-based-half-open", ""))
+            .expect("a 0-based csv source is legitimate (the builder shifts it)");
+        assert_eq!(m.coordinate_system, CoordinateSystem::ZeroBasedHalfOpen);
+    }
+
+    // validate() hangs off load(), NOT Deserialize: the tests above and elsewhere
+    // build manifests straight from TOML strings, and must keep working.
+    #[test]
+    fn toml_from_str_does_not_validate() {
+        let m: SourceManifest =
+            toml::from_str(&manifest_with("vcf", "0-based-half-open", "")).unwrap();
+        assert!(
+            m.validate().is_err(),
+            "the same manifest must fail an explicit validate()"
         );
     }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/test_fixtures.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/test_fixtures.rs
@@ -1,0 +1,52 @@
+//! Test-only fixture builders shared by the plugin-cache build tests: a gzipped
+//! raw source and a minimal variation shard to join against.
+
+use std::io::Write;
+use std::path::Path;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Int8Array, StringArray, UInt32Array};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+
+/// Write `body` to `path` as gzip (the compression the CSV/TSV provider expects).
+pub fn write_gz(path: &Path, body: &str) {
+    let f = std::fs::File::create(path).unwrap();
+    let mut enc = flate2::write::GzEncoder::new(f, flate2::Compression::default());
+    enc.write_all(body.as_bytes()).unwrap();
+    enc.finish().unwrap();
+}
+
+/// Write a minimal `variation/<chrom>.parquet` shard: the columns the plugin build
+/// joins against (`chrom`, `start`, `allele_string`) plus the inherited `tier`.
+pub fn write_variation(path: &Path, rows: &[(&str, u32, &str, i8)]) {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("chrom", DataType::Utf8, false),
+        Field::new("start", DataType::UInt32, false),
+        Field::new("allele_string", DataType::Utf8, false),
+        Field::new("tier", DataType::Int8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(StringArray::from(
+                rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+            )),
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                rows.iter().map(|r| r.2).collect::<Vec<_>>(),
+            )),
+            Arc::new(Int8Array::from(
+                rows.iter().map(|r| r.3).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .unwrap();
+    let file = std::fs::File::create(path).unwrap();
+    let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+    w.write(&batch).unwrap();
+    w.close().unwrap();
+}

--- a/datafusion/bio-function-vep/src/plugin_cache/test_fixtures.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/test_fixtures.rs
@@ -18,6 +18,19 @@ pub fn write_gz(path: &Path, body: &str) {
     enc.finish().unwrap();
 }
 
+/// Write `body` to `path` as **BGZF** — the block-gzip every real `.vcf.gz` uses.
+///
+/// Not interchangeable with [`write_gz`] here: bio-formats' `get_compression_type`
+/// sniffs the first 18 bytes for BGZF's `BC` extra subfield and routes BGZF and plain
+/// GZIP down *different* header readers. A flate2 fixture would silently exercise the
+/// GZIP path and leave the BGZF one — the one production actually takes — untested.
+pub fn write_bgzf(path: &Path, body: &str) {
+    let f = std::fs::File::create(path).unwrap();
+    let mut w = noodles_bgzf::io::Writer::new(f);
+    w.write_all(body.as_bytes()).unwrap();
+    w.finish().unwrap();
+}
+
 /// Write a minimal `variation/<chrom>.parquet` shard: the columns the plugin build
 /// joins against (`chrom`, `start`, `allele_string`) plus the inherited `tier`.
 pub fn write_variation(path: &Path, rows: &[(&str, u32, &str, i8)]) {

--- a/docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md
+++ b/docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md
@@ -217,8 +217,8 @@ runtime from a named per-transcript **engine attribute**.
 
 ```toml
 [[match_column]]
-column      = "protein_variant"     # produced by ingest_sql, stored in the key
-engine_attr = "amino_acid_change"   # runtime value per transcript: {refAA}{protpos}{altAA}
+column   = "protein_variant"                   # produced by ingest_sql, stored in the key
+template = "{ref_aa}{Protein_position}{alt_aa}"  # built per transcript from engine attributes
 ```
 
 - **Cache key** becomes `(chrom, start, allele_string, <match columns…>)`; the
@@ -414,8 +414,28 @@ coordinate system, value→CSQ mapping, and tier policy. The cache builder consu
 it end-to-end — **no per-plugin Rust for the common case**.
 
 ```toml
+# NOTE: every top-level scalar key (plugin_name, coordinate_system, ingest_sql) MUST
+# precede the first [[source]] header. TOML absorbs a scalar key that follows a table
+# header INTO that table, so a trailing `ingest_sql` parses as `source.ingest_sql` and
+# is rejected as an unknown field.
 plugin_name       = "cadd"
 coordinate_system = "1-based"          # or "0-based-half-open"; drives the start shift (§3.3)
+
+# The ingest view SELECT (§3.1). Maps raw cols → shared key cols + values, in the
+# source's own contig-style/coordinate-basis; the builder applies canonical_contig
+# + the coordinate shift as a shared wrapper (§3.3), so this SQL stays focused on
+# column mapping (INFO parsing, split_part, unions, unnest for multi-allelic, …).
+ingest_sql = """
+SELECT chrom, CAST(pos AS INTEGER) AS start, CAST(pos AS INTEGER) AS end,
+       concat(ref, '/', alt) AS allele_string,
+       CAST(rawscore AS FLOAT) AS raw_score, CAST(phred AS FLOAT) AS phred_score
+FROM plugin_cadd_src_snv
+UNION ALL
+SELECT chrom, CAST(pos AS INTEGER) AS start, CAST(pos AS INTEGER) AS end,
+       concat(ref, '/', alt) AS allele_string,
+       CAST(rawscore AS FLOAT) AS raw_score, CAST(phred AS FLOAT) AS phred_score
+FROM plugin_cadd_src_indel
+"""
 
 # One or more raw sources → registered as plugin_<name>_src[_<part>] (§3.1).
 [[source]]
@@ -441,42 +461,51 @@ path     = "…/whole_genome_SNVs.tsv.gz"
 part = "indel"
 provider = "csv"
 path = "…/InDels.tsv.gz"
-  # …same csv params + schema…
-
-# The ingest view SELECT (§3.1). Maps raw cols → shared key cols + values, in the
-# source's own contig-style/coordinate-basis; the builder applies canonical_contig
-# + the coordinate shift as a shared wrapper (§3.3), so this SQL stays focused on
-# column mapping (INFO parsing, split_part, unions, unnest for multi-allelic, …).
-ingest_sql = """
-SELECT chrom, CAST(pos AS INTEGER) AS start, CAST(pos AS INTEGER) AS end,
-       concat(ref, '/', alt) AS allele_string,
-       CAST(rawscore AS FLOAT) AS raw_score, CAST(phred AS FLOAT) AS phred_score
-FROM plugin_cadd_src_snv
-UNION ALL
-SELECT chrom, CAST(pos AS INTEGER) AS start, CAST(pos AS INTEGER) AS end,
-       concat(ref, '/', alt) AS allele_string,
-       CAST(rawscore AS FLOAT) AS raw_score, CAST(phred AS FLOAT) AS phred_score
-FROM plugin_cadd_src_indel
-"""
+  [source.csv]
+  # …same csv params + schema as the snv source above…
+  delimiter   = "\t"
+  has_header  = false
+  comment     = "#"
+  compression = "gzip"
+  schema = [
+    { name = "chrom", type = "Utf8" },
+    { name = "pos",   type = "Utf8" },
+    { name = "ref",   type = "Utf8" },
+    { name = "alt",   type = "Utf8" },
+    { name = "rawscore", type = "Utf8" },
+    { name = "phred",    type = "Utf8" },
+  ]
 
 [[value_columns]]
-column = "raw_score";   csq_field = "CADD_RAW";   type = "Float32"
-[[value_columns]]
-column = "phred_score"; csq_field = "CADD_PHRED"; type = "Float32"
+column    = "raw_score"
+csq_field = "CADD_RAW"
+type      = "Float32"
 
-[tier]
-threshold = 0.01
-unmatched = "cold"
+[[value_columns]]
+column    = "phred_score"
+csq_field = "CADD_PHRED"
+type      = "Float32"
 ```
+
+> **No `[tier]` block.** Tiering is *inherited from the variation cache* at build time
+> (the builder LEFT-joins the variation shard and takes its warm/cold `tier` — see
+> `plugin_cache::join`), so a plugin never declares its own threshold. `SourceManifest`
+> has no `tier` field and sets `deny_unknown_fields`: a stray `[tier]` block is a hard
+> parse error, not a no-op.
 
 **Provider factory.** `provider` names map to a constructor via a small factory:
 
 | `provider` | Backed by | Params (`[source.<provider>]`) |
 |---|---|---|
-| `vcf` | bio-formats `VcfTableProvider` (sibling crate) | INFO fields, etc. |
+| `vcf` | bio-formats `VcfTableProvider` (sibling crate) | `info_fields` (INFO keys to materialize) |
 | `csv` / `tsv` | builtin `ctx.register_csv` + `CsvReadOptions` | `delimiter`, `has_header`, `comment`, `compression`, `schema` |
 | `parquet` | builtin `ctx.register_parquet` | — |
-| `bed` | bio-formats BED provider (sibling crate) | — |
+| `bed` | **not wired yet** — `ProviderKind::Bed` returns `NotImplemented` (no plugin needs it; wire the bio-formats BED provider the way `vcf` is wired when one does) | — |
+
+A params block must match its provider: `[source.csv]` is only valid for `csv`/`tsv`
+and `[source.vcf]` only for `vcf`, so `parquet` and `bed` accept neither. A `vcf`
+source additionally requires `coordinate_system = "1-based"`. `SourceManifest::validate`
+enforces all of this at load time rather than silently ignoring the mismatch.
 
 Bio-formats providers delegate to the sibling crate (which owns those deps);
 builtin providers are registered directly by this repo's build code. The factory


### PR DESCRIPTION
Plan A of the VEP plugin port factory. Spec + plan: #194.

**855 tests pass, clippy `-D warnings` clean, `cargo fmt --check` clean.**

## What this delivers

**1. `provider = "vcf"` works.** It previously passed manifest validation and then exploded at *build* time with `NotImplemented` — the worst possible ordering. `datafusion-bio-format-vcf` was already a dependency, so this was wiring, not implementation. Unblocks the VCF-sourced plugins (Mastermind, gnomADMt, EVE, Geno2MP, SubsetVCF) that the feasibility analysis had filed under "manifest only".

**2. A wrong manifest now fails loudly.** That is the actual point of the branch. Four things used to fail *silently*:

| Was | Now |
|---|---|
| Unknown manifest keys silently ignored — including a `[tier]` block our own test fixture carried, which had been swallowed for months | `deny_unknown_fields` on every manifest struct |
| `--overwrite` was literally `let _ = self.overwrite;` | Honoured by the builder **and parsed by the CLI** (see below) |
| `--source-path` reached only the first source, so multi-part manifests kept stale paths | Applies to all sources; bare form is an error when ambiguous, `<part>=<path>` targets one |
| `--chrom` read only its first occurrence, silently building less than asked | Repeatable |

Plus a new class of validation the VCF wiring made necessary: a manifest whose `provider` contradicts its own settings is rejected at `load()` — a `vcf` source declaring `0-based-half-open`, or a `[source.csv]` block under `provider = "vcf"`, and so on.

## Two things worth knowing (both found by review, both would have burned the first manifest author)

- **The VCF reader has no `pos` column.** Core schema is `chrom, start, end, id, ref, alt, qual, filter` + bare, case-sensitive INFO keys (`AF`, not `info_af` — the crate's own docs are wrong). `ingest_sql` must select `start`/`end` and backtick INFO keys. Now documented on `VcfParams`, which is where an author actually looks.
- **`alt` is pipe-joined for multi-allelic records** (`G|T`). The natural `concat(ref,'/',alt)` therefore yields `A/G|T`, which can never match the probe key — the rows build clean and are dead forever. Documented + pinned by a characterization test. Enforcing the split belongs to the multi-ALT engine work, which is deliberately not in this branch.

## Review caught a blocker in my own plan

The first pass fixed `--overwrite` in `PluginCacheBuilder`, tested it, and went green — while the CLI never parsed the flag. From a user's seat nothing had changed, and the docs now *claimed* it worked: the exact silent-no-op class this branch exists to kill, reintroduced one layer up. It escaped because the argv handling lived in an example with zero tests. Fixed, and the parsing is now a unit-tested `plugin_cache::cli` module so it can't happen again.

Same pass found the design spec's canonical CADD manifest had **three** parse-blocking defects (not the one I'd claimed) — including `ingest_sql` placed after `[[source]]`, the very TOML-ordering trap the document warns about. The examples now actually parse; verified by feeding them to the real parser.

## Deliberately NOT here

BED stays `NotImplemented` — no plugin needs it and it isn't a dependency; the error now says so. No multi-ALT engine work. No `[workspace.dependencies]` dep hoisting (recorded as follow-up: the `bio-format-core`/`-vcf` tag pin is enforced only by a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JaQJ1j5wfA54dRxYmEtQs