### PR TITLE
Plugin-cache: streaming shard write, assume_unique, VCF provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-bio-format-bed"
+version = "1.8.8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#1623f1dc6b21b9b49234ea533ca4da0ee832d942"
+dependencies = [
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "datafusion",
+ "datafusion-bio-format-core 1.8.8",
+ "datafusion-execution",
+ "env_logger",
+ "futures",
+ "futures-util",
+ "log",
+ "noodles-bed",
+ "noodles-bgzf 0.36.0",
+ "opendal",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "datafusion-bio-format-core"
 version = "1.8.0"
 source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.0#7f7fdcd6e4c3f818d08fa42a60866f57a76daa08"
@@ -1247,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#1623f1dc6b21b9b49234ea533ca4da0ee832d942"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1269,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#1623f1dc6b21b9b49234ea533ca4da0ee832d942"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1287,7 +1310,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#1623f1dc6b21b9b49234ea533ca4da0ee832d942"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1366,6 +1389,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
+ "datafusion-bio-format-bed",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
  "datafusion-bio-function-ranges",
@@ -3412,6 +3436,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "noodles-bed"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b1628807aa4c3068c91c84592389b38304825dcbe0f9b0bb0f9382c94f11fc7"
+dependencies = [
+ "bstr",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf 0.41.0",
+ "noodles-core 0.17.0",
+ "noodles-csi 0.49.0",
+ "noodles-tabix 0.55.0",
+]
+
+[[package]]
 name = "noodles-bgzf"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3426,6 +3465,18 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07e5d75eb7e00c1fe140acef39dea0aea2f48a05ab698a16c6797dd0c0db7e4"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
 ]
 
 [[package]]
@@ -3479,6 +3530,15 @@ dependencies = [
 
 [[package]]
 name = "noodles-core"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce89752158657dd1d7195061e9d9190e2d3bb594eb71086762163d4a430b0b4b"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "noodles-core"
 version = "0.18.0"
 source = "git+https://github.com/biodatageeks/noodles.git?rev=086061d2ff5385f63a5bf0c500ebebb84a153af1#086061d2ff5385f63a5bf0c500ebebb84a153af1"
 dependencies = [
@@ -3499,6 +3559,20 @@ version = "0.18.0"
 source = "git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db#e2b53501afd9d327735355db68dfb33d3e6ce9db"
 dependencies = [
  "bstr",
+]
+
+[[package]]
+name = "noodles-csi"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c291585d38573d80921a9b57b47f1da57fdf24969ed8fe0b0f79acc1cce18a42"
+dependencies = [
+ "bit-vec",
+ "bstr",
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf 0.41.0",
+ "noodles-core 0.17.0",
 ]
 
 [[package]]
@@ -3563,6 +3637,19 @@ dependencies = [
  "noodles-bgzf 0.42.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
  "noodles-core 0.18.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
  "noodles-csi 0.50.0 (git+https://github.com/biodatageeks/noodles.git?rev=e2b53501afd9d327735355db68dfb33d3e6ce9db)",
+]
+
+[[package]]
+name = "noodles-tabix"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "461b6173ee2ec38d7ddbce206c31c83d8c7b61d6a5db2b2c4ff2ac74653ac751"
+dependencies = [
+ "byteorder",
+ "indexmap",
+ "noodles-bgzf 0.41.0",
+ "noodles-core 0.17.0",
+ "noodles-csi 0.49.0",
 ]
 
 [[package]]

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -31,6 +31,7 @@ noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
 datafusion-bio-format-vcf ={ git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8", optional = true }
 indicatif = "0.18.4"
 

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -6236,6 +6236,7 @@ impl AnnotateProvider {
                             let ns = crate::plugin_cache::template::build_attr_namespace(
                                 terms_str,
                                 gene,
+                                symbol,
                                 feature_type,
                                 feature,
                                 biotype,

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -258,6 +258,7 @@ pub async fn build_plugin_chrom(
             .downcast_ref::<Int8Array>()
             .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
             .clone();
+        let mut kept_this_batch = 0usize;
         for keep in [0i8, 1i8] {
             let mask: BooleanArray = (0..reordered.num_rows())
                 .map(|i| Some(tier_col.value(i) == keep))
@@ -267,6 +268,7 @@ pub async fn build_plugin_chrom(
             if filtered.num_rows() == 0 {
                 continue;
             }
+            kept_this_batch += filtered.num_rows();
             if keep == 0 {
                 warm_last_start =
                     assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
@@ -278,6 +280,19 @@ pub async fn build_plugin_chrom(
                 cold += filtered.num_rows();
                 cold_writer.write(&filtered)?;
             }
+        }
+        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
+        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
+        // would silently drop a row with any other value rather than error,
+        // so check explicitly instead of trusting that invariant blindly.
+        if kept_this_batch != reordered.num_rows() {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{}/{chrom}]: {} row(s) had a tier value outside {{0,1}} and were \
+                 dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
+                 impossible; investigate before trusting this shard",
+                src.plugin_name,
+                reordered.num_rows() - kept_this_batch
+            )));
         }
     }
     warm_writer.finish()?;
@@ -308,7 +323,16 @@ pub async fn build_plugin_chrom(
     // start-sorted by construction (see above), so this is a plain streaming
     // batch-by-batch copy into the final writer (which carries the point-lookup
     // page-index properties) — no sort, O(one batch) memory.
-    let mut writer = PluginShardWriter::create(&shard_path, Arc::clone(&out_schema))?;
+    //
+    // Written to a `.merge.tmp` path and renamed into place only once fully
+    // flushed, rather than directly to `shard_path`: a crash mid-merge already
+    // fails loudly on next open (a parquet file with no footer, not a silent
+    // half-written one), but writing in place still leaves a corrupt file
+    // *at the path the runtime looks up* until the next successful rebuild
+    // overwrites it -- a rename is atomic on the same filesystem, so a crash
+    // here instead leaves either the previous good shard (if any) or nothing.
+    let merge_tmp = plugin_dir.join(format!("{file_name}.merge.tmp"));
+    let mut writer = PluginShardWriter::create(&merge_tmp, Arc::clone(&out_schema))?;
     for tmp in [&warm_tmp, &cold_tmp] {
         let file = std::fs::File::open(tmp)
             .map_err(|e| DataFusionError::Execution(format!("open temp {}: {e}", tmp.display())))?;
@@ -325,7 +349,16 @@ pub async fn build_plugin_chrom(
     }
     let rows = writer.finish()?;
     if rows == 0 {
+        let _ = std::fs::remove_file(&merge_tmp);
         let _ = std::fs::remove_file(&shard_path);
+    } else {
+        std::fs::rename(&merge_tmp, &shard_path).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "rename {} -> {}: {e}",
+                merge_tmp.display(),
+                shard_path.display()
+            ))
+        })?;
     }
     info!(
         "plugin_cache[{}/{chrom}]: done, rows={rows}, {:.1}s total",

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -13,6 +13,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::{StreamExt, TryStreamExt};
+use log::info;
+use std::time::Instant;
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
@@ -49,6 +51,11 @@ pub async fn build_plugin_chrom(
     output_cache_root: &Path,
     chrom: &str,
 ) -> Result<ChromEntry> {
+    // Coarse-grained stage timing at `info` level — cheap (a handful of
+    // `Instant::now()` calls) and the only thing that would have turned CADD
+    // chr6's multi-hour "is it stuck?" investigation (no visibility into
+    // which stage was running) into a 30-second log check.
+    let t_start = Instant::now();
     // Read context: single partition ONLY for the source scan → normalize →
     // dedup leg, so the CSV scan yields rows in source-file order (a
     // multi-partition scan reads byte ranges concurrently and coalescing does not
@@ -126,6 +133,12 @@ pub async fn build_plugin_chrom(
     };
     // The source scan is done — drop the decompressed temp before the join leg.
     drop(src_temps);
+    let read_rows: usize = deduped.iter().map(|b| b.num_rows()).sum();
+    info!(
+        "plugin_cache[{}/{chrom}]: read+normalize+dedup done, {read_rows} rows, {:.1}s elapsed",
+        src.plugin_name,
+        t_start.elapsed().as_secs_f64()
+    );
 
     // Build context: single partition, same reasoning as `read_ctx` above — the
     // streaming write below (see `tiered_stream` consumption) relies on the join
@@ -210,6 +223,11 @@ pub async fn build_plugin_chrom(
     }
     warm_writer.finish()?;
     cold_writer.finish()?;
+    info!(
+        "plugin_cache[{}/{chrom}]: tier-join+streaming-write done, warm={warm} cold={cold}, {:.1}s elapsed",
+        src.plugin_name,
+        t_start.elapsed().as_secs_f64()
+    );
 
     // Empty chrom → no shard (matches variation builder cleanup). Remove any
     // stale shard from a previous build so the manifest (rows: 0) matches disk
@@ -250,6 +268,11 @@ pub async fn build_plugin_chrom(
     if rows == 0 {
         let _ = std::fs::remove_file(&shard_path);
     }
+    info!(
+        "plugin_cache[{}/{chrom}]: done, rows={rows}, {:.1}s total",
+        src.plugin_name,
+        t_start.elapsed().as_secs_f64()
+    );
     Ok(ChromEntry {
         chrom: canonical_chrom_label(chrom),
         file: file_name,

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -12,13 +12,13 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use log::info;
 use std::time::Instant;
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
-use crate::plugin_cache::dedup::dedup_keep_first;
+use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
 use crate::plugin_cache::join::tiered_stream;
 use crate::plugin_cache::normalize::{
     canonical_contig_str, canonical_contig_udf, wrap_normalization,
@@ -167,12 +167,15 @@ pub async fn build_plugin_chrom(
         .execute_stream()
         .await?;
     let norm_schema = norm_stream.schema();
-    // `assume_unique` sources are structurally guaranteed to never repeat a
-    // probe key, so the keep-first pass (a HashSet<String> with one entry per
-    // row — the dominant memory cost on the largest chromosomes) is skipped;
-    // batches are collected as-is.
+    // `assume_unique` sources are claimed to never repeat a probe key, so the
+    // exhaustive keep-first pass (a HashSet<String> with one entry per row —
+    // the dominant memory cost on the largest chromosomes) is skipped in
+    // favor of a bounded-memory sampled check that still catches a violated
+    // claim instead of trusting it blindly (see `check_assume_unique_sample`
+    // docs for why this can't be exhaustive without reintroducing the same
+    // memory cost the flag exists to avoid).
     let deduped = if src.assume_unique {
-        norm_stream.try_collect::<Vec<_>>().await?
+        check_assume_unique_sample(norm_stream, &match_cols).await?
     } else {
         dedup_keep_first(norm_stream, &match_cols).await?
     };

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -2,18 +2,22 @@
 //! normalization wrapper → variation-frequency join/tier → two-pass tiered
 //! shard write → cache-manifest chrom entry.
 //!
-//! Known tradeoff (noted during PR #196 review): the tiered join is only
-//! guaranteed to stream in position-ascending order per tier when the
-//! optimizer keeps the plugin on the join's probe side, which needs the
-//! plugin's own row count to be large relative to the chromosome's variation
-//! shard (true for whole-genome plugins like CADD/SpliceAI). A sparse or
-//! low-coverage-chromosome plugin can end up on the *build* side instead,
-//! whose order a hash join doesn't preserve -- `assert_start_monotonic`
-//! below then hard-fails that build rather than silently writing a
-//! wrong-order shard. There is currently no re-sort fallback for that case
-//! (see the review thread on PR #196 for the tradeoff analysis); a future
-//! sparse-plugin manifest that hits this needs one added here, not just a
-//! bigger `assume_unique`-style flag.
+//! The tiered join (`p LEFT JOIN v`) plans as `HashJoinExec` in `CollectLeft`
+//! mode: the plugin (`p`, the LEFT side) is collected into a hash table, and
+//! the variation probe (`v`) streams as the probe side. A row that MATCHES
+//! comes out in the probe's own scan order, which is fine -- a real variation
+//! shard is itself position-sorted. A row that MISSES gets appended
+//! afterward by iterating the plugin's own original row order. So this holds
+//! in position-ascending order for any plugin whose input already arrives
+//! globally sorted (true whenever the source is a single position-sorted
+//! file, or a `bcftools`/`tabix` query over one) -- but a source built by
+//! concatenating multiple files without a merge sort (the original CADD
+//! SNV+indel bug) surfaces here as soon as any of its rows miss the variation
+//! probe. `assert_start_monotonic` catches a real violation as it writes;
+//! `build_plugin_chrom` responds by re-running the join once with an explicit
+//! `ORDER BY` (see `join::tiered_stream_sorted`) rather than hard-failing the
+//! build. The sort only runs on the retry, so a normally-sorted source (every
+//! plugin shipped so far) pays nothing extra.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -24,6 +28,9 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
+use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::StreamExt;
 use log::info;
@@ -32,7 +39,7 @@ use std::time::Instant;
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
 use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
-use crate::plugin_cache::join::tiered_stream;
+use crate::plugin_cache::join::{tiered_stream, tiered_stream_sorted};
 use crate::plugin_cache::normalize::{
     canonical_contig_str, canonical_contig_udf, wrap_normalization,
 };
@@ -61,15 +68,15 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
 /// final `start` on success.
 ///
 /// The streaming shard write below relies on the tiered join emitting rows in
-/// position-ascending order per tier; that holds by construction for the
-/// query shapes exercised so far (see the comment above the call site), but
-/// `HashJoinExec`'s build/probe side can flip based on table-size statistics
-/// for other plugin/variation size ratios, and a flipped build side does not
-/// preserve row order. Rather than trust that silently, check it: a real
-/// violation aborts the build immediately (no shard is written) instead of
-/// producing a page directory whose binary-search lookup can silently miss
-/// rows that are actually present (`PageDir::resolve_ranges` assumes a
-/// genuinely sorted run).
+/// position-ascending order per tier; that holds whenever the plugin's own
+/// input already arrives globally sorted (see the module doc for why), but a
+/// source that isn't -- multiple files concatenated without a merge sort,
+/// say -- can surface a genuine regression here. Rather than trust the
+/// assumption silently, check it: a real violation aborts the fast write
+/// immediately (no shard is written) instead of producing a page directory
+/// whose binary-search lookup can silently miss rows that are actually
+/// present (`PageDir::resolve_ranges` assumes a genuinely sorted run);
+/// `build_plugin_chrom` catches this and retries with an explicit sort.
 fn assert_start_monotonic(
     batch: &RecordBatch,
     start_idx: usize,
@@ -90,15 +97,108 @@ fn assert_start_monotonic(
         {
             return Err(DataFusionError::Execution(format!(
                 "plugin_cache[{chrom}]: tier {tier} shard write is not position-ascending \
-                 (start {v} follows {p}) -- the tier join did not preserve row order for \
-                 this plugin/variation size ratio; the on-disk point-lookup directory \
-                 requires a sorted shard, so refusing to write a corrupt one. This needs \
-                 a real re-sort of the tier's output, not just a bigger error message."
+                 (start {v} follows {p}) -- the tier join did not preserve row order; the \
+                 on-disk point-lookup directory requires a sorted shard, so refusing to \
+                 write a corrupt one from the fast path. The caller retries with an \
+                 explicit sort instead of trusting this shard."
             )));
         }
         prev = Some(v);
     }
     Ok(prev)
+}
+
+/// `assert_start_monotonic` reports a genuine reorder with this exact phrase;
+/// matching on it (rather than introducing a dedicated error variant threaded
+/// through every `Result<_, DataFusionError>` in this module) is enough to
+/// distinguish "the join lost row order, retry with a sort" from any other
+/// failure in the write pass (I/O, cast errors, tier-value corruption), which
+/// must still propagate as-is rather than trigger a pointless retry.
+fn is_order_violation(e: &DataFusionError) -> bool {
+    e.to_string().contains("is not position-ascending")
+}
+
+/// Memory budget for the sorted retry's `FairSpillPool`: generous for the
+/// sparse plugins this path exists for (ClinVar-scale, low hundreds of
+/// thousands of rows per chromosome), but bounded so a plugin that turns out
+/// far larger than expected spills to disk instead of raising the OOM risk
+/// the streaming write (the common/fast path) exists to avoid.
+const RETRY_SORT_MEMORY_LIMIT_BYTES: usize = 2 * 1024 * 1024 * 1024;
+
+/// Consume `stream`, split rows by `tier` into warm (0) / cold (1), and write
+/// each run through its own `PluginShardWriter`. Checks `start` is
+/// position-ascending within each tier as it writes (`assert_start_monotonic`)
+/// and returns that error immediately without finishing the writers -- the
+/// caller decides whether to retry with a sorted stream or propagate.
+///
+/// `PluginShardWriter::create` truncates its target path, so calling this
+/// twice at the same `warm_path`/`cold_path` (fast attempt, then sorted retry)
+/// is safe -- the first attempt's partial output is simply overwritten.
+async fn write_tiered_shard(
+    mut stream: SendableRecordBatchStream,
+    out_schema: &SchemaRef,
+    warm_path: &Path,
+    cold_path: &Path,
+    chrom: &str,
+    plugin_name: &str,
+) -> Result<(usize, usize)> {
+    let mut warm_writer = PluginShardWriter::create(warm_path, Arc::clone(out_schema))?;
+    let mut cold_writer = PluginShardWriter::create(cold_path, Arc::clone(out_schema))?;
+    let (mut warm, mut cold) = (0usize, 0usize);
+    let start_idx = out_schema.index_of("start")?;
+    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
+
+    while let Some(b) = stream.next().await {
+        let batch = b?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let reordered = reproject_cast(&batch, out_schema)?;
+        let tier_col = reordered
+            .column(out_schema.index_of("tier")?)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
+            .clone();
+        let mut kept_this_batch = 0usize;
+        for keep in [0i8, 1i8] {
+            let mask: BooleanArray = (0..reordered.num_rows())
+                .map(|i| Some(tier_col.value(i) == keep))
+                .collect();
+            let filtered = filter_record_batch(&reordered, &mask)
+                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
+            if filtered.num_rows() == 0 {
+                continue;
+            }
+            kept_this_batch += filtered.num_rows();
+            if keep == 0 {
+                warm_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
+                warm += filtered.num_rows();
+                warm_writer.write(&filtered)?;
+            } else {
+                cold_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
+                cold += filtered.num_rows();
+                cold_writer.write(&filtered)?;
+            }
+        }
+        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
+        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
+        // would silently drop a row with any other value rather than error,
+        // so check explicitly instead of trusting that invariant blindly.
+        if kept_this_batch != reordered.num_rows() {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{plugin_name}/{chrom}]: {} row(s) had a tier value outside {{0,1}} \
+                 and were dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
+                 impossible; investigate before trusting this shard",
+                reordered.num_rows() - kept_this_batch
+            )));
+        }
+    }
+    warm_writer.finish()?;
+    cold_writer.finish()?;
+    Ok((warm, cold))
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -213,9 +313,14 @@ pub async fn build_plugin_chrom(
     // build regardless of partition count. The deduped survivors are
     // re-registered here as a MemTable the join consumes in place of the raw
     // normalized view.
+    // Kept for the sorted retry below (see the fast/retry split further down):
+    // cloning a `Vec<RecordBatch>` only clones the `Arc`-backed column data,
+    // not the underlying buffers, so holding a second copy here is cheap
+    // regardless of chromosome size.
+    let deduped_for_retry = deduped.clone();
     let build_ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
-    let mem = MemTable::try_new(norm_schema, vec![deduped])
+    let mem = MemTable::try_new(norm_schema.clone(), vec![deduped])
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
     build_ctx.register_table(&dedup_view, Arc::new(mem))?;
 
@@ -225,6 +330,8 @@ pub async fn build_plugin_chrom(
         .map_err(|e| DataFusionError::Execution(format!("mkdir {}: {e}", plugin_dir.display())))?;
     let file_name = format!("{}.parquet", canonical_chrom_label(chrom));
     let shard_path = plugin_dir.join(&file_name);
+    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
+    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
 
     // Stream the tiered join output straight into two per-tier temp shards
     // (warm run, cold run) instead of collecting the whole chromosome into one
@@ -232,86 +339,64 @@ pub async fn build_plugin_chrom(
     // sorting it in memory. That collect+concat+sort was the dominant remaining
     // memory cost after `assume_unique` removed the dedup HashSet, and still
     // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
-    // peak memory at O(one batch) instead of O(whole chromosome).
-    //
-    // Correctness needs each tier's rows position-ascending on disk
-    // (`PageDir::resolve_ranges`'s binary search assumes a sorted run). That
-    // does NOT follow from `target_partitions=1` alone: `p LEFT JOIN v` plans
-    // as `HashJoinExec`, and the query optimizer picks which side to hash
-    // (`join_type`) based on relative table size -- for a whole-genome plugin
-    // bigger than the variation probe (CADD, SpliceAI: the configs actually
-    // built and shipped so far) it swaps to `join_type=Right` with the plugin
-    // on the probe side, which DOES stream through unreordered; for a plugin
-    // smaller than the probe (a sparse plugin, a small custom subset, a
-    // low-coverage chrom) it can plan `join_type=Left` with the plugin on the
-    // *build* side instead, whose row order a hash join does not preserve.
-    // `assert_start_monotonic` below checks the actual invariant directly
-    // rather than trusting which side the optimizer chose: a real violation
-    // aborts the build loudly instead of silently writing a shard whose
-    // point-lookup can miss rows that are actually present.
-    let mut stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
-
-    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
-    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
-    let mut warm_writer = PluginShardWriter::create(&warm_tmp, Arc::clone(&out_schema))?;
-    let mut cold_writer = PluginShardWriter::create(&cold_tmp, Arc::clone(&out_schema))?;
-    let (mut warm, mut cold) = (0usize, 0usize);
-    let start_idx = out_schema.index_of("start")?;
-    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
-
-    while let Some(b) = stream.next().await {
-        let batch = b?;
-        if batch.num_rows() == 0 {
-            continue;
+    // peak memory at O(one batch) instead of O(whole chromosome) -- this is
+    // the fast path, and it's correct as long as the plugin's own input
+    // already arrives position-ascending (see the module doc for why that's
+    // enough, regardless of the plugin's size relative to the variation
+    // shard). `write_tiered_shard`'s `assert_start_monotonic` check catches it
+    // directly if that assumption doesn't hold, and the fallback below
+    // re-runs the join with an explicit sort instead of failing.
+    let fast_stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
+    let (warm, cold) = match write_tiered_shard(
+        fast_stream,
+        &out_schema,
+        &warm_tmp,
+        &cold_tmp,
+        chrom,
+        &src.plugin_name,
+    )
+    .await
+    {
+        Ok(counts) => counts,
+        Err(e) if is_order_violation(&e) => {
+            // The plugin's input wasn't globally position-ascending by the
+            // time it reached the join (see the module doc), so a miss row
+            // surfaced out of order. Re-run with `ORDER BY` on a session
+            // whose memory pool can spill to disk -- this is the exception,
+            // not the common case the O(1)-memory streaming write above is
+            // optimized for.
+            info!(
+                "plugin_cache[{}/{chrom}]: tier join did not preserve row order \
+                 ({read_rows} plugin rows this chrom) -- retrying with an explicit sort",
+                src.plugin_name
+            );
+            let sort_runtime = RuntimeEnvBuilder::new()
+                .with_memory_pool(Arc::new(FairSpillPool::new(RETRY_SORT_MEMORY_LIMIT_BYTES)))
+                .build_arc()
+                .map_err(|e| DataFusionError::Execution(format!("retry runtime env: {e}")))?;
+            let sort_ctx = SessionContext::new_with_config_rt(
+                SessionConfig::new().with_target_partitions(1),
+                sort_runtime,
+            );
+            let sort_mem = MemTable::try_new(norm_schema, vec![deduped_for_retry])
+                .map_err(|e| DataFusionError::Execution(format!("retry dedup memtable: {e}")))?;
+            sort_ctx.register_table(&dedup_view, Arc::new(sort_mem))?;
+            let sorted_stream =
+                tiered_stream_sorted(&sort_ctx, &dedup_view, variation_shard).await?;
+            write_tiered_shard(
+                sorted_stream,
+                &out_schema,
+                &warm_tmp,
+                &cold_tmp,
+                chrom,
+                &src.plugin_name,
+            )
+            .await?
         }
-        let reordered = reproject_cast(&batch, &out_schema)?;
-        let tier_col = reordered
-            .column(out_schema.index_of("tier")?)
-            .as_any()
-            .downcast_ref::<Int8Array>()
-            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
-            .clone();
-        let mut kept_this_batch = 0usize;
-        for keep in [0i8, 1i8] {
-            let mask: BooleanArray = (0..reordered.num_rows())
-                .map(|i| Some(tier_col.value(i) == keep))
-                .collect();
-            let filtered = filter_record_batch(&reordered, &mask)
-                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
-            if filtered.num_rows() == 0 {
-                continue;
-            }
-            kept_this_batch += filtered.num_rows();
-            if keep == 0 {
-                warm_last_start =
-                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
-                warm += filtered.num_rows();
-                warm_writer.write(&filtered)?;
-            } else {
-                cold_last_start =
-                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
-                cold += filtered.num_rows();
-                cold_writer.write(&filtered)?;
-            }
-        }
-        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
-        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
-        // would silently drop a row with any other value rather than error,
-        // so check explicitly instead of trusting that invariant blindly.
-        if kept_this_batch != reordered.num_rows() {
-            return Err(DataFusionError::Execution(format!(
-                "plugin_cache[{}/{chrom}]: {} row(s) had a tier value outside {{0,1}} and were \
-                 dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
-                 impossible; investigate before trusting this shard",
-                src.plugin_name,
-                reordered.num_rows() - kept_this_batch
-            )));
-        }
-    }
-    warm_writer.finish()?;
-    cold_writer.finish()?;
+        Err(e) => return Err(e),
+    };
     info!(
-        "plugin_cache[{}/{chrom}]: tier-join+streaming-write done, warm={warm} cold={cold}, {:.1}s elapsed",
+        "plugin_cache[{}/{chrom}]: tier-join+write done, warm={warm} cold={cold}, {:.1}s elapsed",
         src.plugin_name,
         t_start.elapsed().as_secs_f64()
     );
@@ -638,6 +723,170 @@ type = "Float32"
         .unwrap();
         let last_seen = assert_start_monotonic(&batch, 0, 0, "1", None).unwrap();
         assert_eq!(last_seen, Some(30));
+    }
+
+    // `write_tiered_shard` must surface a genuine reorder as the same
+    // "not position-ascending" error `assert_start_monotonic` raises directly
+    // (this is what `build_plugin_chrom` pattern-matches on via
+    // `is_order_violation` to decide whether to retry with a sort), and it
+    // must do so without finishing the writers on the failing tier.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_tiered_shard_flags_disordered_input_as_order_violation() {
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("end", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        let make_batch = |starts: &[u32]| {
+            let n = starts.len();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(vec!["1"; n])),
+                    Arc::new(UInt32Array::from(starts.to_vec())),
+                    Arc::new(UInt32Array::from(starts.to_vec())),
+                    Arc::new(StringArray::from(vec!["A/G"; n])),
+                    Arc::new(Int8Array::from(vec![0i8; n])),
+                ],
+            )
+            .unwrap()
+        };
+        // Two batches, both internally sorted, but the second regresses
+        // relative to the first -- exactly what a hash join's build side can
+        // produce (each batch may look locally fine, the cross-batch order is
+        // what breaks).
+        let batches: Vec<Result<RecordBatch>> =
+            vec![Ok(make_batch(&[100, 200])), Ok(make_batch(&[50, 300]))];
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            futures::stream::iter(batches),
+        ));
+        let dir = tempfile::tempdir().unwrap();
+        let warm = dir.path().join("warm.tmp");
+        let cold = dir.path().join("cold.tmp");
+        let err = write_tiered_shard(stream, &schema, &warm, &cold, "1", "demo")
+            .await
+            .unwrap_err();
+        assert!(is_order_violation(&err), "unexpected error: {err}");
+    }
+
+    // C1 regression, end-to-end: `HashJoinExec`'s `CollectLeft` mode collects
+    // the plugin (LEFT of the LEFT JOIN) into a hash table and streams the
+    // variation probe; a MATCHED row's emission order follows the probe's
+    // scan (fine, since a real variation shard is itself position-sorted),
+    // but an UNMATCHED plugin row is appended afterward by iterating the
+    // plugin's own original row order. A plugin whose rows are already
+    // ascending never regresses under this mechanism regardless of its size
+    // relative to the probe -- but a source that isn't globally sorted (two
+    // files concatenated, an upstream ordering bug) surfaces here as soon as
+    // any of its rows miss the variation probe. Confirmed empirically (not
+    // just asserted) via a temporary EXPLAIN probe against this exact
+    // mechanism before writing this test.
+    //
+    // `build_plugin_chrom` must recover from that with a sort, not hard-fail.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sparse_plugin_with_disordered_source_still_builds_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Plugin: 20 rows, DESCENDING -- simulates a source that isn't
+        // globally position-sorted (e.g. two per-chrom files concatenated
+        // without a merge sort, à la the original CADD SNV+indel bug).
+        let mut tsv_body = String::new();
+        for i in (1..=20u32).rev() {
+            tsv_body.push_str(&format!("chr1\t{}\tA\tG\t0.{i}\n", i * 100));
+        }
+        let tsv = dir.path().join("sparse.tsv.gz");
+        write_gz(&tsv, &tsv_body);
+
+        // Variation shard: none of the plugin's positions have an entry, so
+        // every plugin row misses (tier=1/cold) -- cold-row emission order
+        // follows the plugin's own (here: descending) row order, reproducing
+        // a genuine `assert_start_monotonic` violation. The other 5000 rows
+        // are unrelated positions, matching production's scale (chr22's
+        // variation shard vs. ClinVar's row count is a ~157x skew).
+        let mut var_rows: Vec<(&str, u32, String, i8)> = Vec::new();
+        for i in 0..5000u32 {
+            var_rows.push(("1", 10_000_000 + i, "C/T".to_string(), 1i8));
+        }
+        let var_path = dir.path().join("var.parquet");
+        let var_rows_ref: Vec<(&str, u32, &str, i8)> = var_rows
+            .iter()
+            .map(|(c, s, a, t)| (*c, *s, a.as_str(), *t))
+            .collect();
+        write_synthetic_variation(&var_path, &var_rows_ref);
+
+        let toml = format!(
+            r##"
+plugin_name = "sparse"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_sparse_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let entry = build_plugin_chrom(&manifest, "sparse.source.toml", &var_path, &out, "1")
+            .await
+            .unwrap();
+        assert_eq!(entry.rows, 20);
+        assert_eq!(entry.warm, 0);
+        assert_eq!(
+            entry.cold, 20,
+            "all 20 plugin rows miss the variation shard"
+        );
+
+        // The on-disk shard must actually be position-ascending -- this is
+        // the real invariant `PageDir::resolve_ranges` depends on, and the
+        // one thing a passing `entry.rows` count alone can't prove.
+        let shard_path = out.join("plugin").join("sparse").join("chr1.parquet");
+        let file = std::fs::File::open(&shard_path).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut starts = Vec::new();
+        for batch in reader {
+            let batch = batch.unwrap();
+            let col = batch
+                .column(batch.schema().index_of("start").unwrap())
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap()
+                .clone();
+            starts.extend((0..col.len()).map(|i| col.value(i)));
+        }
+        assert_eq!(starts.len(), 20);
+        let mut sorted = starts.clone();
+        sorted.sort_unstable();
+        assert_eq!(starts, sorted, "shard on disk is not position-ascending");
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, Int8Array};
+use datafusion::arrow::array::{Array, BooleanArray, Int8Array, UInt32Array};
 use datafusion::arrow::compute::{cast, filter_record_batch};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -41,6 +41,51 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(Arc::clone(schema), cols)
         .map_err(|e| DataFusionError::Execution(format!("reproject: {e}")))
+}
+
+/// Verify `start` is non-decreasing within `batch` and against `last_seen` (the
+/// previous batch's final `start` for this tier), returning the batch's own
+/// final `start` on success.
+///
+/// The streaming shard write below relies on the tiered join emitting rows in
+/// position-ascending order per tier; that holds by construction for the
+/// query shapes exercised so far (see the comment above the call site), but
+/// `HashJoinExec`'s build/probe side can flip based on table-size statistics
+/// for other plugin/variation size ratios, and a flipped build side does not
+/// preserve row order. Rather than trust that silently, check it: a real
+/// violation aborts the build immediately (no shard is written) instead of
+/// producing a page directory whose binary-search lookup can silently miss
+/// rows that are actually present (`PageDir::resolve_ranges` assumes a
+/// genuinely sorted run).
+fn assert_start_monotonic(
+    batch: &RecordBatch,
+    start_idx: usize,
+    tier: i8,
+    chrom: &str,
+    last_seen: Option<u32>,
+) -> Result<Option<u32>> {
+    let starts = batch
+        .column(start_idx)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .ok_or_else(|| DataFusionError::Execution("start column not UInt32".into()))?;
+    let mut prev = last_seen;
+    for i in 0..starts.len() {
+        let v = starts.value(i);
+        if let Some(p) = prev
+            && v < p
+        {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{chrom}]: tier {tier} shard write is not position-ascending \
+                 (start {v} follows {p}) -- the tier join did not preserve row order for \
+                 this plugin/variation size ratio; the on-disk point-lookup directory \
+                 requires a sorted shard, so refusing to write a corrupt one. This needs \
+                 a real re-sort of the tier's output, not just a bigger error message."
+            )));
+        }
+        prev = Some(v);
+    }
+    Ok(prev)
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -173,16 +218,21 @@ pub async fn build_plugin_chrom(
     // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
     // peak memory at O(one batch) instead of O(whole chromosome).
     //
-    // Correctness relies on the join preserving row order end to end: the
-    // source scan (`read_ctx`, single partition) yields rows in file order,
-    // which for these per-chrom tabix-extracted sources is position-ascending;
-    // dedup (`dedup_keep_first`/`try_collect`) filters within that order without
-    // reordering; and the tier join (`build_ctx`, now also single partition)
-    // streams the probe side through unreordered. A per-batch tier filter
-    // (`filter_record_batch`) never reorders survivors either, so each tier's
-    // rows stay position-ascending both within a batch and across batches —
-    // meeting the on-disk (tier, start)-sorted contract (`point_lookup_writer_
-    // properties`'s `sorting_columns`) without any explicit sort.
+    // Correctness needs each tier's rows position-ascending on disk
+    // (`PageDir::resolve_ranges`'s binary search assumes a sorted run). That
+    // does NOT follow from `target_partitions=1` alone: `p LEFT JOIN v` plans
+    // as `HashJoinExec`, and the query optimizer picks which side to hash
+    // (`join_type`) based on relative table size -- for a whole-genome plugin
+    // bigger than the variation probe (CADD, SpliceAI: the configs actually
+    // built and shipped so far) it swaps to `join_type=Right` with the plugin
+    // on the probe side, which DOES stream through unreordered; for a plugin
+    // smaller than the probe (a sparse plugin, a small custom subset, a
+    // low-coverage chrom) it can plan `join_type=Left` with the plugin on the
+    // *build* side instead, whose row order a hash join does not preserve.
+    // `assert_start_monotonic` below checks the actual invariant directly
+    // rather than trusting which side the optimizer chose: a real violation
+    // aborts the build loudly instead of silently writing a shard whose
+    // point-lookup can miss rows that are actually present.
     let mut stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
 
     let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
@@ -190,6 +240,8 @@ pub async fn build_plugin_chrom(
     let mut warm_writer = PluginShardWriter::create(&warm_tmp, Arc::clone(&out_schema))?;
     let mut cold_writer = PluginShardWriter::create(&cold_tmp, Arc::clone(&out_schema))?;
     let (mut warm, mut cold) = (0usize, 0usize);
+    let start_idx = out_schema.index_of("start")?;
+    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
 
     while let Some(b) = stream.next().await {
         let batch = b?;
@@ -213,9 +265,13 @@ pub async fn build_plugin_chrom(
                 continue;
             }
             if keep == 0 {
+                warm_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
                 warm += filtered.num_rows();
                 warm_writer.write(&filtered)?;
             } else {
+                cold_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
                 cold += filtered.num_rows();
                 cold_writer.write(&filtered)?;
             }
@@ -477,6 +533,62 @@ type = "Float32"
             PluginScalar::F32(v) => assert!((v - 0.7).abs() < 1e-6),
             ref other => panic!("{other:?}"),
         }
+    }
+
+    // C1 regression: a tiered join that does NOT preserve row order (e.g. the
+    // planner puts the plugin on the hash-build side for a small-plugin/
+    // large-probe query shape) must fail the build loudly rather than write a
+    // shard whose on-disk (tier, start) sort claim is false.
+    #[test]
+    fn assert_start_monotonic_catches_within_batch_disorder() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "start",
+            DataType::UInt32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(UInt32Array::from(vec![10u32, 20, 15]))],
+        )
+        .unwrap();
+        let err = assert_start_monotonic(&batch, 0, 1, "1", None).unwrap_err();
+        assert!(err.to_string().contains("not position-ascending"));
+    }
+
+    #[test]
+    fn assert_start_monotonic_catches_cross_batch_regression() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "start",
+            DataType::UInt32,
+            false,
+        )]));
+        let first = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(UInt32Array::from(vec![100u32]))],
+        )
+        .unwrap();
+        let last_seen = assert_start_monotonic(&first, 0, 0, "1", None).unwrap();
+        assert_eq!(last_seen, Some(100));
+        let second =
+            RecordBatch::try_new(schema, vec![Arc::new(UInt32Array::from(vec![50u32]))]).unwrap();
+        let err = assert_start_monotonic(&second, 0, 0, "1", last_seen).unwrap_err();
+        assert!(err.to_string().contains("not position-ascending"));
+    }
+
+    #[test]
+    fn assert_start_monotonic_accepts_sorted_input() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "start",
+            DataType::UInt32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(UInt32Array::from(vec![10u32, 10, 20, 30]))],
+        )
+        .unwrap();
+        let last_seen = assert_start_monotonic(&batch, 0, 0, "1", None).unwrap();
+        assert_eq!(last_seen, Some(30));
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -1,6 +1,19 @@
 //! End-to-end per-chrom plugin cache build: register sources → ingest view →
 //! normalization wrapper → variation-frequency join/tier → two-pass tiered
 //! shard write → cache-manifest chrom entry.
+//!
+//! Known tradeoff (noted during PR #196 review): the tiered join is only
+//! guaranteed to stream in position-ascending order per tier when the
+//! optimizer keeps the plugin on the join's probe side, which needs the
+//! plugin's own row count to be large relative to the chromosome's variation
+//! shard (true for whole-genome plugins like CADD/SpliceAI). A sparse or
+//! low-coverage-chromosome plugin can end up on the *build* side instead,
+//! whose order a hash join doesn't preserve -- `assert_start_monotonic`
+//! below then hard-fails that build rather than silently writing a
+//! wrong-order shard. There is currently no re-sort fallback for that case
+//! (see the review thread on PR #196 for the tradeoff analysis); a future
+//! sparse-plugin manifest that hits this needs one added here, not just a
+//! bigger `assume_unique`-style flag.
 
 use std::path::Path;
 use std::sync::Arc;

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -6,15 +6,13 @@ use std::path::Path;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, BooleanArray, Int8Array};
-use datafusion::arrow::compute::{
-    cast, concat_batches, filter_record_batch, sort_to_indices, take,
-};
+use datafusion::arrow::compute::{cast, filter_record_batch};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
@@ -41,21 +39,6 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(Arc::clone(schema), cols)
         .map_err(|e| DataFusionError::Execution(format!("reproject: {e}")))
-}
-
-/// Sort a batch ascending by `start` (the per-tier run order the PageDir needs).
-fn sort_by_start(batch: &RecordBatch) -> Result<RecordBatch> {
-    let start = batch.column(batch.schema().index_of("start")?);
-    let idx = sort_to_indices(start, None, None)
-        .map_err(|e| DataFusionError::Execution(format!("sort_to_indices: {e}")))?;
-    let cols = batch
-        .columns()
-        .iter()
-        .map(|c| take(c, &idx, None))
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| DataFusionError::Execution(format!("take: {e}")))?;
-    RecordBatch::try_new(batch.schema(), cols)
-        .map_err(|e| DataFusionError::Execution(format!("rebuild sorted: {e}")))
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -132,14 +115,31 @@ pub async fn build_plugin_chrom(
         .execute_stream()
         .await?;
     let norm_schema = norm_stream.schema();
-    let deduped = dedup_keep_first(norm_stream, &match_cols).await?;
+    // `assume_unique` sources are structurally guaranteed to never repeat a
+    // probe key, so the keep-first pass (a HashSet<String> with one entry per
+    // row — the dominant memory cost on the largest chromosomes) is skipped;
+    // batches are collected as-is.
+    let deduped = if src.assume_unique {
+        norm_stream.try_collect::<Vec<_>>().await?
+    } else {
+        dedup_keep_first(norm_stream, &match_cols).await?
+    };
     // The source scan is done — drop the decompressed temp before the join leg.
     drop(src_temps);
 
-    // Build context: default parallelism for the tier join over the (multi-GB)
-    // variation shard + write. The deduped survivors are re-registered here as a
-    // MemTable the join consumes in place of the raw normalized view.
-    let build_ctx = SessionContext::new();
+    // Build context: single partition, same reasoning as `read_ctx` above — the
+    // streaming write below (see `tiered_stream` consumption) relies on the join
+    // emitting rows in the same position-ascending order the dedup pass fed it,
+    // so it never has to buffer more than one batch. With `target_partitions=1`
+    // there is exactly one task for the whole join, so HashJoinExec has no
+    // opportunity to reorder rows across partitions. The join's build side
+    // (`plugin_variation_probe`, DISTINCT-projected and typically far smaller
+    // than the plugin's own per-chrom row count for whole-genome plugins like
+    // CADD/SpliceAI) is unaffected by this — it's still a single hash-table
+    // build regardless of partition count. The deduped survivors are
+    // re-registered here as a MemTable the join consumes in place of the raw
+    // normalized view.
+    let build_ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
     let mem = MemTable::try_new(norm_schema, vec![deduped])
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
@@ -152,19 +152,71 @@ pub async fn build_plugin_chrom(
     let file_name = format!("{}.parquet", canonical_chrom_label(chrom));
     let shard_path = plugin_dir.join(&file_name);
 
-    // Materialize tiered rows (tier inherited from the variation cache) from the
-    // deduped rows.
+    // Stream the tiered join output straight into two per-tier temp shards
+    // (warm run, cold run) instead of collecting the whole chromosome into one
+    // Vec<RecordBatch>, concat_batches-ing it into a single allocation, and
+    // sorting it in memory. That collect+concat+sort was the dominant remaining
+    // memory cost after `assume_unique` removed the dedup HashSet, and still
+    // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
+    // peak memory at O(one batch) instead of O(whole chromosome).
+    //
+    // Correctness relies on the join preserving row order end to end: the
+    // source scan (`read_ctx`, single partition) yields rows in file order,
+    // which for these per-chrom tabix-extracted sources is position-ascending;
+    // dedup (`dedup_keep_first`/`try_collect`) filters within that order without
+    // reordering; and the tier join (`build_ctx`, now also single partition)
+    // streams the probe side through unreordered. A per-batch tier filter
+    // (`filter_record_batch`) never reorders survivors either, so each tier's
+    // rows stay position-ascending both within a batch and across batches —
+    // meeting the on-disk (tier, start)-sorted contract (`point_lookup_writer_
+    // properties`'s `sorting_columns`) without any explicit sort.
     let mut stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
-    let mut batches = Vec::new();
+
+    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
+    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
+    let mut warm_writer = PluginShardWriter::create(&warm_tmp, Arc::clone(&out_schema))?;
+    let mut cold_writer = PluginShardWriter::create(&cold_tmp, Arc::clone(&out_schema))?;
+    let (mut warm, mut cold) = (0usize, 0usize);
+
     while let Some(b) = stream.next().await {
-        batches.push(b?);
+        let batch = b?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let reordered = reproject_cast(&batch, &out_schema)?;
+        let tier_col = reordered
+            .column(out_schema.index_of("tier")?)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
+            .clone();
+        for keep in [0i8, 1i8] {
+            let mask: BooleanArray = (0..reordered.num_rows())
+                .map(|i| Some(tier_col.value(i) == keep))
+                .collect();
+            let filtered = filter_record_batch(&reordered, &mask)
+                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
+            if filtered.num_rows() == 0 {
+                continue;
+            }
+            if keep == 0 {
+                warm += filtered.num_rows();
+                warm_writer.write(&filtered)?;
+            } else {
+                cold += filtered.num_rows();
+                cold_writer.write(&filtered)?;
+            }
+        }
     }
+    warm_writer.finish()?;
+    cold_writer.finish()?;
 
     // Empty chrom → no shard (matches variation builder cleanup). Remove any
     // stale shard from a previous build so the manifest (rows: 0) matches disk
     // and the runtime never opens a leftover file for an empty chrom.
-    let non_empty: Vec<RecordBatch> = batches.into_iter().filter(|b| b.num_rows() > 0).collect();
-    if non_empty.is_empty() {
+    if warm + cold == 0 {
+        let _ = std::fs::remove_file(&warm_tmp);
+        let _ = std::fs::remove_file(&cold_tmp);
         let _ = std::fs::remove_file(&shard_path);
         return Ok(ChromEntry {
             chrom: canonical_chrom_label(chrom),
@@ -174,36 +226,25 @@ pub async fn build_plugin_chrom(
             cold: 0,
         });
     }
-    let joined_schema = non_empty[0].schema();
-    let full = concat_batches(&joined_schema, &non_empty)
-        .map_err(|e| DataFusionError::Execution(format!("concat: {e}")))?;
-    let reordered = reproject_cast(&full, &out_schema)?;
 
-    // Split into warm (0) then cold (1) runs, each start-sorted, and write.
-    let tier_col = reordered
-        .column(out_schema.index_of("tier")?)
-        .as_any()
-        .downcast_ref::<Int8Array>()
-        .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
-        .clone();
-    let (mut warm, mut cold) = (0usize, 0usize);
+    // Merge: final shard = warm run then cold run. Both temps are already
+    // start-sorted by construction (see above), so this is a plain streaming
+    // batch-by-batch copy into the final writer (which carries the point-lookup
+    // page-index properties) — no sort, O(one batch) memory.
     let mut writer = PluginShardWriter::create(&shard_path, Arc::clone(&out_schema))?;
-    for keep in [0i8, 1i8] {
-        let mask: BooleanArray = (0..reordered.num_rows())
-            .map(|i| Some(tier_col.value(i) == keep))
-            .collect();
-        let filtered = filter_record_batch(&reordered, &mask)
-            .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
-        if filtered.num_rows() == 0 {
-            continue;
+    for tmp in [&warm_tmp, &cold_tmp] {
+        let file = std::fs::File::open(tmp)
+            .map_err(|e| DataFusionError::Execution(format!("open temp {}: {e}", tmp.display())))?;
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .map_err(|e| DataFusionError::Execution(format!("open temp reader: {e}")))?
+            .build()
+            .map_err(|e| DataFusionError::Execution(format!("build temp reader: {e}")))?;
+        for batch in reader {
+            let batch =
+                batch.map_err(|e| DataFusionError::Execution(format!("read temp batch: {e}")))?;
+            writer.write(&batch)?;
         }
-        let sorted = sort_by_start(&filtered)?;
-        if keep == 0 {
-            warm += sorted.num_rows();
-        } else {
-            cold += sorted.num_rows();
-        }
-        writer.write(&sorted)?;
+        let _ = std::fs::remove_file(tmp);
     }
     let rows = writer.finish()?;
     if rows == 0 {

--- a/datafusion/bio-function-vep/src/plugin_cache/dedup.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/dedup.rs
@@ -96,6 +96,77 @@ pub async fn dedup_keep_first(
     Ok(out)
 }
 
+/// Bound on how many distinct keys `check_assume_unique_sample` tracks before
+/// it stops checking. An `assume_unique` source skips `dedup_keep_first`
+/// entirely to avoid materializing a `HashSet<String>` sized to the whole
+/// chromosome (the dominant remaining memory cost on CADD/SpliceAI's largest
+/// chromosomes) -- so this check trades exhaustive coverage for a hard,
+/// small memory ceiling: it validates the FIRST `SAMPLE_CAP` distinct keys
+/// seen (in source-file order) and then stops, rather than either costing
+/// nothing (leaving the assumption fully untested) or costing exactly what
+/// the flag exists to avoid (an exhaustive `HashSet`).
+const SAMPLE_CAP: usize = 2_000_000;
+
+/// Validate (a bounded prefix of) an `assume_unique` source's claim that it
+/// never repeats a runtime probe key, without filtering anything.
+///
+/// A violated assumption is caught here rather than left to the runtime
+/// lookup `HashMap`, which keeps the *last* row of a duplicate key --
+/// silently inverting VEP's first-in-file rule (see module docs). This
+/// checks only the first `SAMPLE_CAP` distinct keys encountered so memory
+/// stays bounded regardless of chromosome size; a source whose duplicates
+/// only occur past that prefix will not be caught by this pass.
+pub async fn check_assume_unique_sample(
+    mut stream: SendableRecordBatchStream,
+    match_columns: &[String],
+) -> Result<Vec<RecordBatch>> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<RecordBatch> = Vec::new();
+    let opts = FormatOptions::default().with_null("\u{0}NULL");
+
+    let mut key_names: Vec<&str> = vec!["start", "allele_string"];
+    key_names.extend(match_columns.iter().map(|s| s.as_str()));
+
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        if seen.len() < SAMPLE_CAP {
+            let schema = batch.schema();
+            let formatters = key_names
+                .iter()
+                .map(|name| {
+                    let idx = schema.index_of(name)?;
+                    ArrayFormatter::try_new(batch.column(idx).as_ref(), &opts).map_err(|e| {
+                        DataFusionError::Execution(format!("key formatter {name}: {e}"))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let mut key = String::new();
+            for r in 0..batch.num_rows() {
+                if seen.len() >= SAMPLE_CAP {
+                    break;
+                }
+                use std::fmt::Write;
+                key.clear();
+                for f in &formatters {
+                    let _ = write!(key, "{}{KEY_SEP}", f.value(r));
+                }
+                if !seen.insert(std::mem::take(&mut key)) {
+                    return Err(DataFusionError::Execution(
+                        "assume_unique source violated its own claim: a duplicate runtime \
+                         probe key was found in the first sampled rows. The manifest's \
+                         `assume_unique = true` is unsafe for this source -- remove it so \
+                         the keep-first dedup pass runs (VEP's first-in-file rule), or fix \
+                         the source if the duplicate is unexpected."
+                            .into(),
+                    ));
+                }
+            }
+        }
+        out.push(batch);
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,6 +259,44 @@ mod tests {
         // The distinct aa-change at the same position survives (not over-deduped).
         assert!(survivors.iter().any(|(pv, _)| pv == "K55N"));
         assert!(survivors.iter().any(|(pv, _)| pv == "D43Y"));
+    }
+
+    // I2 fix: an `assume_unique` source that actually repeats a probe key must
+    // be caught, not silently accepted (the runtime lookup would then keep the
+    // *last* duplicate, inverting VEP's first-in-file rule).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_assume_unique_sample_rejects_a_real_duplicate() {
+        let stream = stream_of(norm_batch()).await;
+        let err = check_assume_unique_sample(stream, &["protein_variant".to_string()])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("violated its own claim"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_assume_unique_sample_passes_genuinely_unique_input() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("score", DataType::Float32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(Int64Array::from(vec![50i64, 51])),
+                Arc::new(Int64Array::from(vec![50i64, 51])),
+                Arc::new(StringArray::from(vec!["A/G", "C/T"])),
+                Arc::new(Float32Array::from(vec![Some(1.0f32), Some(2.0)])),
+            ],
+        )
+        .unwrap();
+        let stream = stream_of(batch).await;
+        let out = check_assume_unique_sample(stream, &[]).await.unwrap();
+        let rows: usize = out.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 2, "unique input must pass through untouched");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -21,12 +21,47 @@ pub fn tier_sql(normalized_view: &str, variation_probe: &str) -> String {
     )
 }
 
+/// Same join, with an explicit `ORDER BY` so the output is position-ascending
+/// regardless of which side of the physical `HashJoinExec` the optimizer put
+/// the plugin on (see `build.rs`'s module doc). Used only as the retry path
+/// after the cheap, unsorted `tiered_stream` trips `assert_start_monotonic` --
+/// the sort is real work, so it's not paid by the common case (a whole-genome
+/// plugin bigger than the variation probe, which streams through unreordered
+/// already).
+pub fn tier_sql_sorted(normalized_view: &str, variation_probe: &str) -> String {
+    format!(
+        "{} ORDER BY p.start",
+        tier_sql(normalized_view, variation_probe)
+    )
+}
+
 /// Register the variation shard as a `tier`-bearing probe view, then stream the
-/// tiered rows (tier inherited from the variation record).
+/// tiered rows (tier inherited from the variation record) in whatever order
+/// the join happens to produce.
 pub async fn tiered_stream(
     ctx: &SessionContext,
     normalized_view: &str,
     variation_shard: &Path,
+) -> Result<SendableRecordBatchStream> {
+    tiered_stream_impl(ctx, normalized_view, variation_shard, false).await
+}
+
+/// Same as `tiered_stream`, but the output is guaranteed position-ascending on
+/// `start` (see `tier_sql_sorted`). Costs a real sort -- use only as the
+/// fallback once the unsorted stream has been shown to need it.
+pub async fn tiered_stream_sorted(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    variation_shard: &Path,
+) -> Result<SendableRecordBatchStream> {
+    tiered_stream_impl(ctx, normalized_view, variation_shard, true).await
+}
+
+async fn tiered_stream_impl(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    variation_shard: &Path,
+    sorted: bool,
 ) -> Result<SendableRecordBatchStream> {
     let shard = variation_shard.to_string_lossy();
     ctx.register_parquet(
@@ -74,9 +109,12 @@ pub async fn tiered_stream(
          GROUP BY v.chrom, v.start, v.allele_string"
     ))
     .await?;
-    let df = ctx
-        .sql(&tier_sql(normalized_view, "plugin_variation_probe"))
-        .await?;
+    let sql = if sorted {
+        tier_sql_sorted(normalized_view, "plugin_variation_probe")
+    } else {
+        tier_sql(normalized_view, "plugin_variation_probe")
+    };
+    let df = ctx.sql(&sql).await?;
     df.execute_stream().await
 }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -36,8 +36,13 @@ pub async fn tiered_stream(
     )
     .await?;
     ctx.sql(
+        // DISTINCT: the variation shard can carry multiple source rows for the
+        // same (chrom, start, allele_string) (e.g. distinct dbSNP/COSMIC-origin
+        // entries for one variant). Without it, the tier LEFT JOIN below fans
+        // out the plugin row once per matching variation row, inflating the
+        // built cache with duplicate (but value-identical) rows.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT chrom, start, allele_string, tier FROM plugin_variation_raw",
+         SELECT DISTINCT chrom, start, allele_string, tier FROM plugin_variation_raw",
     )
     .await?;
     let df = ctx

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -35,7 +35,7 @@ pub async fn tiered_stream(
         datafusion::prelude::ParquetReadOptions::default(),
     )
     .await?;
-    ctx.sql(
+    ctx.sql(&format!(
         // GROUP BY (not DISTINCT): the variation shard can carry multiple
         // source rows for the same (chrom, start, allele_string) (e.g.
         // distinct dbSNP/COSMIC-origin entries for one variant). If those
@@ -52,10 +52,27 @@ pub async fn tiered_stream(
         // warm. This also guarantees `HashJoinExec`'s build side can never
         // fan out, which is a (data-dependent) join-skew risk this GROUP BY
         // removes entirely rather than merely reduces.
+        //
+        // The inner JOIN against a DISTINCT projection of the plugin's own
+        // keys is a semi-join emulation that restricts the aggregation to
+        // keys the plugin table actually has, computed BEFORE the `GROUP BY`
+        // rather than after: for a sparse plugin (far fewer rows than the
+        // chromosome's full variation shard), grouping the *entire* shard
+        // just to inherit tier for a handful of keys is wasted work the LEFT
+        // JOIN below never uses (variation rows with no matching plugin key
+        // can never survive a `p.*`-projected LEFT JOIN regardless).
+        // Semantically a no-op — this narrows which rows get grouped, not
+        // which key wins ties or what a hit resolves to. The DISTINCT on the
+        // plugin side keeps this join's build side small and its own key
+        // unique, so it can't reintroduce the fan-out risk the GROUP BY
+        // above exists to remove.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT chrom, start, allele_string, MIN(tier) AS tier \
-         FROM plugin_variation_raw GROUP BY chrom, start, allele_string",
-    )
+         SELECT v.chrom, v.start, v.allele_string, MIN(v.tier) AS tier \
+         FROM plugin_variation_raw v \
+         INNER JOIN (SELECT DISTINCT chrom, start, allele_string FROM {normalized_view}) p \
+         ON v.chrom = p.chrom AND v.start = p.start AND v.allele_string = p.allele_string \
+         GROUP BY v.chrom, v.start, v.allele_string"
+    ))
     .await?;
     let df = ctx
         .sql(&tier_sql(normalized_view, "plugin_variation_probe"))
@@ -70,7 +87,93 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::prelude::col;
+    use futures::StreamExt;
+    use parquet::arrow::ArrowWriter;
     use std::sync::Arc;
+
+    // Codex review, PR #196: for a sparse plugin the pre-fix
+    // `plugin_variation_probe` unconditionally grouped the ENTIRE variation
+    // shard, including keys no plugin row will ever reference. The semi-join
+    // narrowing must be a pure performance change, not a semantic one --
+    // verify a large-relative-to-plugin variation shard (rows the plugin
+    // never touches, PLUS a conflicting-tier duplicate at a key the plugin
+    // DOES touch) still tiers exactly as before.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tiered_stream_ignores_variation_rows_no_plugin_key_references() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        // 100: two conflicting-tier duplicates (must still collapse to warm).
+        // 999/1000/1001: irrelevant rows no plugin key ever probes.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1", "1", "1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 100, 999, 1000, 1001])),
+                Arc::new(StringArray::from(vec!["A/G", "A/G", "G/T", "C/A", "T/G"])),
+                Arc::new(Int8Array::from(vec![1i8, 0, 0, 0, 1])),
+            ],
+        )
+        .unwrap();
+        let var_path = dir.path().join("var.parquet");
+        let file = std::fs::File::create(&var_path).unwrap();
+        let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let ctx = SessionContext::new();
+        let plug = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("chrom", DataType::Utf8, false),
+                Field::new("start", DataType::UInt32, false),
+                Field::new("end", DataType::UInt32, false),
+                Field::new("allele_string", DataType::Utf8, false),
+                Field::new("demo_score", DataType::Float32, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 300])),
+                Arc::new(UInt32Array::from(vec![100u32, 300])),
+                Arc::new(StringArray::from(vec!["A/G", "G/A"])),
+                Arc::new(Float32Array::from(vec![Some(0.9f32), Some(0.7)])),
+            ],
+        )
+        .unwrap();
+        ctx.register_batch("plugin_demo_norm", plug).unwrap();
+
+        let mut stream = tiered_stream(&ctx, "plugin_demo_norm", &var_path)
+            .await
+            .unwrap();
+        let mut rows: Vec<(u32, i8)> = Vec::new();
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            let starts = b
+                .column(b.schema().index_of("start").unwrap())
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap();
+            let tiers = b
+                .column(b.schema().index_of("tier").unwrap())
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                rows.push((starts.value(i), tiers.value(i)));
+            }
+        }
+        rows.sort();
+        // 100: conflicting-tier duplicate collapses to warm (0), matching
+        // pre-semi-join behavior exactly. 300: no variation match -> cold (1).
+        // The three irrelevant variation rows (999/1000/1001) never surface
+        // here since only the plugin's own rows are projected -- their
+        // absence from `plugin_variation_raw`'s post-semi-join scan is the
+        // thing under test, not something directly observable in the output.
+        assert_eq!(rows, vec![(100, 0), (300, 1)]);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn inherits_tier_from_variation_and_miss_is_cold() {

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -36,13 +36,25 @@ pub async fn tiered_stream(
     )
     .await?;
     ctx.sql(
-        // DISTINCT: the variation shard can carry multiple source rows for the
-        // same (chrom, start, allele_string) (e.g. distinct dbSNP/COSMIC-origin
-        // entries for one variant). Without it, the tier LEFT JOIN below fans
-        // out the plugin row once per matching variation row, inflating the
-        // built cache with duplicate (but value-identical) rows.
+        // GROUP BY (not DISTINCT): the variation shard can carry multiple
+        // source rows for the same (chrom, start, allele_string) (e.g.
+        // distinct dbSNP/COSMIC-origin entries for one variant). If those
+        // duplicates ever disagree on `tier` (one warm, one cold), a plain
+        // `SELECT DISTINCT chrom, start, allele_string, tier` keeps BOTH rows
+        // — the join key is then non-unique on the build side, so the tier
+        // LEFT JOIN below fans out the plugin row once per surviving variant,
+        // silently inflating the cache with duplicate rows for that key
+        // (worse: two rows with the same (start, allele_string) but different
+        // tier, which the point-lookup path never expects). `MIN(tier)`
+        // collapses to exactly one row per key regardless of how many
+        // conflicting-tier duplicates the raw shard has — 0 (warm) wins over
+        // 1 (cold), i.e. any evidence of a known/frequent variant marks it
+        // warm. This also guarantees `HashJoinExec`'s build side can never
+        // fan out, which is a (data-dependent) join-skew risk this GROUP BY
+        // removes entirely rather than merely reduces.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT DISTINCT chrom, start, allele_string, tier FROM plugin_variation_raw",
+         SELECT chrom, start, allele_string, MIN(tier) AS tier \
+         FROM plugin_variation_raw GROUP BY chrom, start, allele_string",
     )
     .await?;
     let df = ctx

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -1,12 +1,19 @@
 //! Provider factory: register a source manifest's raw tables under their
 //! `plugin_<name>_src[_<part>]` names. CSV/TSV/Parquet use builtin DataFusion
-//! providers; VCF/BED (bio-formats) are not wired in the prototype.
+//! providers; VCF uses `datafusion-bio-format-vcf`'s `VcfTableProvider` (INFO
+//! fields come back as typed top-level columns named after the raw INFO tag —
+//! query them directly in `ingest_sql`). BED is not wired in the prototype.
+
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
+use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
-use crate::plugin_cache::source_manifest::{CsvParams, ProviderKind, SourceManifest, ValueType};
+use crate::plugin_cache::source_manifest::{
+    CoordinateSystem, CsvParams, ProviderKind, SourceManifest, ValueType,
+};
 
 fn arrow_type(ty: ValueType) -> DataType {
     match ty {
@@ -108,7 +115,27 @@ pub async fn register_sources(
                 ctx.register_parquet(&table, &spec.path, ParquetReadOptions::default())
                     .await?;
             }
-            ProviderKind::Vcf | ProviderKind::Bed => {
+            ProviderKind::Vcf => {
+                // `coordinate_system` describes how the manifest's `ingest_sql`
+                // should interpret positions; the VCF provider's own
+                // `coordinate_system_zero_based` flag controls how IT reports
+                // `start`/`end` from the file's native 1-based VCF `POS` — keep
+                // them in lock-step so `ingest_sql` always sees the coordinate
+                // system the manifest declares, regardless of source format.
+                let zero_based = matches!(manifest.coordinate_system, CoordinateSystem::ZeroBasedHalfOpen);
+                // No manifest knob yet for selecting a INFO/FORMAT subset — read
+                // every INFO field the VCF header declares (`None`) and let
+                // `ingest_sql` project down to what it needs, same as the CSV
+                // path relies on `ingest_sql` rather than a narrower provider
+                // schema. Revisit if a source has so many INFO fields that
+                // schema inference itself becomes the bottleneck.
+                let provider = VcfTableProvider::new(spec.path.clone(), None, None, None, zero_based)
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
+                    })?;
+                ctx.register_table(&table, Arc::new(provider))?;
+            }
+            ProviderKind::Bed => {
                 return Err(DataFusionError::NotImplemented(format!(
                     "provider {:?} not wired in prototype (table '{table}')",
                     spec.provider

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -2,13 +2,20 @@
 //! `plugin_<name>_src[_<part>]` names. CSV/TSV/Parquet use builtin DataFusion
 //! providers; VCF uses `datafusion-bio-format-vcf`'s `VcfTableProvider` (INFO
 //! fields come back as typed top-level columns named after the raw INFO tag —
-//! query them directly in `ingest_sql`). BED is not wired in the prototype.
+//! query them directly in `ingest_sql`); BED uses `datafusion-bio-format-bed`'s
+//! `BedTableProvider`, whose schema is only ever `chrom, start, end, name`
+//! regardless of the declared column count (`BEDFields` selects how many
+//! columns the reader parses off each line, not how many it exposes) — a
+//! source needing more than one extra field packs it into `name` and splits
+//! it back out in `ingest_sql`, the same trick SpliceAI's flattened INFO tag
+//! uses.
 
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
+use datafusion_bio_format_bed::table_provider::{BEDFields, BedTableProvider};
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
 use crate::plugin_cache::source_manifest::{
@@ -140,10 +147,24 @@ pub async fn register_sources(
                 ctx.register_table(&table, Arc::new(provider))?;
             }
             ProviderKind::Bed => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "provider {:?} not wired in prototype (table '{table}')",
-                    spec.provider
-                )));
+                // Same reasoning as the VCF branch above: the manifest's
+                // `coordinate_system` drives what `ingest_sql` expects, so
+                // keep the provider's own zero-based flag in lock-step with
+                // it rather than trusting the file's own convention.
+                let zero_based = matches!(
+                    manifest.coordinate_system,
+                    CoordinateSystem::ZeroBasedHalfOpen
+                );
+                // No manifest knob yet for BED4/5/6 -- `determine_schema` in
+                // `datafusion-bio-format-bed` only ever exposes `chrom, start,
+                // end, name` regardless of variant, so BED4 is the only
+                // choice that matters until a source needs more raw columns
+                // parsed off each line than that.
+                let provider = BedTableProvider::new(spec.path.clone(), BEDFields::BED4, None, zero_based)
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!("open BED source '{table}': {e}"))
+                    })?;
+                ctx.register_table(&table, Arc::new(provider))?;
             }
         }
     }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -122,17 +122,21 @@ pub async fn register_sources(
                 // `start`/`end` from the file's native 1-based VCF `POS` — keep
                 // them in lock-step so `ingest_sql` always sees the coordinate
                 // system the manifest declares, regardless of source format.
-                let zero_based = matches!(manifest.coordinate_system, CoordinateSystem::ZeroBasedHalfOpen);
+                let zero_based = matches!(
+                    manifest.coordinate_system,
+                    CoordinateSystem::ZeroBasedHalfOpen
+                );
                 // No manifest knob yet for selecting a INFO/FORMAT subset — read
                 // every INFO field the VCF header declares (`None`) and let
                 // `ingest_sql` project down to what it needs, same as the CSV
                 // path relies on `ingest_sql` rather than a narrower provider
                 // schema. Revisit if a source has so many INFO fields that
                 // schema inference itself becomes the bottleneck.
-                let provider = VcfTableProvider::new(spec.path.clone(), None, None, None, zero_based)
-                    .map_err(|e| {
-                        DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
-                    })?;
+                let provider =
+                    VcfTableProvider::new(spec.path.clone(), None, None, None, zero_based)
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
+                        })?;
                 ctx.register_table(&table, Arc::new(provider))?;
             }
             ProviderKind::Bed => {
@@ -150,7 +154,7 @@ pub async fn register_sources(
 mod tests {
     use super::*;
     use crate::plugin_cache::source_manifest::SourceManifest;
-    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::array::{Int64Array, StringArray};
     use std::io::Write;
 
     fn write_gz(path: &std::path::Path, body: &str) {
@@ -221,5 +225,71 @@ threshold = 0.01
             .unwrap()
             .value(0);
         assert_eq!(c, 2);
+    }
+
+    // I4: document (and pin, so a `datafusion-bio-format-vcf` version bump that
+    // changes this can't slip by silently) how the VCF provider actually
+    // reports a multi-allelic ALT. It comes back as one string joined per-
+    // allele (confirmed below: '|', not the VCF spec's own ','), not split
+    // into separate rows -- an `ingest_sql` that assumes the wrong separator
+    // (or assumes it's split already) builds an `allele_string` that never
+    // matches the per-allele variation key, i.e. a silent miss on every
+    // multi-allelic site. This test exists so that would fail loudly here
+    // instead of being discovered downstream.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vcf_source_multiallelic_alt_shape_is_pinned() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("multiallelic.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             1\t100\t.\tG\tA,C\t.\t.\t.\n",
+        )
+        .unwrap();
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+value_columns = []
+
+[[source]]
+provider = "vcf"
+path = "{}"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+        let rows = ctx
+            .sql("SELECT alt FROM plugin_demo_src")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "one row per VCF line, not per allele");
+        let alt = rows[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("alt column is a plain string, not a list -- if this ever fails, the ALT shape changed and every manifest built on this provider needs re-auditing");
+        // Pinned current behavior: `datafusion-bio-format-vcf` v1.8.8 joins a
+        // multi-allelic ALT with '|' (NOT ',' -- the naive guess from the VCF
+        // spec's own comma-separated ALT column would be wrong here). Any
+        // manifest built directly on `ProviderKind::Vcf` for a source that can
+        // be multi-allelic MUST split `alt` on '|' in its own `ingest_sql`
+        // (the way the CADD/ClinVar bcftools-flatten preprocessing already
+        // splits multi-value INFO tags for VCF sources that go through the
+        // CSV path instead).
+        assert_eq!(
+            alt.value(0),
+            "A|C",
+            "ALT shape changed -- re-audit every VCF-provider manifest's \
+             ingest_sql for correct multi-allelic splitting"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/registry.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/registry.rs
@@ -277,6 +277,7 @@ mod tests {
             "",
             "",
             "",
+            "",
             "78",
             "R/G",
             "",
@@ -291,6 +292,7 @@ mod tests {
         // non-missense (no aa-change) → Null (gate)
         let ns_miss = build_attr_namespace(
             "synonymous_variant",
+            "",
             "",
             "",
             "",

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -119,6 +119,20 @@ pub struct SourceManifest {
     /// Optional per-transcript match discriminators (§3.4). Empty = per-variant.
     #[serde(default, rename = "match_column")]
     pub match_columns: Vec<MatchColumn>,
+    /// Skip the build-time keep-first dedup pass (`dedup::dedup_keep_first`)
+    /// when the source is structurally guaranteed to never emit two rows
+    /// sharing a runtime probe key `(start, allele_string, <match cols>)` —
+    /// e.g. SpliceAI's masked release (one prediction per variant) or CADD's
+    /// SNV+indel files (disjoint allele-string shapes, so they can't collide
+    /// with each other or within themselves). Dedup's `HashSet<String>` costs
+    /// one heap-allocated key per row and is the dominant memory cost on the
+    /// largest chromosomes; skipping it for sources that provably have no
+    /// duplicates avoids that cost entirely. Do NOT set this for sources that
+    /// can legitimately repeat a key (e.g. AlphaMissense's overlapping
+    /// UniProt entries) — the manifest author must justify this per-plugin,
+    /// it is not a generic performance knob.
+    #[serde(default)]
+    pub assume_unique: bool,
 }
 
 impl SourceManifest {

--- a/datafusion/bio-function-vep/src/plugin_cache/template.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/template.rs
@@ -12,6 +12,7 @@ use datafusion::common::{DataFusionError, Result};
 pub const ATTR_NAMES: &[&str] = &[
     "Consequence",
     "Gene",
+    "SYMBOL",
     "Feature_type",
     "Feature",
     "BIOTYPE",
@@ -95,6 +96,7 @@ impl CompiledTemplate {
 pub fn build_attr_namespace<'a>(
     consequence: &'a str,
     gene: &'a str,
+    symbol: &'a str,
     feature_type: &'a str,
     feature: &'a str,
     biotype: &'a str,
@@ -121,6 +123,7 @@ pub fn build_attr_namespace<'a>(
     [
         non_empty(consequence),
         non_empty(gene),
+        non_empty(symbol),
         non_empty(feature_type),
         non_empty(feature),
         non_empty(biotype),
@@ -146,6 +149,7 @@ mod tests {
         build_attr_namespace(
             "missense_variant",
             "ENSG1",
+            "GENE1",
             "Transcript",
             "ENST1",
             "protein_coding",
@@ -185,6 +189,7 @@ mod tests {
         let ns = build_attr_namespace(
             "synonymous_variant",
             "ENSG1",
+            "GENE1",
             "Transcript",
             "ENST1",
             "protein_coding",
@@ -205,7 +210,7 @@ mod tests {
     #[test]
     fn range_position_and_multi_residue_gate() {
         let range = build_attr_namespace(
-            "inframe", "", "", "", "", "", "", "", "", "550-551", "VV/A", "", "C", "T",
+            "inframe", "", "", "", "", "", "", "", "", "", "550-551", "VV/A", "", "C", "T",
         );
         let t = CompiledTemplate::compile("{ref_aa}{Protein_position}{alt_aa}").unwrap();
         assert_eq!(t.eval(&range), None);

--- a/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
+++ b/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
@@ -21,8 +21,9 @@ use datafusion_bio_function_vep::plugin_cache::source_manifest::{
 use datafusion_bio_function_vep::plugin_cache::template::build_attr_namespace;
 
 /// Namespace for a `C/G` variant with the given amino-acid change (rest empty).
-fn ns_aa<'a>(amino_acids: &'a str, protein_pos: &'a str) -> [Option<&'a str>; 16] {
+fn ns_aa<'a>(amino_acids: &'a str, protein_pos: &'a str) -> [Option<&'a str>; 17] {
     build_attr_namespace(
+        "",
         "",
         "",
         "",


### PR DESCRIPTION
## Summary
- `build.rs`: stream the tiered join output straight into per-tier temp shards (warm/cold) instead of collecting the whole chromosome into one `Vec<RecordBatch>`, concat-ing, and sorting in memory — that collect+concat+sort was the dominant remaining memory cost after removing the dedup HashSet, and still OOM'd on the largest chromosomes (CADD chr6-8, chrX). Peak memory is now O(one batch) instead of O(whole chromosome).
- `source_manifest.rs`: add `assume_unique` — sources structurally guaranteed to never repeat a runtime probe key can skip the build-time keep-first dedup pass entirely (its `HashSet<String>`, one heap-allocated key per row, was the other dominant memory cost).
- `provider.rs`: wire `ProviderKind::Vcf` to `datafusion-bio-format-vcf`'s `VcfTableProvider` (previously `NotImplemented`) so VCF sources can be queried directly via `ingest_sql` instead of requiring a `bcftools`-flatten preprocessing step.

Paired with `biodatageeks/vepyr-plugins#2` (sets `assume_unique = true` on CADD/SpliceAI manifests, matching the new field).

Built out under this branch: SpliceAI complete (all 23 chroms), CADD near-complete (13/24 chroms, remaining ones running).

## Test plan
- [x] `cargo test -p datafusion-bio-function-vep --lib plugin_cache` — 37 passed, 0 failed
- [x] Validated in production against real chromosome builds (CADD chr6/chr7, SpliceAI chr1-3) on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)