### PR TITLE
feat(vep): enforce cache identity and exact VEP 115/116 parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=eee2d6926331fe5106cbbefbc1ca673e94357327#eee2d6926331fe5106cbbefbc1ca673e94357327"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c81adf1235984c984918ce5bd39d573476b62337#c81adf1235984c984918ce5bd39d573476b62337"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=eee2d6926331fe5106cbbefbc1ca673e94357327#eee2d6926331fe5106cbbefbc1ca673e94357327"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c81adf1235984c984918ce5bd39d573476b62337#c81adf1235984c984918ce5bd39d573476b62337"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1287,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=eee2d6926331fe5106cbbefbc1ca673e94357327#eee2d6926331fe5106cbbefbc1ca673e94357327"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c81adf1235984c984918ce5bd39d573476b62337#c81adf1235984c984918ce5bd39d573476b62337"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=eee2d6926331fe5106cbbefbc1ca673e94357327#eee2d6926331fe5106cbbefbc1ca673e94357327"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=eee2d6926331fe5106cbbefbc1ca673e94357327#eee2d6926331fe5106cbbefbc1ca673e94357327"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1287,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.8#c91fd12263c9cdd1d6c3b3f3371593f88b5dcaf0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=eee2d6926331fe5106cbbefbc1ca673e94357327#eee2d6926331fe5106cbbefbc1ca673e94357327"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,8 +1246,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c81adf1235984c984918ce5bd39d573476b62337#c81adf1235984c984918ce5bd39d573476b62337"
+version = "1.9.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.9.0#6564554619019535ffd3ace5aa650797a31eb8ed"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1268,12 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c81adf1235984c984918ce5bd39d573476b62337#c81adf1235984c984918ce5bd39d573476b62337"
+version = "1.9.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.9.0#6564554619019535ffd3ace5aa650797a31eb8ed"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.8.8",
+ "datafusion-bio-format-core 1.9.0",
  "datafusion-execution",
  "flate2",
  "log",
@@ -1286,15 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.8.8"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c81adf1235984c984918ce5bd39d573476b62337#c81adf1235984c984918ce5bd39d573476b62337"
+version = "1.9.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.9.0#6564554619019535ffd3ace5aa650797a31eb8ed"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.8.8",
+ "datafusion-bio-format-core 1.9.0",
  "datafusion-execution",
  "env_logger",
  "flate2",

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,8 +30,8 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c81adf1235984c984918ce5bd39d573476b62337" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c81adf1235984c984918ce5bd39d573476b62337", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.9.0" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.9.0", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,8 +30,8 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf ={ git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "eee2d6926331fe5106cbbefbc1ca673e94357327" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "eee2d6926331fe5106cbbefbc1ca673e94357327", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,8 +30,8 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "eee2d6926331fe5106cbbefbc1ca673e94357327" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "eee2d6926331fe5106cbbefbc1ca673e94357327", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c81adf1235984c984918ce5bd39d573476b62337" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c81adf1235984c984918ce5bd39d573476b62337", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/examples/build_parquet_context_chrom.rs
+++ b/datafusion/bio-function-vep/examples/build_parquet_context_chrom.rs
@@ -10,7 +10,8 @@
 //!     --entity transcript \
 //!     --cache-root /path/to/homo_sapiens_merged/115_GRCh38 \
 //!     --output-dir /path/to/115_GRCh38_merged \
-//!     --chrom chr1 --cache-source-type merged --partitions 8 --overwrite
+//!     --chrom chr1 --cache-source-type merged --cache-version 115 \
+//!     --partitions 8 --overwrite
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -24,6 +25,7 @@ use datafusion_bio_function_vep::cache::build::{
 use datafusion_bio_function_vep::cache::manifest::{
     CHROM_MANIFEST_FILE, ChromDatasetEntry, ChromManifest,
 };
+use datafusion_bio_function_vep::vep_semantics::target_for_cache_version;
 
 #[derive(Debug)]
 struct Args {
@@ -32,6 +34,7 @@ struct Args {
     output_dir: PathBuf,
     chrom: String,
     cache_source_type: CacheSourceType,
+    cache_version: String,
     partitions: usize,
     overwrite: bool,
 }
@@ -60,6 +63,7 @@ async fn main() -> Result<()> {
         output_dir: args.output_dir.to_string_lossy().to_string(),
         partitions: args.partitions,
         cache_source_type: args.cache_source_type,
+        cache_version: args.cache_version.clone(),
         overwrite: args.overwrite,
         chrom_filter: None,
     };
@@ -69,6 +73,7 @@ async fn main() -> Result<()> {
     eprintln!("output_dir={}", args.output_dir.display());
     eprintln!("chrom={}", args.chrom);
     eprintln!("cache_source_type={}", args.cache_source_type);
+    eprintln!("cache_version={}", args.cache_version);
 
     let (entry, dir_name) = if args.entity == "translation_core" {
         (
@@ -111,6 +116,7 @@ fn parse_args() -> Result<Args> {
     let mut output_dir = None;
     let mut chrom = None;
     let mut cache_source_type = CacheSourceType::Ensembl;
+    let mut cache_version = None;
     let mut partitions = 8usize;
     let mut overwrite = false;
 
@@ -129,12 +135,14 @@ fn parse_args() -> Result<Args> {
                     ))
                 })?;
             }
+            "--cache-version" => cache_version = Some(require_value(&mut args, &arg)?),
             "--partitions" => partitions = parse_usize(require_value(&mut args, &arg)?)?,
             "--overwrite" => overwrite = true,
             "--help" | "-h" => {
                 eprintln!(
                     "Usage: build_parquet_context_chrom --entity <transcript|exon|regulatory|motif|translation_core> \
-                     --cache-root <dir> --output-dir <dir> --chrom chr1 [--cache-source-type merged] [--partitions 8] [--overwrite]"
+                     --cache-root <dir> --output-dir <dir> --chrom chr1 --cache-version 115 \
+                     [--cache-source-type merged] [--partitions 8] [--overwrite]"
                 );
                 std::process::exit(0);
             }
@@ -146,6 +154,10 @@ fn parse_args() -> Result<Args> {
         }
     }
 
+    let cache_version = cache_version
+        .ok_or_else(|| DataFusionError::Execution("--cache-version is required".into()))?;
+    target_for_cache_version(&cache_version)?;
+
     Ok(Args {
         entity: entity.ok_or_else(|| DataFusionError::Execution("--entity is required".into()))?,
         cache_root: cache_root
@@ -154,6 +166,7 @@ fn parse_args() -> Result<Args> {
             .ok_or_else(|| DataFusionError::Execution("--output-dir is required".into()))?,
         chrom: chrom.ok_or_else(|| DataFusionError::Execution("--chrom is required".into()))?,
         cache_source_type,
+        cache_version,
         partitions: partitions.max(1),
         overwrite,
     })

--- a/datafusion/bio-function-vep/examples/build_parquet_translation_sift_chrom.rs
+++ b/datafusion/bio-function-vep/examples/build_parquet_translation_sift_chrom.rs
@@ -9,7 +9,8 @@
 //!     --example build_parquet_translation_sift_chrom -- \
 //!     --cache-root /path/to/homo_sapiens_merged/115_GRCh38 \
 //!     --output-dir /path/to/115_GRCh38_merged \
-//!     --chrom chr1 --cache-source-type merged --partitions 8 --overwrite
+//!     --chrom chr1 --cache-source-type merged --cache-version 115 \
+//!     --partitions 8 --overwrite
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -23,6 +24,7 @@ use datafusion_bio_function_vep::cache::build::{
 use datafusion_bio_function_vep::cache::manifest::{
     CHROM_MANIFEST_FILE, ChromDatasetEntry, ChromManifest,
 };
+use datafusion_bio_function_vep::vep_semantics::target_for_cache_version;
 
 /// Parquet entity directory name (mirrors `parquet_cache::detect`).
 const PARQUET_SIFT_DIR: &str = "translation_sift";
@@ -33,6 +35,7 @@ struct Args {
     output_dir: PathBuf,
     chrom: String,
     cache_source_type: CacheSourceType,
+    cache_version: String,
     partitions: usize,
     overwrite: bool,
 }
@@ -47,6 +50,7 @@ async fn main() -> Result<()> {
         output_dir: args.output_dir.to_string_lossy().to_string(),
         partitions: args.partitions,
         cache_source_type: args.cache_source_type,
+        cache_version: args.cache_version.clone(),
         overwrite: args.overwrite,
         chrom_filter: None,
     };
@@ -55,6 +59,7 @@ async fn main() -> Result<()> {
     eprintln!("output_dir={}", args.output_dir.display());
     eprintln!("chrom={}", args.chrom);
     eprintln!("cache_source_type={}", args.cache_source_type);
+    eprintln!("cache_version={}", args.cache_version);
     eprintln!("partitions={}", args.partitions);
     eprintln!("overwrite={}", args.overwrite);
 
@@ -84,6 +89,7 @@ fn parse_args() -> Result<Args> {
     let mut output_dir = None;
     let mut chrom = None;
     let mut cache_source_type = CacheSourceType::Ensembl;
+    let mut cache_version = None;
     let mut partitions = 8usize;
     let mut overwrite = false;
 
@@ -101,6 +107,7 @@ fn parse_args() -> Result<Args> {
                     ))
                 })?;
             }
+            "--cache-version" => cache_version = Some(require_value(&mut args, &arg)?),
             "--partitions" => partitions = parse_usize(require_value(&mut args, &arg)?)?,
             "--overwrite" => overwrite = true,
             "--help" | "-h" => {
@@ -115,6 +122,10 @@ fn parse_args() -> Result<Args> {
         }
     }
 
+    let cache_version = cache_version
+        .ok_or_else(|| DataFusionError::Execution("--cache-version is required".into()))?;
+    target_for_cache_version(&cache_version)?;
+
     Ok(Args {
         cache_root: cache_root
             .ok_or_else(|| DataFusionError::Execution("--cache-root is required".into()))?,
@@ -122,6 +133,7 @@ fn parse_args() -> Result<Args> {
             .ok_or_else(|| DataFusionError::Execution("--output-dir is required".into()))?,
         chrom: chrom.ok_or_else(|| DataFusionError::Execution("--chrom is required".into()))?,
         cache_source_type,
+        cache_version,
         partitions: partitions.max(1),
         overwrite,
     })
@@ -160,6 +172,6 @@ fn print_usage() {
     eprintln!(
         "Usage: build_parquet_translation_sift_chrom --cache-root /path/to/homo_sapiens_merged/115_GRCh38 \
          --output-dir /path/to/115_GRCh38_merged --chrom chr1 \
-         [--cache-source-type merged] [--partitions 8] [--overwrite]"
+         --cache-version 115 [--cache-source-type merged] [--partitions 8] [--overwrite]"
     );
 }

--- a/datafusion/bio-function-vep/examples/build_parquet_variation_chrom.rs
+++ b/datafusion/bio-function-vep/examples/build_parquet_variation_chrom.rs
@@ -9,7 +9,8 @@
 //!     --example build_parquet_variation_chrom -- \
 //!     --cache-root /path/to/homo_sapiens_merged/115_GRCh38 \
 //!     --output-dir /path/to/115_GRCh38_merged \
-//!     --chrom chr1 --cache-source-type merged --partitions 8 --overwrite
+//!     --chrom chr1 --cache-source-type merged --cache-version 115 \
+//!     --partitions 8 --overwrite
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -21,6 +22,7 @@ use datafusion_bio_function_vep::cache::build::{CacheBuildOptions, build_parquet
 use datafusion_bio_function_vep::cache::manifest::{
     CHROM_MANIFEST_FILE, ChromDatasetEntry, ChromManifest,
 };
+use datafusion_bio_function_vep::vep_semantics::target_for_cache_version;
 
 /// Parquet entity directory name (mirrors `parquet_cache::detect`).
 const PARQUET_VARIATION_DIR: &str = "variation";
@@ -31,6 +33,7 @@ struct Args {
     output_dir: PathBuf,
     chrom: String,
     cache_source_type: CacheSourceType,
+    cache_version: String,
     partitions: usize,
     overwrite: bool,
 }
@@ -45,6 +48,7 @@ async fn main() -> Result<()> {
         output_dir: args.output_dir.to_string_lossy().to_string(),
         partitions: args.partitions,
         cache_source_type: args.cache_source_type,
+        cache_version: args.cache_version.clone(),
         overwrite: args.overwrite,
         chrom_filter: None,
     };
@@ -53,6 +57,7 @@ async fn main() -> Result<()> {
     eprintln!("output_dir={}", args.output_dir.display());
     eprintln!("chrom={}", args.chrom);
     eprintln!("cache_source_type={}", args.cache_source_type);
+    eprintln!("cache_version={}", args.cache_version);
     eprintln!("partitions={}", args.partitions);
     eprintln!("overwrite={}", args.overwrite);
 
@@ -82,6 +87,7 @@ fn parse_args() -> Result<Args> {
     let mut output_dir = None;
     let mut chrom = None;
     let mut cache_source_type = CacheSourceType::Ensembl;
+    let mut cache_version = None;
     let mut partitions = 8usize;
     let mut overwrite = false;
 
@@ -99,6 +105,7 @@ fn parse_args() -> Result<Args> {
                     ))
                 })?;
             }
+            "--cache-version" => cache_version = Some(require_value(&mut args, &arg)?),
             "--partitions" => partitions = parse_usize(require_value(&mut args, &arg)?)?,
             "--overwrite" => overwrite = true,
             "--help" | "-h" => {
@@ -113,6 +120,10 @@ fn parse_args() -> Result<Args> {
         }
     }
 
+    let cache_version = cache_version
+        .ok_or_else(|| DataFusionError::Execution("--cache-version is required".into()))?;
+    target_for_cache_version(&cache_version)?;
+
     Ok(Args {
         cache_root: cache_root
             .ok_or_else(|| DataFusionError::Execution("--cache-root is required".into()))?,
@@ -120,6 +131,7 @@ fn parse_args() -> Result<Args> {
             .ok_or_else(|| DataFusionError::Execution("--output-dir is required".into()))?,
         chrom: chrom.ok_or_else(|| DataFusionError::Execution("--chrom is required".into()))?,
         cache_source_type,
+        cache_version,
         partitions: partitions.max(1),
         overwrite,
     })
@@ -158,6 +170,6 @@ fn print_usage() {
     eprintln!(
         "Usage: build_parquet_variation_chrom --cache-root /path/to/homo_sapiens_merged/115_GRCh38 \
          --output-dir /path/to/115_GRCh38_merged --chrom chr1 \
-         [--cache-source-type merged] [--partitions 8] [--overwrite]"
+         --cache-version 115 [--cache-source-type merged] [--partitions 8] [--overwrite]"
     );
 }

--- a/datafusion/bio-function-vep/src/allele.rs
+++ b/datafusion/bio-function-vep/src/allele.rs
@@ -130,9 +130,12 @@ pub fn trim_sequences_ensembl(
 /// - Ensembl Variation `get_matched_variant_alleles()`
 ///   <https://github.com/Ensembl/ensembl-variation/blob/23c76f60b1592e4df86159cf5530bdc326120c3d/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm#L1098-L1258>
 ///
-/// Upstream matched-allele comparison reverse-complements parser alleles when
-/// the compared features are on opposite strands before sequence trimming.
-fn reverse_complement_ascii(seq: &str) -> Option<String> {
+/// Reverse-complement a VEP allele, preserving the `-` empty-allele sentinel.
+///
+/// Ensembl's `reverse_comp()` accepts the standard IUPAC ambiguity symbols in
+/// addition to A/C/G/T/N. Returning uppercase also mirrors the cache and VCF
+/// allele representation used by VEP's clinical-significance matcher.
+pub(crate) fn reverse_complement_allele(seq: &str) -> Option<String> {
     let mut out = String::with_capacity(seq.len());
     for b in seq.as_bytes().iter().rev() {
         out.push(match b.to_ascii_uppercase() {
@@ -140,6 +143,16 @@ fn reverse_complement_ascii(seq: &str) -> Option<String> {
             b'C' => 'G',
             b'G' => 'C',
             b'T' => 'A',
+            b'R' => 'Y',
+            b'Y' => 'R',
+            b'M' => 'K',
+            b'K' => 'M',
+            b'S' => 'S',
+            b'W' => 'W',
+            b'B' => 'V',
+            b'V' => 'B',
+            b'D' => 'H',
+            b'H' => 'D',
             b'N' => 'N',
             b'-' => '-',
             _ => return None,
@@ -203,7 +216,7 @@ pub fn get_matched_variant_alleles(
 
     let mut a_ref = a_ref_raw.to_string();
     if a.strand != b.strand {
-        let Some(reverse_ref) = reverse_complement_ascii(&a_ref) else {
+        let Some(reverse_ref) = reverse_complement_allele(&a_ref) else {
             return Vec::new();
         };
         a_ref = reverse_ref;
@@ -213,7 +226,7 @@ pub fn get_matched_variant_alleles(
     for (a_index, orig_a_alt) in a_alts_raw.iter().enumerate() {
         let mut a_alt = (*orig_a_alt).to_string();
         if a.strand != b.strand {
-            let Some(reverse_alt) = reverse_complement_ascii(&a_alt) else {
+            let Some(reverse_alt) = reverse_complement_allele(&a_alt) else {
                 return Vec::new();
             };
             a_alt = reverse_alt;
@@ -866,6 +879,20 @@ fn vep_norm_coord_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reverse_complement_allele_supports_vep_iupac_and_gap() {
+        assert_eq!(
+            reverse_complement_allele("ACGTRYMKSWBDHVN-"),
+            Some("-NBDHVWSMKRYACGT".to_string())
+        );
+        assert_eq!(
+            reverse_complement_allele("ggagga"),
+            Some("TCCTCC".to_string())
+        );
+        assert_eq!(reverse_complement_allele(""), Some(String::new()));
+        assert_eq!(reverse_complement_allele("X"), None);
+    }
 
     #[test]
     fn test_snv_conversion() {

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9068,16 +9068,7 @@ async fn load_contig_context(
         cache,
         "motif",
         chrom,
-        &[
-            "motif_id",
-            "feature_id",
-            "chrom",
-            "start",
-            "\"end\"",
-            "binding_matrix",
-            "transcription_factors",
-            "strand",
-        ],
+        &["motif_id", "feature_id", "chrom", "start", "\"end\""],
     )
     .await?;
     record_contig_profile(profile, |profile| {

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -176,7 +176,8 @@ use std::borrow::Cow;
 use std::fmt::Write;
 
 use crate::allele::{
-    MatchedVariantAllele, vcf_to_vep_allele, vcf_to_vep_input_allele, vep_norm_end, vep_norm_start,
+    MatchedVariantAllele, reverse_complement_allele, vcf_to_vep_allele, vcf_to_vep_input_allele,
+    vep_norm_end, vep_norm_start,
 };
 use crate::annotation_store::AnnotationBackend;
 use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
@@ -863,6 +864,7 @@ pub fn cache_lookup_column_names() -> Vec<&'static str> {
         // Clinical
         "clin_sig",
         "clin_sig_allele",
+        "clin_sig_ref_allele",
         "clinical_impact",
         "phenotype_or_disease",
         "pubmed",
@@ -1604,6 +1606,7 @@ struct ColocatedEntry {
     pheno: i64,
     clin_sig: Option<String>,
     clin_sig_allele: Option<String>,
+    clin_sig_ref_allele: Option<String>,
     pubmed: Option<String>,
     /// Zero-copy AF columns (shared by `Arc` from the source cache batch) +
     /// this entry's row. Same column order as `AF_COL_NAMES` / `AF_COLUMNS`.
@@ -1881,6 +1884,7 @@ impl ColocatedData {
         &self,
         output_allele: &str,
         output_allele_unshifted: Option<&str>,
+        live_ref_allele: &str,
         include_pubmed: bool,
     ) -> ColocatedVariantFields {
         let mut fields = ColocatedVariantFields::default();
@@ -1906,10 +1910,27 @@ impl ColocatedData {
             }
 
             if let Some(clin_sig_allele) = &entry.clin_sig_allele {
+                let reverse_labels =
+                    entry
+                        .clin_sig_ref_allele
+                        .as_deref()
+                        .is_some_and(|cached_ref| {
+                            !cached_ref.is_empty() && cached_ref != live_ref_allele
+                        });
                 allele_terms.clear();
                 for chunk in clin_sig_allele.split(';') {
                     let Some((allele, value)) = chunk.split_once(':') else {
                         continue;
+                    };
+                    let transformed_allele;
+                    let allele = if reverse_labels {
+                        let Some(reverse) = reverse_complement_allele(allele) else {
+                            continue;
+                        };
+                        transformed_allele = reverse;
+                        transformed_allele.as_str()
+                    } else {
+                        allele
                     };
                     let slot = allele_terms.entry(allele.to_string()).or_default();
                     if !slot.is_empty() {
@@ -2161,6 +2182,9 @@ fn build_colocated_map_from_sink(
                         existing.matched_alleles.push(matched.clone());
                     }
                 }
+                if existing.clin_sig_ref_allele.is_none() {
+                    existing.clin_sig_ref_allele = ce.clin_sig_ref_allele.clone();
+                }
                 continue;
             }
             seen.insert(ce.variation_name.clone(), entries.len());
@@ -2172,6 +2196,7 @@ fn build_colocated_map_from_sink(
                 pheno: ce.pheno,
                 clin_sig: ce.clin_sig.clone(),
                 clin_sig_allele: ce.clin_sig_allele.clone(),
+                clin_sig_ref_allele: ce.clin_sig_ref_allele.clone(),
                 pubmed: ce.pubmed.clone(),
                 // Arc ref-count bump — no AF string data copied (was a deep Vec<String> clone).
                 af: ce.af.clone(),
@@ -5177,7 +5202,7 @@ impl AnnotateProvider {
         &self,
         state: &dyn Session,
         projection: Option<&Vec<usize>>,
-        requested_columns: &[&str],
+        preferred_columns: &[&str],
         extended_probes: bool,
         cache: PartitionedAnnotationCache,
         translations_sift_table: Option<&str>,
@@ -5255,6 +5280,25 @@ impl AnnotateProvider {
             .filter(|c| cache_chroms.contains(c.as_str()))
             .cloned()
             .collect();
+        let first_contig = contigs.first().ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): none of the VCF's data-bearing contigs have a \
+                 variation shard in cache '{}'",
+                cache.base_dir().display()
+            ))
+        })?;
+        #[cfg(feature = "parquet-cache")]
+        let first_identity = cache.validate_contig_identity(first_contig).await?;
+        #[cfg(feature = "parquet-cache")]
+        if first_identity.source_type != self.cache_source_type {
+            return Err(DataFusionError::Execution(format!(
+                "annotate_vep(): cache source identity differs between the eagerly \
+                 resolved provider schema ({}) and requested contig '{}' ({})",
+                self.cache_source_type.as_str(),
+                first_contig,
+                first_identity.source_type.as_str()
+            )));
+        }
         profile_end!(
             "0. discover_contigs",
             t_contigs,
@@ -5266,7 +5310,31 @@ impl AnnotateProvider {
             )
         );
 
-        let cache_columns: Vec<String> = requested_columns.iter().map(|s| s.to_string()).collect();
+        // Inspect the first *requested* contig for optional variation columns.
+        // This replaces the old arbitrary-manifest-first schema sample.
+        #[cfg(feature = "parquet-cache")]
+        let available_cache_columns: HashSet<String> =
+            {
+                let path = cache.as_parquet().variation_path(first_contig).ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "Parquet cache has no variation shard for requested contig {first_contig}"
+                ))
+            })?;
+                read_parquet_dataset_schema(&path)
+                    .await?
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().clone())
+                    .collect()
+            };
+        #[cfg(not(feature = "parquet-cache"))]
+        let available_cache_columns: HashSet<String> = HashSet::new();
+        let cache_columns: Vec<String> = preferred_columns
+            .iter()
+            .copied()
+            .filter(|name| available_cache_columns.contains(*name))
+            .map(ToString::to_string)
+            .collect();
         let projected_schema = if let Some(indices) = projection {
             Arc::new(self.schema.project(indices)?)
         } else {
@@ -5288,6 +5356,10 @@ impl AnnotateProvider {
             flags,
             hgvs_flags,
             cache_source_type: self.cache_source_type,
+            #[cfg(feature = "parquet-cache")]
+            vep_semantics: first_identity.target.semantics,
+            #[cfg(not(feature = "parquet-cache"))]
+            vep_semantics: crate::vep_semantics::VepSemantics::V115,
             transcript_selection,
             pick_flags,
             allowed_failed,
@@ -5696,6 +5768,7 @@ impl AnnotateProvider {
                     data.variant_fields(
                         &vep_allele,
                         data.variant_match_output_allele(&vep_allele),
+                        &ref_al,
                         flags.pubmed,
                     )
                 } else {
@@ -8505,6 +8578,7 @@ struct ContigAnnotationConfig {
     flags: VepFlags,
     hgvs_flags: HgvsFlags,
     cache_source_type: CacheSourceType,
+    vep_semantics: crate::vep_semantics::VepSemantics,
     transcript_selection: TranscriptSelectionFlags,
     allowed_failed: i64,
     reference_fasta_path: Option<String>,
@@ -8547,14 +8621,17 @@ enum PartitionedAnnotationCache {
     // handle's base dir. (A single variant keeps the type uninhabited — and all
     // methods trivially valid — when the cache feature is disabled.)
     #[cfg(feature = "parquet-cache")]
-    Parquet(crate::parquet_cache::detect::PartitionedParquetCache),
+    Parquet {
+        cache: crate::parquet_cache::detect::PartitionedParquetCache,
+        identity_validator: Arc<crate::cache_identity::LazyCacheIdentityValidator>,
+    },
 }
 
 impl PartitionedAnnotationCache {
     fn available_chroms(&self) -> Vec<String> {
         match self {
             #[cfg(feature = "parquet-cache")]
-            Self::Parquet(variation) => variation
+            Self::Parquet { cache, .. } => cache
                 .available_chroms()
                 .into_iter()
                 .map(ToString::to_string)
@@ -8565,7 +8642,7 @@ impl PartitionedAnnotationCache {
     fn base_dir(&self) -> &std::path::Path {
         match self {
             #[cfg(feature = "parquet-cache")]
-            Self::Parquet(variation) => variation.base_dir(),
+            Self::Parquet { cache, .. } => cache.base_dir(),
         }
     }
 
@@ -8573,7 +8650,20 @@ impl PartitionedAnnotationCache {
     #[cfg(feature = "parquet-cache")]
     fn as_parquet(&self) -> &crate::parquet_cache::detect::PartitionedParquetCache {
         match self {
-            Self::Parquet(variation) => variation,
+            Self::Parquet { cache, .. } => cache,
+        }
+    }
+
+    #[cfg(feature = "parquet-cache")]
+    async fn validate_contig_identity(
+        &self,
+        chrom: &str,
+    ) -> Result<crate::cache_identity::CacheIdentity> {
+        match self {
+            Self::Parquet {
+                cache,
+                identity_validator,
+            } => identity_validator.validate_contig(cache, chrom).await,
         }
     }
 }
@@ -12387,7 +12477,7 @@ async fn prepare_contig_context(
     session: Arc<SessionContext>,
     cache: Arc<PartitionedAnnotationCache>,
     chrom: String,
-    config: ContigAnnotationConfig,
+    mut config: ContigAnnotationConfig,
     full_schema: SchemaRef,
 ) -> Result<Option<ContigReadyState>> {
     let t_contig = profile_start!();
@@ -12398,6 +12488,22 @@ async fn prepare_contig_context(
     let profile_handle = pipeline_profile.clone();
     if profiling_enabled() {
         eprintln!("[VEP_PROFILE] ------ contig {chrom} START ------");
+    }
+
+    // Identity is a contig-local precondition: validate every participating
+    // shard footer before opening variation or context data for this contig.
+    #[cfg(feature = "parquet-cache")]
+    {
+        let identity = cache.validate_contig_identity(&chrom).await?;
+        if identity.source_type != config.cache_source_type {
+            return Err(DataFusionError::Execution(format!(
+                "annotate_vep(): cache source identity changed at contig '{chrom}': \
+                 provider source={}, contig source={}",
+                config.cache_source_type.as_str(),
+                identity.source_type.as_str()
+            )));
+        }
+        config.vep_semantics = identity.target.semantics;
     }
 
     // Derive VCF-only schema.
@@ -12631,10 +12737,11 @@ async fn prepare_contig_context(
         config.options_json.clone(),
         vcf_only_schema,
     )?;
-    let engine = TranscriptConsequenceEngine::new_with_hgvs_shift(
+    let engine = TranscriptConsequenceEngine::new_with_hgvs_shift_and_semantics(
         config.upstream_distance,
         config.downstream_distance,
         config.hgvs_flags.shift_hgvs,
+        config.vep_semantics,
     );
 
     // SIFT source: a shared per-contig prediction store loaded from the Parquet
@@ -12835,9 +12942,19 @@ impl TableProvider for AnnotateProvider {
 
         #[cfg(feature = "parquet-cache")]
         let partitioned_annotation_cache = if partitioned_opt != Some(false) {
+            let expected_cache_version = self
+                .options_json
+                .as_deref()
+                .and_then(|opts| Self::parse_json_string_option(opts, "expected_cache_version"));
+            let identity_validator = Arc::new(
+                crate::cache_identity::LazyCacheIdentityValidator::new(expected_cache_version)?,
+            );
             match crate::parquet_cache::detect::PartitionedParquetCache::detect(&self.cache_source)
             {
-                Some(variation) => Some(PartitionedAnnotationCache::Parquet(variation)),
+                Some(cache) => Some(PartitionedAnnotationCache::Parquet {
+                    cache,
+                    identity_validator,
+                }),
                 None => {
                     return Err(DataFusionError::Plan(format!(
                         "annotate_vep(): a 'variation/' cache layout is required at '{}'",
@@ -12864,27 +12981,6 @@ impl TableProvider for AnnotateProvider {
                 );
             }
 
-            // Read available variation columns from a sample Parquet shard.
-            #[cfg(feature = "parquet-cache")]
-            let available_cache_columns: HashSet<String> = {
-                let sample_chrom = &available_chroms[0];
-                let sample_path = cache.as_parquet().variation_path(sample_chrom).ok_or_else(
-                    || {
-                        DataFusionError::Execution(format!(
-                            "Parquet cache has no variation shard for sample chrom {sample_chrom}"
-                        ))
-                    },
-                )?;
-                let cache_schema = read_parquet_dataset_schema(&sample_path).await?;
-                cache_schema
-                    .fields()
-                    .iter()
-                    .map(|f| f.name().clone())
-                    .collect()
-            };
-            #[cfg(not(feature = "parquet-cache"))]
-            let available_cache_columns: HashSet<String> = HashSet::new();
-
             let mut preferred_columns = vec!["consequence_types", "most_severe_consequence"];
             for c in cache_lookup_column_names() {
                 if !preferred_columns.contains(&c) {
@@ -12910,12 +13006,7 @@ impl TableProvider for AnnotateProvider {
                     },
                 }
             };
-            let requested_columns: Vec<&str> = preferred_columns
-                .iter()
-                .copied()
-                .filter(|name| available_cache_columns.contains(*name))
-                .filter(|name| cache_only_selected(name))
-                .collect();
+            preferred_columns.retain(|name| cache_only_selected(name));
 
             let extended_probes = self
                 .options_json
@@ -12932,7 +13023,7 @@ impl TableProvider for AnnotateProvider {
                 .scan_with_transcript_engine_partitioned(
                     state,
                     projection,
-                    &requested_columns,
+                    &preferred_columns,
                     extended_probes,
                     cache,
                     translations_sift_table.as_deref(),
@@ -13082,6 +13173,7 @@ mod tests {
             pheno: 0,
             clin_sig: None,
             clin_sig_allele: None,
+            clin_sig_ref_allele: None,
             pubmed: None,
             af: af.clone(),
             af_row: 0,
@@ -13130,6 +13222,7 @@ mod tests {
                 pheno: 0,
                 clin_sig: None,
                 clin_sig_allele: None,
+                clin_sig_ref_allele: None,
                 pubmed: None,
                 af,
                 af_row: 0,
@@ -13139,7 +13232,8 @@ mod tests {
         };
         let flags = VepFlags::from_options_json(Some("{\"everything\":true}"));
 
-        let variant_fields = data.variant_fields("-", data.variant_match_output_allele("-"), false);
+        let variant_fields =
+            data.variant_fields("-", data.variant_match_output_allele("-"), "A", false);
         assert_eq!(variant_fields.existing_variation, "rs34467003");
 
         let frequency_fields =
@@ -13152,6 +13246,89 @@ mod tests {
         );
         assert!(frequency_fields.max_af.is_empty());
         assert!(frequency_fields.max_af_pops.is_empty());
+    }
+
+    fn clinical_colocated_data(
+        count: usize,
+        labelled_allele: &str,
+        significance: &str,
+        cached_ref: Option<&str>,
+    ) -> ColocatedData {
+        let af = AfColumns::new(
+            (0..AF_COLUMNS.len())
+                .map(|_| Arc::new(StringArray::from(vec![""])) as Arc<dyn Array>)
+                .collect(),
+        );
+        let entries = (0..count)
+            .map(|index| ColocatedEntry {
+                variation_name: format!("clinvar_{index}"),
+                allele_string: String::new(),
+                matched_alleles: Vec::new(),
+                somatic: 0,
+                pheno: 0,
+                clin_sig: None,
+                clin_sig_allele: Some(format!("{labelled_allele}:{significance}")),
+                clin_sig_ref_allele: cached_ref.map(ToString::to_string),
+                pubmed: None,
+                af: af.clone(),
+                af_row: 0,
+            })
+            .collect();
+        ColocatedData {
+            entries,
+            compare_output_allele: None,
+            unshifted_output_allele: None,
+        }
+    }
+
+    #[test]
+    fn clinvar_116_chr3_strand_flip_removes_41_false_matches() {
+        let data = clinical_colocated_data(41, "GGAGGA", "benign", Some("AGG"));
+        assert_eq!(data.entries.len(), 41);
+        let fields = data.variant_fields("GGAGGA", None, "C", false);
+        assert_eq!(fields.clin_sig, "");
+    }
+
+    #[test]
+    fn clinvar_116_chr15_strand_flip_removes_63_false_matches() {
+        let data = clinical_colocated_data(
+            63,
+            "TGC",
+            "conflicting_interpretations_of_pathogenicity",
+            Some("TGC"),
+        );
+        assert_eq!(data.entries.len(), 63);
+        let fields = data.variant_fields("TGC", None, "T", false);
+        assert_eq!(fields.clin_sig, "");
+    }
+
+    #[test]
+    fn clinvar_116_chr14_strand_flip_restores_8_benign_matches() {
+        let data = clinical_colocated_data(8, "ATGCGCGC", "benign", Some("ATGCGCGC"));
+        assert_eq!(data.entries.len(), 8);
+        let fields = data.variant_fields("GCGCGCAT", None, "C", false);
+        assert_eq!(fields.clin_sig, "benign");
+    }
+
+    #[test]
+    fn clinvar_absent_or_matching_reference_preserves_115_label_matching() {
+        let absent = clinical_colocated_data(1, "GGAGGA", "benign", None);
+        assert_eq!(
+            absent.variant_fields("GGAGGA", None, "C", false).clin_sig,
+            "benign"
+        );
+
+        let matching = clinical_colocated_data(1, "GGAGGA", "benign", Some("C"));
+        assert_eq!(
+            matching.variant_fields("GGAGGA", None, "C", false).clin_sig,
+            "benign"
+        );
+
+        let empty = clinical_colocated_data(1, "GGAGGA", "benign", Some(""));
+        assert_eq!(
+            empty.variant_fields("GGAGGA", None, "C", false).clin_sig,
+            "benign"
+        );
     }
 
     #[cfg(feature = "parquet-cache")]
@@ -13202,6 +13379,7 @@ mod tests {
             flags: VepFlags::from_options_json(None),
             hgvs_flags: HgvsFlags::default(),
             cache_source_type: CacheSourceType::Ensembl,
+            vep_semantics: crate::vep_semantics::VepSemantics::V115,
             transcript_selection: TranscriptSelectionFlags::default(),
             allowed_failed: 0,
             reference_fasta_path: None,

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -6002,6 +6002,7 @@ impl AnnotateProvider {
                             strand_str
                         };
                         let motif_name = tc.motif_name.as_deref().unwrap_or("");
+                        let motif_pos = OptDisplay(tc.motif_pos);
                         let motif_tfs = csq_multi_value(
                             tc.motif_transcription_factors.as_deref().unwrap_or(""),
                         );
@@ -6252,7 +6253,7 @@ impl AnnotateProvider {
                                 "|{gene_pheno}|\
                              {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
                              {hgvs_offset}|\
-                             {batch3_suffix}|{motif_name}||||{motif_tfs}"
+                             {batch3_suffix}|{motif_name}|{motif_pos}|||{motif_tfs}"
                             );
                         } else {
                             // 74-field CSQ base layout, with optional PICK and RefSeq fields.

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -4336,7 +4336,16 @@ impl AnnotateProvider {
         let cols = Self::projected_columns_for_table(
             &self.session,
             table,
-            &["motif_id", "feature_id", "chrom", "start", "\"end\""],
+            &[
+                "motif_id",
+                "feature_id",
+                "chrom",
+                "start",
+                "\"end\"",
+                "binding_matrix",
+                "transcription_factors",
+                "strand",
+            ],
         )
         .await;
         let query = format!("SELECT {cols} FROM `{table}`{filter}");
@@ -4364,6 +4373,11 @@ impl AnnotateProvider {
                     "annotate_vep(): motif table '{table}' is missing required column end"
                 ))
             })?;
+            // Optional: absent on caches built before the BindingMatrix
+            // extraction fix, in which case these CSQ fields stay empty.
+            let matrix_idx = schema.index_of("binding_matrix").ok();
+            let tf_idx = schema.index_of("transcription_factors").ok();
+            let strand_idx = schema.index_of("strand").ok();
 
             for row in 0..batch.num_rows() {
                 let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
@@ -4378,11 +4392,21 @@ impl AnnotateProvider {
                 let motif_id = id_idx
                     .and_then(|idx| string_at(batch.column(idx).as_ref(), row))
                     .unwrap_or_else(|| "motif".to_string());
+                let binding_matrix =
+                    matrix_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
+                let transcription_factors =
+                    tf_idx.and_then(|idx| string_at(batch.column(idx).as_ref(), row));
+                let strand = strand_idx
+                    .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
+                    .map(|v| v as i8);
                 out.push(MotifFeature {
                     motif_id,
                     chrom,
                     start,
                     end,
+                    binding_matrix,
+                    transcription_factors,
+                    strand,
                 });
             }
         }
@@ -4853,6 +4877,11 @@ impl AnnotateProvider {
                     "annotate_vep(): motif table '{table}' is missing required column end"
                 ))
             })?;
+            // Optional: absent on caches built before the BindingMatrix
+            // extraction fix, in which case these CSQ fields stay empty.
+            let matrix_idx = schema.index_of("binding_matrix").ok();
+            let tf_idx = schema.index_of("transcription_factors").ok();
+            let strand_idx = schema.index_of("strand").ok();
             for row in 0..batch.num_rows() {
                 let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
                     continue;
@@ -4870,6 +4899,13 @@ impl AnnotateProvider {
                     chrom,
                     start,
                     end,
+                    binding_matrix: matrix_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
+                    transcription_factors: tf_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
+                    strand: strand_idx
+                        .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
+                        .map(|v| v as i8),
                 });
             }
         }
@@ -5945,6 +5981,19 @@ impl AnnotateProvider {
                             } else {
                                 ("", "", "", "", "", "", "")
                             };
+                        // MotifFeature consequences have no transcript to take
+                        // orientation from; use the motif's own strand.
+                        let strand_str = if strand_str.is_empty() {
+                            match tc.motif_strand {
+                                Some(v) if v >= 0 => "1",
+                                Some(_) => "-1",
+                                None => "",
+                            }
+                        } else {
+                            strand_str
+                        };
+                        let motif_name = tc.motif_name.as_deref().unwrap_or("");
+                        let motif_tfs = tc.motif_transcription_factors.as_deref().unwrap_or("");
                         let biotype = tc.biotype_override.as_deref().unwrap_or(biotype_tx);
                         let exon = tc.exon_str.as_deref().unwrap_or("");
                         let intron = tc.intron_str.as_deref().unwrap_or("");
@@ -6192,7 +6241,7 @@ impl AnnotateProvider {
                                 "|{gene_pheno}|\
                              {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
                              {hgvs_offset}|\
-                             {batch3_suffix}|||||"
+                             {batch3_suffix}|{motif_name}||||{motif_tfs}"
                             );
                         } else {
                             // 74-field CSQ base layout, with optional PICK and RefSeq fields.
@@ -15250,6 +15299,8 @@ mod tests {
         assert_eq!(merged_values[merged_index("VARIANT_CLASS")], "SNV");
         assert_eq!(merged_values[merged_index("CLIN_SIG")], "pathogenic");
         assert_eq!(merged_values[merged_index("PUBMED")], "12345");
+        // Transcript consequences carry no motif metadata; motif entries are
+        // covered by the MotifFeature tests in transcript_consequence.rs.
         assert_eq!(merged_values[merged_index("MOTIF_NAME")], "");
         assert_eq!(merged_values[merged_index("TRANSCRIPTION_FACTORS")], "");
     }

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -4355,6 +4355,9 @@ impl AnnotateProvider {
                 "transcription_factors",
                 "strand",
                 "binding_matrix_length",
+                "binding_matrix_elements",
+                "binding_matrix_unit",
+                "motif_seq",
             ],
         )
         .await;
@@ -4389,6 +4392,9 @@ impl AnnotateProvider {
             let tf_idx = schema.index_of("transcription_factors").ok();
             let strand_idx = schema.index_of("strand").ok();
             let matrix_len_idx = schema.index_of("binding_matrix_length").ok();
+            let matrix_elements_idx = schema.index_of("binding_matrix_elements").ok();
+            let matrix_unit_idx = schema.index_of("binding_matrix_unit").ok();
+            let motif_seq_idx = schema.index_of("motif_seq").ok();
 
             for row in 0..batch.num_rows() {
                 let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
@@ -4421,6 +4427,12 @@ impl AnnotateProvider {
                     binding_matrix_length: matrix_len_idx
                         .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
                         .map(|v| v as i32),
+                    binding_matrix_elements: matrix_elements_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
+                    binding_matrix_unit: matrix_unit_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
+                    motif_seq: motif_seq_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
                 });
             }
         }
@@ -4897,6 +4909,9 @@ impl AnnotateProvider {
             let tf_idx = schema.index_of("transcription_factors").ok();
             let strand_idx = schema.index_of("strand").ok();
             let matrix_len_idx = schema.index_of("binding_matrix_length").ok();
+            let matrix_elements_idx = schema.index_of("binding_matrix_elements").ok();
+            let matrix_unit_idx = schema.index_of("binding_matrix_unit").ok();
+            let motif_seq_idx = schema.index_of("motif_seq").ok();
             for row in 0..batch.num_rows() {
                 let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
                     continue;
@@ -4924,6 +4939,12 @@ impl AnnotateProvider {
                     binding_matrix_length: matrix_len_idx
                         .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
                         .map(|v| v as i32),
+                    binding_matrix_elements: matrix_elements_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
+                    binding_matrix_unit: matrix_unit_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
+                    motif_seq: motif_seq_idx
+                        .and_then(|idx| string_at(batch.column(idx).as_ref(), row)),
                 });
             }
         }
@@ -6012,6 +6033,12 @@ impl AnnotateProvider {
                         };
                         let motif_name = tc.motif_name.as_deref().unwrap_or("");
                         let motif_pos = OptDisplay(tc.motif_pos);
+                        let high_inf_pos = match tc.high_inf_pos {
+                            Some(true) => "Y",
+                            Some(false) => "N",
+                            None => "",
+                        };
+                        let motif_score_change = tc.motif_score_change.as_deref().unwrap_or("");
                         let motif_tfs = csq_multi_value(
                             tc.motif_transcription_factors.as_deref().unwrap_or(""),
                         );
@@ -6262,7 +6289,7 @@ impl AnnotateProvider {
                                 "|{gene_pheno}|\
                              {sift_str}|{polyphen_str}|{domains}|{mirna_str}|\
                              {hgvs_offset}|\
-                             {batch3_suffix}|{motif_name}|{motif_pos}|||{motif_tfs}"
+                             {batch3_suffix}|{motif_name}|{motif_pos}|{high_inf_pos}|{motif_score_change}|{motif_tfs}"
                             );
                         } else {
                             // 74-field CSQ base layout, with optional PICK and RefSeq fields.
@@ -9098,6 +9125,10 @@ async fn load_contig_context(
             "binding_matrix",
             "transcription_factors",
             "strand",
+            "binding_matrix_length",
+            "binding_matrix_elements",
+            "binding_matrix_unit",
+            "motif_seq",
         ],
     )
     .await?;

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9068,7 +9068,16 @@ async fn load_contig_context(
         cache,
         "motif",
         chrom,
-        &["motif_id", "feature_id", "chrom", "start", "\"end\""],
+        &[
+            "motif_id",
+            "feature_id",
+            "chrom",
+            "start",
+            "\"end\"",
+            "binding_matrix",
+            "transcription_factors",
+            "strand",
+        ],
     )
     .await?;
     record_contig_profile(profile, |profile| {

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -4354,6 +4354,7 @@ impl AnnotateProvider {
                 "binding_matrix",
                 "transcription_factors",
                 "strand",
+                "binding_matrix_length",
             ],
         )
         .await;
@@ -4387,6 +4388,7 @@ impl AnnotateProvider {
             let matrix_idx = schema.index_of("binding_matrix").ok();
             let tf_idx = schema.index_of("transcription_factors").ok();
             let strand_idx = schema.index_of("strand").ok();
+            let matrix_len_idx = schema.index_of("binding_matrix_length").ok();
 
             for row in 0..batch.num_rows() {
                 let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
@@ -4416,6 +4418,9 @@ impl AnnotateProvider {
                     binding_matrix,
                     transcription_factors,
                     strand,
+                    binding_matrix_length: matrix_len_idx
+                        .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
+                        .map(|v| v as i32),
                 });
             }
         }
@@ -4891,6 +4896,7 @@ impl AnnotateProvider {
             let matrix_idx = schema.index_of("binding_matrix").ok();
             let tf_idx = schema.index_of("transcription_factors").ok();
             let strand_idx = schema.index_of("strand").ok();
+            let matrix_len_idx = schema.index_of("binding_matrix_length").ok();
             for row in 0..batch.num_rows() {
                 let Some(chrom) = string_at(batch.column(chrom_idx).as_ref(), row) else {
                     continue;
@@ -4915,6 +4921,9 @@ impl AnnotateProvider {
                     strand: strand_idx
                         .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
                         .map(|v| v as i8),
+                    binding_matrix_length: matrix_len_idx
+                        .and_then(|idx| int64_at(batch.column(idx).as_ref(), row))
+                        .map(|v| v as i32),
                 });
             }
         }

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -2235,6 +2235,15 @@ fn merge_colocated_delta(
 /// array separators become `&`, semicolons are percent-encoded, spaces become
 /// underscores, pipes become `&`, and `-` is serialized as an empty field.
 #[inline]
+/// Renders a multi-valued CSQ sub-field.
+///
+/// The cache joins list values with `,`, but `,` separates whole CSQ *entries*,
+/// so emitting them raw splits one entry into several. Ensembl VEP joins
+/// multi-valued sub-fields with `&` (e.g. `TRANSCRIPTION_FACTORS=FOS&ATF7&JUN`).
+fn csq_multi_value(raw: &str) -> String {
+    raw.replace(',', "&")
+}
+
 fn csq_escape(val: &str) -> std::borrow::Cow<'_, str> {
     if val == "-" {
         return std::borrow::Cow::Borrowed("");
@@ -5993,7 +6002,9 @@ impl AnnotateProvider {
                             strand_str
                         };
                         let motif_name = tc.motif_name.as_deref().unwrap_or("");
-                        let motif_tfs = tc.motif_transcription_factors.as_deref().unwrap_or("");
+                        let motif_tfs = csq_multi_value(
+                            tc.motif_transcription_factors.as_deref().unwrap_or(""),
+                        );
                         let biotype = tc.biotype_override.as_deref().unwrap_or(biotype_tx);
                         let exon = tc.exon_str.as_deref().unwrap_or("");
                         let intron = tc.intron_str.as_deref().unwrap_or("");
@@ -9068,7 +9079,16 @@ async fn load_contig_context(
         cache,
         "motif",
         chrom,
-        &["motif_id", "feature_id", "chrom", "start", "\"end\""],
+        &[
+            "motif_id",
+            "feature_id",
+            "chrom",
+            "start",
+            "\"end\"",
+            "binding_matrix",
+            "transcription_factors",
+            "strand",
+        ],
     )
     .await?;
     record_contig_profile(profile, |profile| {
@@ -16135,5 +16155,14 @@ mod tests {
         assert!(line.contains("engine=0.013s"));
         assert!(line.contains("projection=0.014s"));
         assert!(line.contains("input_buffers=15"));
+    }
+
+    #[test]
+    fn csq_multi_value_uses_ampersand_like_vep() {
+        // Ensembl VEP 116 emits TRANSCRIPTION_FACTORS=FOS&ATF7&JUN; the cache
+        // stores FOS,ATF7,JUN. A raw comma would split the CSQ entry.
+        assert_eq!(csq_multi_value("FOS,ATF7,JUN"), "FOS&ATF7&JUN");
+        assert_eq!(csq_multi_value("CTCF"), "CTCF");
+        assert_eq!(csq_multi_value(""), "");
     }
 }

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -14,6 +14,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::io::{BufRead, Seek};
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context as TaskCtx, Poll};
@@ -164,6 +165,7 @@ use datafusion::datasource::{MemTable, TableProvider, TableType};
 use datafusion::execution::{RecordBatchStream, SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::EquivalenceProperties;
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlanProperties, PlanProperties,
@@ -5275,18 +5277,19 @@ impl AnnotateProvider {
         for c in &available_chroms {
             cache_chroms.extend(crate::cache::manifest::contig_alias_set(c));
         }
-        let contigs: Vec<String> = vcf_contigs
-            .iter()
-            .filter(|c| cache_chroms.contains(c.as_str()))
-            .cloned()
-            .collect();
-        let first_contig = contigs.first().ok_or_else(|| {
-            DataFusionError::Execution(format!(
-                "annotate_vep(): none of the VCF's data-bearing contigs have a \
-                 variation shard in cache '{}'",
-                cache.base_dir().display()
-            ))
-        })?;
+        let contigs = select_cache_backed_contigs(&vcf_contigs, &cache_chroms, cache.base_dir())?;
+        let projected_schema = if let Some(indices) = projection {
+            Arc::new(self.schema.project(indices)?)
+        } else {
+            self.schema.clone()
+        };
+        if contigs.is_empty() {
+            // An empty VCF is a valid input. No cache shard participates, so
+            // preserve lazy identity validation and return the projected empty
+            // result without selecting an arbitrary shard for schema/identity.
+            return Ok(Arc::new(EmptyExec::new(projected_schema)));
+        }
+        let first_contig = &contigs[0];
         #[cfg(feature = "parquet-cache")]
         let first_identity = cache.validate_contig_identity(first_contig).await?;
         #[cfg(feature = "parquet-cache")]
@@ -5335,11 +5338,6 @@ impl AnnotateProvider {
             .filter(|name| available_cache_columns.contains(*name))
             .map(ToString::to_string)
             .collect();
-        let projected_schema = if let Some(indices) = projection {
-            Arc::new(self.schema.project(indices)?)
-        } else {
-            self.schema.clone()
-        };
         // The base dir holds the parquet.* shards; the variation exec is always
         // built via `new_parquet`.
         #[cfg(feature = "parquet-cache")]
@@ -8783,6 +8781,26 @@ impl ExecutionPlan for ContigAnnotationExec {
             self.config.clone(),
         )))
     }
+}
+
+fn select_cache_backed_contigs(
+    vcf_contigs: &[String],
+    cache_chroms: &HashSet<String>,
+    cache_root: &Path,
+) -> Result<Vec<String>> {
+    let contigs: Vec<String> = vcf_contigs
+        .iter()
+        .filter(|contig| cache_chroms.contains(contig.as_str()))
+        .cloned()
+        .collect();
+    if !vcf_contigs.is_empty() && contigs.is_empty() {
+        return Err(DataFusionError::Execution(format!(
+            "annotate_vep(): none of the VCF's data-bearing contigs have a \
+             variation shard in cache '{}'",
+            cache_root.display()
+        )));
+    }
+    Ok(contigs)
 }
 
 fn partition_contigs_for_execution(contigs: Vec<String>) -> Vec<Vec<String>> {
@@ -13066,6 +13084,25 @@ mod tests {
         // No progress → always park (waker armed), regardless of inflight.
         assert!(!may_yield_partial_buffer(false, false));
         assert!(!may_yield_partial_buffer(false, true));
+    }
+
+    #[test]
+    fn cache_contig_selection_preserves_empty_input_but_rejects_missing_shards() {
+        let cache_chroms = HashSet::from(["chr1".to_string()]);
+        assert_eq!(
+            select_cache_backed_contigs(&[], &cache_chroms, Path::new("/cache")).unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            select_cache_backed_contigs(&["chr1".to_string()], &cache_chroms, Path::new("/cache"))
+                .unwrap(),
+            vec!["chr1".to_string()]
+        );
+
+        let error =
+            select_cache_backed_contigs(&["chr2".to_string()], &cache_chroms, Path::new("/cache"))
+                .unwrap_err();
+        assert!(error.to_string().contains("none of the VCF"));
     }
 
     /// `colocated::AF_COL_NAMES` is maintained by hand alongside `AF_COLUMNS`

--- a/datafusion/bio-function-vep/src/cache/build.rs
+++ b/datafusion/bio-function-vep/src/cache/build.rs
@@ -28,8 +28,8 @@ use crate::cache::manifest::{
     CHROM_MANIFEST_FILE, ChromDatasetEntry, ChromManifest, canonical_chrom_label,
 };
 use crate::cache::schema::{
-    VARIATION_FORBIDDEN_COLUMNS, VARIATION_REQUIRED_COLUMNS, variation_projected_schema,
-    with_cache_source_metadata,
+    VARIATION_FORBIDDEN_COLUMNS, VARIATION_OPTIONAL_COLUMNS, VARIATION_REQUIRED_COLUMNS,
+    variation_projected_schema, with_cache_identity_metadata,
 };
 use crate::cache_builder::EntityStats;
 use crate::cache_common::{
@@ -59,6 +59,9 @@ pub struct CacheBuildOptions {
     pub output_dir: String,
     pub partitions: usize,
     pub cache_source_type: BioFormatsCacheSourceType,
+    /// Release independently established from the raw cache and validated
+    /// against the compiled vepyr support matrix before any shard is written.
+    pub cache_version: String,
     pub overwrite: bool,
     /// Optional allow-list of chromosomes to build (e.g. `["chr1"]`). Matched
     /// after stripping any `chr` prefix, so `"1"` and `"chr1"` are equivalent.
@@ -139,7 +142,12 @@ pub async fn build_parquet_variation_chrom(
     // Derive the output schema once from the source plan schema and reuse it for
     // every written batch so the shard carries one stable Arrow schema.
     let schema_plan = ctx.sql(&query).await?.create_physical_plan().await?;
-    let out_schema = variation_output_schema(schema_plan.schema().as_ref(), &source_type)?;
+    let projected = variation_output_schema(schema_plan.schema().as_ref(), &source_type)?;
+    let out_schema = Arc::new(with_cache_identity_metadata(
+        projected.as_ref(),
+        &source_type,
+        &options.cache_version,
+    ));
 
     let mut writer = VariationParquetShardWriter::create(&shard_path, Arc::clone(&out_schema))?;
     for &keep_tier in passes {
@@ -323,7 +331,12 @@ pub async fn build_parquet_translation_sift_chrom(
     let mut batches: Vec<RecordBatch> = Vec::new();
     while let Some(batch) = stream.next().await {
         let batch = drop_row_number_batch(batch?)?;
-        let out = transform_translation_sift_position_batch(batch, &source_type, &uid_map)?;
+        let out = transform_translation_sift_position_batch(
+            batch,
+            &source_type,
+            &options.cache_version,
+            &uid_map,
+        )?;
         if out.num_rows() > 0 {
             batches.push(out);
         }
@@ -450,17 +463,18 @@ pub async fn build_parquet_context_entity_chrom(
         provider_schema.as_deref(),
     );
     let source_type = options.cache_source_type.as_str().to_string();
+    let cache_version = options.cache_version.clone();
     let ctx = make_ctx_and_register(options, kind, table_name)?;
 
     let rows = if kind == EnsemblEntityKind::Transcript {
         let uid_map = Arc::new(load_transcript_uid_map(options, source_chrom).await?);
         write_query_stream_to_parquet(&ctx, &query, &shard_path, move |batch| {
-            attach_transcript_uid_batch(batch, &source_type, &uid_map)
+            attach_transcript_uid_batch(batch, &source_type, &cache_version, &uid_map)
         })
         .await?
     } else {
         write_query_stream_to_parquet(&ctx, &query, &shard_path, move |batch| {
-            attach_schema_metadata_to_batch(batch, &source_type)
+            attach_schema_metadata_to_batch(batch, &source_type, &cache_version)
         })
         .await?
     };
@@ -495,11 +509,12 @@ pub async fn build_parquet_translation_core_chrom(
 
     let target_schema = translation_core_schema(false, options.cache_source_type);
     let source_type = options.cache_source_type.as_str().to_string();
+    let cache_version = options.cache_version.clone();
     let ctx = make_ctx_and_register(options, EnsemblEntityKind::Translation, "tl")?;
     let rows = write_query_stream_to_parquet(&ctx, &query, &shard_path, move |batch| {
         let batch = drop_row_number_batch(batch)?;
         let batch = project_batch_to_schema(batch, Arc::clone(&target_schema))?;
-        attach_schema_metadata_to_batch(batch, &source_type)
+        attach_schema_metadata_to_batch(batch, &source_type, &cache_version)
     })
     .await?;
     Ok(ChromDatasetEntry::new(manifest_chrom, file_name, rows))
@@ -775,6 +790,13 @@ fn transform_variation_tier_batch(
         } else {
             columns.push(batch.column(index).clone());
         }
+        if *name == "clin_sig_allele" {
+            for optional_name in VARIATION_OPTIONAL_COLUMNS {
+                if let Some((optional_index, _)) = schema.column_with_name(optional_name) {
+                    columns.push(batch.column(optional_index).clone());
+                }
+            }
+        }
     }
 
     // Derive tier from the source `start` and build the keep mask in one pass.
@@ -813,8 +835,12 @@ fn transform_variation_tier_batch(
     })
 }
 
-fn attach_schema_metadata_to_batch(batch: RecordBatch, source_type: &str) -> Result<RecordBatch> {
-    let schema = with_cache_source_metadata(batch.schema().as_ref(), source_type);
+fn attach_schema_metadata_to_batch(
+    batch: RecordBatch,
+    source_type: &str,
+    cache_version: &str,
+) -> Result<RecordBatch> {
+    let schema = with_cache_identity_metadata(batch.schema().as_ref(), source_type, cache_version);
     RecordBatch::try_new(Arc::new(schema), batch.columns().to_vec()).map_err(|err| {
         DataFusionError::Execution(format!("failed to attach Lance schema metadata: {err}"))
     })
@@ -870,6 +896,7 @@ async fn load_transcript_uid_map(
 fn attach_transcript_uid_batch(
     batch: RecordBatch,
     source_type: &str,
+    cache_version: &str,
     uid_map: &HashMap<String, u32>,
 ) -> Result<RecordBatch> {
     let schema = batch.schema();
@@ -900,7 +927,10 @@ fn attach_transcript_uid_batch(
     let mut columns = batch.columns().to_vec();
     columns.push(Arc::new(UInt32Array::from(uids)) as ArrayRef);
 
-    let new_schema = with_cache_source_metadata(&Schema::new(fields), source_type);
+    let schema_with_upstream_metadata =
+        Schema::new_with_metadata(fields, schema.metadata().clone());
+    let new_schema =
+        with_cache_identity_metadata(&schema_with_upstream_metadata, source_type, cache_version);
     RecordBatch::try_new(Arc::new(new_schema), columns).map_err(|err| {
         DataFusionError::Execution(format!("failed to attach transcript_uid column: {err}"))
     })
@@ -909,11 +939,15 @@ fn attach_transcript_uid_batch(
 /// Position-sliced translation_sift schema: one row per `(transcript, position)`.
 /// `key = (transcript_uid << 32) | position`; small `sift`/`poly` payloads use
 /// miniblock + zstd (v2.1), not FullZip.
-fn compact_translation_sift_position_schema(source_type: &str) -> Schema {
+fn compact_translation_sift_position_schema(source_type: &str, cache_version: &str) -> Schema {
     let key = Field::new("key", DataType::UInt64, false);
     let sift = Field::new("sift", DataType::Binary, false);
     let poly = Field::new("poly", DataType::Binary, false);
-    let schema = with_cache_source_metadata(&Schema::new(vec![key, sift, poly]), source_type);
+    let schema = with_cache_identity_metadata(
+        &Schema::new(vec![key, sift, poly]),
+        source_type,
+        cache_version,
+    );
     let mut md = schema.metadata().clone();
     md.insert(
         crate::cache_common::SIFT_BLOB_VERSION_KEY.to_string(),
@@ -928,6 +962,7 @@ fn compact_translation_sift_position_schema(source_type: &str) -> Schema {
 fn transform_translation_sift_position_batch(
     batch: RecordBatch,
     source_type: &str,
+    cache_version: &str,
     uid_map: &HashMap<String, u32>,
 ) -> Result<RecordBatch> {
     let schema = batch.schema();
@@ -965,7 +1000,10 @@ fn transform_translation_sift_position_batch(
         )?;
     }
 
-    let target_schema = Arc::new(compact_translation_sift_position_schema(source_type));
+    let target_schema = Arc::new(compact_translation_sift_position_schema(
+        source_type,
+        cache_version,
+    ));
     RecordBatch::try_new(
         target_schema,
         vec![
@@ -1224,6 +1262,45 @@ mod tests {
     }
 
     #[test]
+    fn variation_transform_preserves_optional_clin_sig_ref_allele_when_present() {
+        let mut fields = Vec::new();
+        let mut columns = Vec::<ArrayRef>::new();
+        for name in VARIATION_REQUIRED_COLUMNS {
+            match *name {
+                "start" | "end" => {
+                    fields.push(Field::new(*name, DataType::Int64, false));
+                    columns.push(Arc::new(Int64Array::from(vec![10])) as ArrayRef);
+                }
+                "failed" => {
+                    fields.push(Field::new(*name, DataType::Int8, true));
+                    columns.push(Arc::new(Int8Array::from(vec![Some(0)])) as ArrayRef);
+                }
+                _ => {
+                    fields.push(Field::new(*name, DataType::Utf8, true));
+                    columns.push(Arc::new(StringArray::from(vec![Some("value")])) as ArrayRef);
+                }
+            }
+            if *name == "clin_sig_allele" {
+                fields.push(Field::new("clin_sig_ref_allele", DataType::Utf8, false));
+                columns.push(Arc::new(StringArray::from(vec!["AGG"])) as ArrayRef);
+            }
+        }
+        let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap();
+        let transformed =
+            transform_variation_tier_batch(batch, "ensembl", &BTreeSet::from([10]), 0).unwrap();
+        let schema = transformed.schema();
+        let field = schema.field_with_name("clin_sig_ref_allele").unwrap();
+        assert_eq!(field.data_type(), &DataType::Utf8);
+        assert!(field.is_nullable());
+        let values = transformed
+            .column(schema.index_of("clin_sig_ref_allele").unwrap())
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(values.value(0), "AGG");
+    }
+
+    #[test]
     fn assign_transcript_uids_is_dense_and_unique() {
         let mut ids = vec![
             "ENST2".to_string(),
@@ -1257,7 +1334,7 @@ mod tests {
                 .into_iter()
                 .collect();
 
-        let out = attach_transcript_uid_batch(batch, "ensembl", &uid_map).unwrap();
+        let out = attach_transcript_uid_batch(batch, "ensembl", "115", &uid_map).unwrap();
         let out_schema = out.schema();
         let uid_idx = out_schema.index_of("transcript_uid").unwrap();
         assert_eq!(out_schema.field(uid_idx).data_type(), &DataType::UInt32);
@@ -1274,6 +1351,12 @@ mod tests {
                 .get(crate::cache_source::CACHE_SOURCE_METADATA_KEY),
             Some(&"ensembl".to_string())
         );
+        assert_eq!(
+            out_schema
+                .metadata()
+                .get(crate::cache_identity::CACHE_VERSION_METADATA_KEY),
+            Some(&"115".to_string())
+        );
 
         // An id absent from the map is a hard error (consistency guard).
         let orphan = RecordBatch::try_new(
@@ -1284,7 +1367,7 @@ mod tests {
             ],
         )
         .unwrap();
-        assert!(attach_transcript_uid_batch(orphan, "ensembl", &uid_map).is_err());
+        assert!(attach_transcript_uid_batch(orphan, "ensembl", "115", &uid_map).is_err());
     }
 
     #[test]
@@ -1433,7 +1516,7 @@ mod tests {
         assert_eq!(p2.polyphen[0].prediction, 4);
 
         // Schema is key/sift/poly.
-        let schema = compact_translation_sift_position_schema("ensembl");
+        let schema = compact_translation_sift_position_schema("ensembl", "115");
         assert_eq!(schema.field(0).name(), "key");
         assert_eq!(schema.field(0).data_type(), &DataType::UInt64);
         assert_eq!(schema.field(1).name(), "sift");
@@ -1488,7 +1571,7 @@ mod tests {
 
     #[test]
     fn sift_position_schema_carries_v2_flag() {
-        let schema = compact_translation_sift_position_schema("ensembl");
+        let schema = compact_translation_sift_position_schema("ensembl", "115");
         assert_eq!(
             schema
                 .metadata()

--- a/datafusion/bio-function-vep/src/cache/build.rs
+++ b/datafusion/bio-function-vep/src/cache/build.rs
@@ -19,7 +19,6 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_bio_format_ensembl_cache::{
     CacheSourceType as BioFormatsCacheSourceType, EnsemblCacheOptions, EnsemblCacheTableProvider,
     EnsemblEntityKind, VEP_CACHE_REGION_SIZE_BP, build_export_query, translation_core_schema,
-    translation_sift_schema,
 };
 use futures::StreamExt;
 use log::info;
@@ -384,7 +383,8 @@ fn provider_output_schema(
 ) -> Result<SchemaRef> {
     use datafusion::catalog::TableProvider;
     let mut provider_options = EnsemblCacheOptions::new(&options.cache_root)
-        .with_cache_source_type(options.cache_source_type);
+        .with_cache_source_type(options.cache_source_type)
+        .with_expected_cache_version(&options.cache_version);
     provider_options.target_partitions = Some(options.partitions);
     Ok(EnsemblCacheTableProvider::for_entity(kind, provider_options)?.schema())
 }
@@ -507,7 +507,8 @@ pub async fn build_parquet_translation_core_chrom(
     let shard_path = entity_dir.join(&file_name);
     remove_existing_parquet_shard(&shard_path, options.overwrite)?;
 
-    let target_schema = translation_core_schema(false, options.cache_source_type);
+    let target_schema =
+        translation_core_schema(false, options.cache_source_type, &options.cache_version);
     let source_type = options.cache_source_type.as_str().to_string();
     let cache_version = options.cache_version.clone();
     let ctx = make_ctx_and_register(options, EnsemblEntityKind::Translation, "tl")?;
@@ -747,7 +748,8 @@ fn make_ctx_and_register(
     let config = SessionConfig::new().with_target_partitions(options.partitions);
     let ctx = SessionContext::new_with_config(config);
     let mut provider_options = EnsemblCacheOptions::new(&options.cache_root)
-        .with_cache_source_type(options.cache_source_type);
+        .with_cache_source_type(options.cache_source_type)
+        .with_expected_cache_version(&options.cache_version);
     provider_options.target_partitions = Some(options.partitions);
     let provider = EnsemblCacheTableProvider::for_entity(kind, provider_options)?;
     ctx.register_table(table_name, provider)?;

--- a/datafusion/bio-function-vep/src/cache/lookup_exec.rs
+++ b/datafusion/bio-function-vep/src/cache/lookup_exec.rs
@@ -400,6 +400,7 @@ struct WarmColocIndices {
     pheno: Option<usize>,
     clin_sig: Option<usize>,
     clin_sig_allele: Option<usize>,
+    clin_sig_ref_allele: Option<usize>,
     pubmed: Option<usize>,
     af_indices: Vec<Option<usize>>,
 }
@@ -1150,6 +1151,11 @@ fn probe_taken_batch_position(
                         pheno: batch_i64_value(batch, ci.pheno, row_usize).unwrap_or(0),
                         clin_sig: batch_string_value(batch, ci.clin_sig, row_usize)?,
                         clin_sig_allele: batch_string_value(batch, ci.clin_sig_allele, row_usize)?,
+                        clin_sig_ref_allele: batch_string_value(
+                            batch,
+                            ci.clin_sig_ref_allele,
+                            row_usize,
+                        )?,
                         pubmed: batch_string_value(batch, ci.pubmed, row_usize)?,
                         af: af_cols.clone(),
                         af_row: row,
@@ -1979,6 +1985,7 @@ fn resolve_batch_coloc_indices(batch: &RecordBatch) -> Option<WarmColocIndices> 
         pheno: find("phenotype_or_disease"),
         clin_sig: find("clin_sig"),
         clin_sig_allele: find("clin_sig_allele"),
+        clin_sig_ref_allele: find("clin_sig_ref_allele"),
         pubmed: find("pubmed"),
         af_indices: AF_COL_NAMES.iter().map(|name| find(name)).collect(),
     })

--- a/datafusion/bio-function-vep/src/cache/schema.rs
+++ b/datafusion/bio-function-vep/src/cache/schema.rs
@@ -3,13 +3,16 @@ use std::collections::{HashMap, HashSet};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 
+use crate::cache_identity::CACHE_VERSION_METADATA_KEY;
 use crate::cache_source::CACHE_SOURCE_METADATA_KEY;
 
 /// Project a source variation Arrow schema to the cache's variation output
-/// schema: keep [`VARIATION_REQUIRED_COLUMNS`] (dropping [`VARIATION_FORBIDDEN_COLUMNS`]),
-/// widen `start`/`end` to `UInt32`, and append the derived `tier` column. Used by
-/// both the Parquet shard writer and the build driver, so it lives here (under
-/// the read-runtime `parquet-cache` feature) rather than in the builder module.
+/// schema: keep [`VARIATION_REQUIRED_COLUMNS`] plus any present
+/// [`VARIATION_OPTIONAL_COLUMNS`] (dropping [`VARIATION_FORBIDDEN_COLUMNS`]),
+/// widen `start`/`end` to `UInt32`, and append the derived `tier` column. Used
+/// by both the Parquet shard writer and the build driver, so it lives here
+/// (under the read-runtime `parquet-cache` feature) rather than in the builder
+/// module.
 pub(crate) fn variation_projected_schema(
     source_schema: &Schema,
     source_type: &str,
@@ -32,13 +35,27 @@ pub(crate) fn variation_projected_schema(
         } else {
             fields.push(field.as_ref().clone());
         }
+        if *name == "clin_sig_allele" {
+            for optional_name in VARIATION_OPTIONAL_COLUMNS {
+                if let Some((_, optional_field)) = source_schema.column_with_name(optional_name) {
+                    if optional_field.data_type() != &DataType::Utf8 {
+                        return Err(DataFusionError::Execution(format!(
+                            "optional variation field {optional_name} must be Utf8, got {:?}",
+                            optional_field.data_type()
+                        )));
+                    }
+                    fields.push(Field::new(*optional_name, DataType::Utf8, true));
+                }
+            }
+        }
     }
 
     // Derived warm/cold tier column (0 = warm/common, 1 = cold/rare). Appended
     // here rather than read from the source table.
     fields.push(Field::new("tier", DataType::Int8, false));
 
-    let target_schema = with_cache_source_metadata(&Schema::new(fields), source_type);
+    let projected = Schema::new_with_metadata(fields, source_schema.metadata().clone());
+    let target_schema = with_cache_source_metadata(&projected, source_type);
     validate_variation_schema(&target_schema)?;
     Ok(target_schema)
 }
@@ -100,6 +117,11 @@ pub const VARIATION_REQUIRED_COLUMNS: &[&str] = &[
     "dbsnp_ids",
 ];
 
+/// Release-specific variation fields that are preserved when present but are
+/// not required. VEP cache 116 added `clin_sig_ref_allele`; cache 115 does not
+/// contain it and must retain its existing physical schema and behavior.
+pub const VARIATION_OPTIONAL_COLUMNS: &[&str] = &["clin_sig_ref_allele"];
+
 pub fn validate_variation_schema(schema: &Schema) -> Result<()> {
     for name in VARIATION_FORBIDDEN_COLUMNS {
         if schema.index_of(name).is_ok() {
@@ -145,6 +167,20 @@ pub fn with_cache_source_metadata(schema: &Schema, source_type: &str) -> Schema 
     Schema::new_with_metadata(schema.fields().clone(), metadata)
 }
 
+pub fn with_cache_identity_metadata(
+    schema: &Schema,
+    source_type: &str,
+    cache_version: &str,
+) -> Schema {
+    let schema = with_cache_source_metadata(schema, source_type);
+    let mut metadata = schema.metadata().clone();
+    metadata.insert(
+        CACHE_VERSION_METADATA_KEY.to_string(),
+        cache_version.to_string(),
+    );
+    Schema::new_with_metadata(schema.fields().clone(), metadata)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,6 +194,8 @@ mod tests {
         assert!(!VARIATION_REQUIRED_COLUMNS.contains(&"position_key"));
         assert!(!VARIATION_REQUIRED_COLUMNS.contains(&"variant_keys"));
         assert!(!VARIATION_REQUIRED_COLUMNS.contains(&"tier"));
+        assert!(!VARIATION_REQUIRED_COLUMNS.contains(&"clin_sig_ref_allele"));
+        assert_eq!(VARIATION_OPTIONAL_COLUMNS, &["clin_sig_ref_allele"]);
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -183,8 +183,11 @@ impl CacheBuilder {
 
     #[cfg(feature = "parquet-cache")]
     fn validate_raw_cache_identity(&self, kind: EnsemblEntityKind) -> Result<String> {
-        let options = EnsemblCacheOptions::new(&self.cache_root)
+        let mut options = EnsemblCacheOptions::new(&self.cache_root)
             .with_cache_source_type(self.cache_source_type);
+        if let Some(expected) = self.expected_cache_version.as_deref() {
+            options = options.with_expected_cache_version(expected);
+        }
         let provider = EnsemblCacheTableProvider::for_entity(kind, options)?;
         let schema = provider.schema();
         let detected = schema

--- a/datafusion/bio-function-vep/src/cache_builder.rs
+++ b/datafusion/bio-function-vep/src/cache_builder.rs
@@ -3,12 +3,17 @@
 //! this module provides the public [`CacheBuilder`] entry point and entity
 //! dispatch. Parquet is the only supported output format.
 
+use datafusion::catalog::TableProvider;
 use datafusion::common::{DataFusionError, Result};
 use log::info;
 
 use datafusion_bio_format_ensembl_cache::{
-    CacheSourceType as BioFormatsCacheSourceType, EnsemblEntityKind,
+    CacheSourceType as BioFormatsCacheSourceType, EnsemblCacheOptions, EnsemblCacheTableProvider,
+    EnsemblEntityKind,
 };
+
+use crate::cache_identity::CACHE_VERSION_METADATA_KEY as VEP_CACHE_VERSION_METADATA_KEY;
+use crate::vep_semantics::target_for_cache_version;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum CacheFormat {
@@ -53,6 +58,7 @@ pub struct CacheBuilder {
     cache_format: CacheFormat,
     overwrite: bool,
     cache_source_type: BioFormatsCacheSourceType,
+    expected_cache_version: Option<String>,
     chrom_filter: Option<Vec<String>>,
 }
 
@@ -65,6 +71,7 @@ impl CacheBuilder {
             cache_format: CacheFormat::default(),
             overwrite: false,
             cache_source_type: BioFormatsCacheSourceType::Ensembl,
+            expected_cache_version: None,
             chrom_filter: None,
         }
     }
@@ -99,6 +106,16 @@ impl CacheBuilder {
 
     pub fn with_cache_source_type(mut self, cache_source_type: BioFormatsCacheSourceType) -> Self {
         self.cache_source_type = cache_source_type;
+        self
+    }
+
+    /// Assert the release detected independently from the raw cache metadata.
+    ///
+    /// The assertion cannot label an unknown raw cache. When omitted, the raw
+    /// cache must still provide a supported release and that detected value is
+    /// embedded in every generated Parquet shard.
+    pub fn with_expected_cache_version(mut self, cache_version: impl Into<String>) -> Self {
+        self.expected_cache_version = Some(cache_version.into());
         self
     }
 
@@ -142,11 +159,13 @@ impl CacheBuilder {
 
         #[cfg(feature = "parquet-cache")]
         {
+            let cache_version = self.validate_raw_cache_identity(kind)?;
             let options = crate::cache::build::CacheBuildOptions {
                 cache_root: self.cache_root.clone(),
                 output_dir: self.output_dir.clone(),
                 partitions: self.partitions,
                 cache_source_type: self.cache_source_type,
+                cache_version,
                 overwrite: self.overwrite,
                 chrom_filter: self.chrom_filter.clone(),
             };
@@ -160,6 +179,50 @@ impl CacheBuilder {
                 "cache builder requires the parquet-cache feature".to_string(),
             ))
         }
+    }
+
+    #[cfg(feature = "parquet-cache")]
+    fn validate_raw_cache_identity(&self, kind: EnsemblEntityKind) -> Result<String> {
+        let options = EnsemblCacheOptions::new(&self.cache_root)
+            .with_cache_source_type(self.cache_source_type);
+        let provider = EnsemblCacheTableProvider::for_entity(kind, options)?;
+        let schema = provider.schema();
+        let detected = schema
+            .metadata()
+            .get(VEP_CACHE_VERSION_METADATA_KEY)
+            .filter(|value| !value.is_empty() && value.as_str() != "unknown")
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "cache build refused before writing output: raw cache '{}' has no usable \
+                     {VEP_CACHE_VERSION_METADATA_KEY}; add cache_version/version to info.txt or \
+                     use a canonical raw VEP cache-root basename",
+                    self.cache_root
+                ))
+            })?
+            .to_string();
+        target_for_cache_version(&detected).map_err(|error| {
+            DataFusionError::Execution(format!(
+                "cache build refused before writing output: raw cache '{}' declares {error}",
+                self.cache_root
+            ))
+        })?;
+
+        if let Some(expected) = self.expected_cache_version.as_deref() {
+            target_for_cache_version(expected).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "cache build refused before writing output: invalid expected cache release: \
+                     {error}"
+                ))
+            })?;
+            if detected != expected {
+                return Err(DataFusionError::Execution(format!(
+                    "cache build refused before writing output: raw cache '{}' declares \
+                     {VEP_CACHE_VERSION_METADATA_KEY}={detected}, requested release is {expected}",
+                    self.cache_root
+                )));
+            }
+        }
+        Ok(detected)
     }
 }
 
@@ -231,6 +294,7 @@ mod tests {
         assert_eq!(builder.cache_format, CacheFormat::Parquet);
         assert_eq!(builder.partitions, 8);
         assert!(!builder.overwrite);
+        assert!(builder.expected_cache_version.is_none());
         assert!(builder.chrom_filter.is_none());
     }
 
@@ -240,10 +304,12 @@ mod tests {
             .with_partitions(4)
             .with_cache_format(CacheFormat::Parquet)
             .with_overwrite(true)
+            .with_expected_cache_version("116")
             .with_chrom_filter(["chr1", "chr2"]);
         assert_eq!(builder.partitions, 4);
         assert_eq!(builder.cache_format, CacheFormat::Parquet);
         assert!(builder.overwrite);
+        assert_eq!(builder.expected_cache_version.as_deref(), Some("116"));
         assert_eq!(
             builder.chrom_filter.as_deref(),
             Some(["chr1".to_string(), "chr2".to_string()].as_slice())

--- a/datafusion/bio-function-vep/src/cache_identity.rs
+++ b/datafusion/bio-function-vep/src/cache_identity.rs
@@ -1,0 +1,436 @@
+//! Lazy, shard-local cache identity validation.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use datafusion::arrow::datatypes::Schema;
+use datafusion::common::{DataFusionError, Result};
+
+use crate::cache::manifest::canonical_chrom_label;
+use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
+use crate::parquet_cache::detect::PartitionedParquetCache;
+use crate::vep_semantics::{SupportedVepTarget, target_for_cache_version};
+
+// Keep the release contract independent of whether the optional raw-cache
+// builder dependency has already published the same metadata-key constant.
+pub(crate) const CACHE_VERSION_METADATA_KEY: &str = "bio.vep.cache_version";
+
+const CACHE_ENTITIES: &[&str] = &[
+    "variation",
+    "transcript",
+    "exon",
+    "translation_core",
+    "translation_sift",
+    "regulatory",
+    "motif",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CacheIdentity {
+    pub(crate) source_type: CacheSourceType,
+    pub(crate) cache_version: String,
+    pub(crate) target: &'static SupportedVepTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedCacheIdentity {
+    pub cache_source_type: String,
+    pub cache_version: String,
+    pub target: &'static SupportedVepTarget,
+}
+
+#[derive(Debug, Default)]
+struct ValidationState {
+    validated_contigs: HashMap<String, CacheIdentity>,
+    invocation_identity: Option<CacheIdentity>,
+}
+
+/// Validate only the Parquet shards participating in one requested contig.
+///
+/// This is the reporting/diagnostic façade over the same validator used by the
+/// annotation runtime. It intentionally reads manifests plus the selected
+/// contig's footers and never probes an unrelated contig.
+pub async fn validate_partitioned_cache_contig(
+    cache_source: &str,
+    chrom: &str,
+    expected_cache_version: Option<String>,
+) -> Result<ValidatedCacheIdentity> {
+    let cache = PartitionedParquetCache::detect(cache_source).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "no partitioned Parquet VEP cache found at '{cache_source}'"
+        ))
+    })?;
+    let identity = LazyCacheIdentityValidator::new(expected_cache_version)?
+        .validate_contig(&cache, chrom)
+        .await?;
+    Ok(ValidatedCacheIdentity {
+        cache_source_type: identity.source_type.as_str().to_string(),
+        cache_version: identity.cache_version,
+        target: identity.target,
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct LazyCacheIdentityValidator {
+    expected_cache_version: Option<String>,
+    state: Mutex<ValidationState>,
+}
+
+impl LazyCacheIdentityValidator {
+    pub(crate) fn new(expected_cache_version: Option<String>) -> Result<Self> {
+        if let Some(expected) = expected_cache_version.as_deref() {
+            target_for_cache_version(expected).map_err(|error| {
+                DataFusionError::Plan(format!(
+                    "annotate_vep(): invalid expected_cache_version assertion: {error}"
+                ))
+            })?;
+        }
+        Ok(Self {
+            expected_cache_version,
+            state: Mutex::new(ValidationState::default()),
+        })
+    }
+
+    pub(crate) async fn validate_contig(
+        &self,
+        cache: &PartitionedParquetCache,
+        chrom: &str,
+    ) -> Result<CacheIdentity> {
+        let canonical_chrom = canonical_chrom_label(chrom);
+        if let Some(identity) = self
+            .state
+            .lock()
+            .map_err(lock_error)?
+            .validated_contigs
+            .get(&canonical_chrom)
+            .cloned()
+        {
+            return Ok(identity);
+        }
+
+        let shards = participating_shards(cache, chrom)?;
+        let mut first: Option<(String, PathBuf, CacheSourceType, String)> = None;
+        for (entity, path) in shards {
+            let schema = read_parquet_shard_schema(&path).await?;
+            let source_type = CacheSourceType::from_schema(&schema).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "annotate_vep(): cache identity validation failed for contig \
+                     '{chrom}', entity '{entity}', shard '{}': {error}",
+                    path.display()
+                ))
+            })?;
+            let cache_version = schema
+                .metadata()
+                .get(CACHE_VERSION_METADATA_KEY)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "annotate_vep(): cache identity validation failed for contig \
+                         '{chrom}', entity '{entity}', shard '{}': missing \
+                         {CACHE_VERSION_METADATA_KEY}; rebuild this metadata-less cache",
+                        path.display()
+                    ))
+                })?
+                .to_string();
+            target_for_cache_version(&cache_version).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "annotate_vep(): cache identity validation failed for contig \
+                     '{chrom}', entity '{entity}', shard '{}': {error}",
+                    path.display()
+                ))
+            })?;
+
+            if let Some((first_entity, first_path, first_source, first_version)) = &first {
+                if source_type != *first_source || cache_version != *first_version {
+                    return Err(DataFusionError::Execution(format!(
+                        "annotate_vep(): mixed cache identity for contig '{chrom}': \
+                         {first_entity} shard '{}' declares source={} version={}, but \
+                         {entity} shard '{}' declares source={} version={}",
+                        first_path.display(),
+                        first_source.as_str(),
+                        first_version,
+                        path.display(),
+                        source_type.as_str(),
+                        cache_version
+                    )));
+                }
+            } else {
+                first = Some((entity, path, source_type, cache_version));
+            }
+        }
+
+        let (_, _, source_type, cache_version) = first.ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): no participating Parquet cache shards found for contig '{chrom}'"
+            ))
+        })?;
+        if let Some(expected) = self.expected_cache_version.as_deref()
+            && cache_version != expected
+        {
+            return Err(DataFusionError::Execution(format!(
+                "annotate_vep(): cache version assertion failed for contig '{chrom}': \
+                 embedded {CACHE_VERSION_METADATA_KEY}={cache_version}, expected {expected}"
+            )));
+        }
+
+        let identity = CacheIdentity {
+            source_type,
+            target: target_for_cache_version(&cache_version)?,
+            cache_version,
+        };
+        let mut state = self.state.lock().map_err(lock_error)?;
+        if let Some(invocation) = &state.invocation_identity {
+            if invocation.source_type != identity.source_type
+                || invocation.cache_version != identity.cache_version
+            {
+                return Err(DataFusionError::Execution(format!(
+                    "annotate_vep(): cache identity changed within one invocation at \
+                     contig '{chrom}': first contig used source={} version={}, this \
+                     contig uses source={} version={}",
+                    invocation.source_type.as_str(),
+                    invocation.cache_version,
+                    identity.source_type.as_str(),
+                    identity.cache_version
+                )));
+            }
+        } else {
+            state.invocation_identity = Some(identity.clone());
+        }
+        state
+            .validated_contigs
+            .insert(canonical_chrom, identity.clone());
+        Ok(identity)
+    }
+}
+
+fn lock_error<T>(error: std::sync::PoisonError<T>) -> DataFusionError {
+    DataFusionError::Execution(format!("cache identity validator lock poisoned: {error}"))
+}
+
+fn participating_shards(
+    cache: &PartitionedParquetCache,
+    chrom: &str,
+) -> Result<Vec<(String, PathBuf)>> {
+    let variation = cache.variation_path(chrom).ok_or_else(|| {
+        DataFusionError::Execution(format!(
+            "annotate_vep(): Parquet cache has no variation shard for contig '{chrom}'"
+        ))
+    })?;
+    let mut shards = vec![("variation".to_string(), variation)];
+    for entity in CACHE_ENTITIES.iter().copied().skip(1) {
+        if let Some(path) = cache.context_path(entity, chrom) {
+            shards.push((entity.to_string(), path));
+        }
+    }
+    Ok(shards)
+}
+
+async fn read_parquet_shard_schema(path: &Path) -> Result<Schema> {
+    use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
+
+    let file = tokio::fs::File::open(path).await.map_err(|error| {
+        DataFusionError::Execution(format!(
+            "annotate_vep(): failed to open Parquet cache shard footer '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let builder = ParquetRecordBatchStreamBuilder::new(file)
+        .await
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "annotate_vep(): failed to read Parquet cache shard footer '{}': {error}",
+                path.display()
+            ))
+        })?;
+    Ok(builder.schema().as_ref().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Int64Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use parquet::arrow::ArrowWriter;
+
+    use super::*;
+    use crate::cache::manifest::{ChromDatasetEntry, ChromManifest};
+
+    fn write_shard(
+        root: &Path,
+        entity: &str,
+        chrom: &str,
+        source_type: Option<&str>,
+        cache_version: Option<&str>,
+    ) {
+        let entity_dir = root.join(entity);
+        std::fs::create_dir_all(&entity_dir).unwrap();
+        let file_name = format!("{chrom}.parquet");
+        let path = entity_dir.join(&file_name);
+        let mut metadata = HashMap::new();
+        if let Some(source_type) = source_type {
+            metadata.insert(
+                CACHE_SOURCE_METADATA_KEY.to_string(),
+                source_type.to_string(),
+            );
+        }
+        if let Some(cache_version) = cache_version {
+            metadata.insert(
+                CACHE_VERSION_METADATA_KEY.to_string(),
+                cache_version.to_string(),
+            );
+        }
+        let schema = Arc::new(
+            Schema::new(vec![Field::new("value", DataType::Int64, false)]).with_metadata(metadata),
+        );
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(vec![1]))])
+            .unwrap();
+        let mut writer =
+            ArrowWriter::try_new(std::fs::File::create(&path).unwrap(), schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        ChromManifest::new(vec![ChromDatasetEntry::new(chrom, file_name, 1)])
+            .write_to_entity_dir(&entity_dir)
+            .unwrap();
+    }
+
+    fn write_two_chrom_manifest(root: &Path, entity: &str) {
+        ChromManifest::new(vec![
+            ChromDatasetEntry::new("chr1", "chr1.parquet", 1),
+            ChromDatasetEntry::new("chr2", "chr2.parquet", 1),
+        ])
+        .write_to_entity_dir(&root.join(entity))
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn validates_supported_115_and_116_identities() {
+        for version in ["115", "116"] {
+            let tmp = tempfile::tempdir().unwrap();
+            write_shard(
+                tmp.path(),
+                "variation",
+                "chr1",
+                Some("merged"),
+                Some(version),
+            );
+            write_shard(
+                tmp.path(),
+                "transcript",
+                "chr1",
+                Some("merged"),
+                Some(version),
+            );
+            let cache = PartitionedParquetCache::detect(tmp.path().to_str().unwrap()).unwrap();
+            let identity = LazyCacheIdentityValidator::new(Some(version.to_string()))
+                .unwrap()
+                .validate_contig(&cache, "chr1")
+                .await
+                .unwrap();
+            assert_eq!(identity.cache_version, version);
+            assert_eq!(identity.source_type, CacheSourceType::Merged);
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_and_mixed_metadata_with_shard_diagnostics() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_shard(tmp.path(), "variation", "chr1", Some("merged"), Some("116"));
+        write_shard(tmp.path(), "transcript", "chr1", Some("merged"), None);
+        let cache = PartitionedParquetCache::detect(tmp.path().to_str().unwrap()).unwrap();
+        let error = LazyCacheIdentityValidator::new(None)
+            .unwrap()
+            .validate_contig(&cache, "chr1")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("transcript"));
+        assert!(error.contains(CACHE_VERSION_METADATA_KEY));
+
+        write_shard(
+            tmp.path(),
+            "transcript",
+            "chr1",
+            Some("merged"),
+            Some("115"),
+        );
+        let error = LazyCacheIdentityValidator::new(None)
+            .unwrap()
+            .validate_contig(&cache, "chr1")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("mixed cache identity"));
+        assert!(error.contains("version=116"));
+        assert!(error.contains("version=115"));
+    }
+
+    #[tokio::test]
+    async fn chr1_validation_does_not_open_broken_chr2_footer() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_shard(tmp.path(), "variation", "chr1", Some("merged"), Some("116"));
+        std::fs::write(
+            tmp.path().join("variation").join("chr2.parquet"),
+            b"not parquet",
+        )
+        .unwrap();
+        write_two_chrom_manifest(tmp.path(), "variation");
+        let cache = PartitionedParquetCache::detect(tmp.path().to_str().unwrap()).unwrap();
+        let validator = LazyCacheIdentityValidator::new(None).unwrap();
+
+        validator.validate_contig(&cache, "chr1").await.unwrap();
+        let error = validator
+            .validate_contig(&cache, "chr2")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("chr2.parquet"));
+    }
+
+    #[tokio::test]
+    async fn assertion_cannot_replace_missing_or_conflicting_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_shard(tmp.path(), "variation", "chr1", Some("ensembl"), None);
+        let cache = PartitionedParquetCache::detect(tmp.path().to_str().unwrap()).unwrap();
+        let error = LazyCacheIdentityValidator::new(Some("115".to_string()))
+            .unwrap()
+            .validate_contig(&cache, "chr1")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("missing bio.vep.cache_version"));
+
+        write_shard(
+            tmp.path(),
+            "variation",
+            "chr1",
+            Some("ensembl"),
+            Some("116"),
+        );
+        let error = LazyCacheIdentityValidator::new(Some("115".to_string()))
+            .unwrap()
+            .validate_contig(&cache, "chr1")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("embedded bio.vep.cache_version=116, expected 115"));
+    }
+
+    #[tokio::test]
+    async fn later_contig_must_match_invocation_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_shard(tmp.path(), "variation", "chr1", Some("merged"), Some("115"));
+        write_shard(tmp.path(), "variation", "chr2", Some("merged"), Some("116"));
+        write_two_chrom_manifest(tmp.path(), "variation");
+        let cache = PartitionedParquetCache::detect(tmp.path().to_str().unwrap()).unwrap();
+        let validator = LazyCacheIdentityValidator::new(None).unwrap();
+        validator.validate_contig(&cache, "chr1").await.unwrap();
+        let error = validator
+            .validate_contig(&cache, "chr2")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("changed within one invocation"));
+    }
+}

--- a/datafusion/bio-function-vep/src/colocated.rs
+++ b/datafusion/bio-function-vep/src/colocated.rs
@@ -110,6 +110,7 @@ pub struct ColocatedCacheEntry {
     pub pheno: i64,
     pub clin_sig: Option<String>,
     pub clin_sig_allele: Option<String>,
+    pub clin_sig_ref_allele: Option<String>,
     pub pubmed: Option<String>,
     /// Zero-copy AF columns shared across all entries from the same cache batch.
     /// Indexed same as `AF_COL_NAMES`; read this row's value via [`Self::af_value`].

--- a/datafusion/bio-function-vep/src/hgvs.rs
+++ b/datafusion/bio-function-vep/src/hgvs.rs
@@ -2033,8 +2033,10 @@ pub fn format_hgvsp(
     // - Ensembl Variation
     //   `TranscriptVariationAllele::_get_hgvs_protein_type()`
     //   <https://github.com/Ensembl/ensembl-variation/blob/release/116/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L2041-L2077>
-    notation.ref_allele = notation.ref_allele.replace('*', "X");
-    notation.alt_allele = notation.alt_allele.replace('*', "X");
+    if !protein.frameshift {
+        notation.ref_allele = notation.ref_allele.replace('*', "X");
+        notation.alt_allele = notation.alt_allele.replace('*', "X");
+    }
 
     format_hgvsp_notation(&protein_id, &notation, protein)
 }
@@ -2126,7 +2128,15 @@ fn resolve_frameshift_hgvs(
 ) -> Option<()> {
     notation.kind = "fs".to_string();
     let ref_translation = append_terminal_stop(&protein.ref_translation);
-    let alt_translation = protein.alt_translation.as_str();
+    // VEP `_get_fs_peptides()` translates `_get_alternate_cds()`, whose
+    // frameshift path includes the 3' UTR. The local alternate translation can
+    // end in an incomplete `X` even when that exact extended CDS translates to
+    // an immediate stop; use the replayed alternate-CDS translation whenever
+    // it is available.
+    let alt_translation = protein
+        .alt_translation_extension
+        .as_deref()
+        .unwrap_or(&protein.alt_translation);
     let mut start = notation.start;
 
     if start > alt_translation.len() {
@@ -2451,7 +2461,7 @@ fn format_hgvsp_notation(
         }
         "delins" | "ins" => {
             let mut alt_allele = notation.alt_allele.clone();
-            if let Some(stop_idx) = alt_allele.find('*') {
+            if let Some(stop_idx) = alt_allele.find('X') {
                 alt_allele.truncate(stop_idx.saturating_add(1));
             }
             let mut alt = peptide_to_three_letter(&alt_allele);
@@ -6551,6 +6561,31 @@ mod tests {
         assert_eq!(
             format_hgvsp(&translation, &protein, true),
             Some("ENSPHGVS000001.1:p.Ala2Ter".into())
+        );
+    }
+
+    #[test]
+    fn test_format_hgvsp_frameshift_uses_extended_alternate_cds_immediate_stop() {
+        let translation = make_translation();
+        let protein = ProteinHgvsData {
+            start: 3,
+            end: 3,
+            ref_peptide: "-".into(),
+            alt_peptide: "X".into(),
+            ref_translation: "MAY*".into(),
+            // The local codon window is incomplete, but VEP
+            // `_get_fs_peptides()` translates `_get_alternate_cds()` including
+            // 3' UTR and sees an immediate stop at the first changed residue.
+            alt_translation: "MAX".into(),
+            alt_translation_extension: Some("MA*".into()),
+            frameshift: true,
+            start_lost: false,
+            stop_lost: false,
+            native_refseq: false,
+        };
+        assert_eq!(
+            format_hgvsp(&translation, &protein, true),
+            Some("ENSPHGVS000001.1:p.Tyr3Ter".into())
         );
     }
 

--- a/datafusion/bio-function-vep/src/hgvs.rs
+++ b/datafusion/bio-function-vep/src/hgvs.rs
@@ -12,6 +12,7 @@ use crate::transcript_consequence::{
     mapper_deleted_gap_cdna_index, raw_cdna_position_from_genomic, refseq_deleted_edit_cdna_index,
     refseq_sequence_offset_for_cdna,
 };
+use crate::vep_semantics::VepSemantics;
 use datafusion::common::{DataFusionError, Result};
 use noodles_core::{Position, Region};
 use noodles_fasta as fasta;
@@ -179,6 +180,33 @@ pub fn format_hgvsc(
     variant_end: i64,
     genomic_shift: Option<&HgvsGenomicShift>,
 ) -> Option<String> {
+    format_hgvsc_with_semantics(
+        tx,
+        tx_exons,
+        cdna_position,
+        cds_position,
+        ref_allele,
+        alt_allele,
+        variant_start,
+        variant_end,
+        genomic_shift,
+        VepSemantics::V115,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn format_hgvsc_with_semantics(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    cdna_position: Option<&str>,
+    cds_position: Option<&str>,
+    ref_allele: &str,
+    alt_allele: &str,
+    variant_start: i64,
+    variant_end: i64,
+    genomic_shift: Option<&HgvsGenomicShift>,
+    semantics: VepSemantics,
+) -> Option<String> {
     format_hgvsc_inner(
         tx,
         tx_exons,
@@ -190,6 +218,7 @@ pub fn format_hgvsc(
         variant_end,
         genomic_shift,
         None,
+        semantics,
     )
 }
 
@@ -206,6 +235,35 @@ pub fn format_hgvsc_profiled(
     genomic_shift: Option<&HgvsGenomicShift>,
     profile: &mut HgvscProfile,
 ) -> Option<String> {
+    format_hgvsc_profiled_with_semantics(
+        tx,
+        tx_exons,
+        cdna_position,
+        cds_position,
+        ref_allele,
+        alt_allele,
+        variant_start,
+        variant_end,
+        genomic_shift,
+        profile,
+        VepSemantics::V115,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn format_hgvsc_profiled_with_semantics(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    cdna_position: Option<&str>,
+    cds_position: Option<&str>,
+    ref_allele: &str,
+    alt_allele: &str,
+    variant_start: i64,
+    variant_end: i64,
+    genomic_shift: Option<&HgvsGenomicShift>,
+    profile: &mut HgvscProfile,
+    semantics: VepSemantics,
+) -> Option<String> {
     format_hgvsc_inner(
         tx,
         tx_exons,
@@ -217,6 +275,7 @@ pub fn format_hgvsc_profiled(
         variant_end,
         genomic_shift,
         Some(profile),
+        semantics,
     )
 }
 
@@ -232,6 +291,7 @@ fn format_hgvsc_inner(
     variant_end: i64,
     genomic_shift: Option<&HgvsGenomicShift>,
     mut profile: Option<&mut HgvscProfile>,
+    semantics: VepSemantics,
 ) -> Option<String> {
     // Traceability:
     // - Ensembl Variation `TranscriptVariationAllele::hgvs_transcript()`
@@ -242,7 +302,7 @@ fn format_hgvsc_inner(
     //   https://github.com/Ensembl/ensembl-variation/blob/release/115/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L1416
     if ref_allele != "-" && alt_allele == "-" {
         // Deletion: check if either end extends beyond transcript boundaries.
-        if variant_start < tx.start || variant_end > tx.end {
+        if !semantics.partial_overlap_hgvs() && (variant_start < tx.start || variant_end > tx.end) {
             return None;
         }
     }
@@ -285,6 +345,7 @@ fn format_hgvsc_inner(
         variant_end,
         genomic_shift,
         profile.as_deref_mut(),
+        semantics,
     );
     if let (Some(started), Some(profile)) = (fallback_started, profile.as_deref_mut()) {
         profile.fallback += started.elapsed();
@@ -304,6 +365,7 @@ fn format_hgvsc_fallback(
     variant_end: i64,
     genomic_shift: Option<&HgvsGenomicShift>,
     mut profile: Option<&mut HgvscProfile>,
+    semantics: VepSemantics,
 ) -> Option<String> {
     let tx_id = versioned_id(&tx.transcript_id, tx.version);
     let numbering = if tx.cds_start.is_some() && tx.cds_end.is_some() {
@@ -320,8 +382,32 @@ fn format_hgvsc_fallback(
             && !shift.shifted_output_allele.is_empty()
             && shift.shifted_output_allele != "-"
     });
+    let partial_deletion = (ref_allele != "-"
+        && alt_allele == "-"
+        && (variant_start < tx.start || variant_end > tx.end))
+        .then(|| {
+            vep116_partial_overlap_deletion(
+                tx,
+                ref_allele,
+                variant_start,
+                variant_end,
+                use_genomic_shift,
+            )
+        })
+        .flatten();
+    if ref_allele != "-"
+        && alt_allele == "-"
+        && (variant_start < tx.start || variant_end > tx.end)
+        && (!semantics.partial_overlap_hgvs() || partial_deletion.is_none())
+    {
+        return None;
+    }
+    let partial_ref;
     let (ref_allele, alt_allele, variant_start, variant_end) =
-        if let Some(shift) = use_genomic_shift {
+        if let Some((clamped_ref, clamped_start, clamped_end)) = partial_deletion {
+            partial_ref = clamped_ref;
+            (partial_ref.as_str(), alt_allele, clamped_start, clamped_end)
+        } else if let Some(shift) = use_genomic_shift {
             (
                 ref_allele,
                 if ref_allele == "-" {
@@ -433,6 +519,88 @@ fn format_hgvsc_fallback(
         profile.format_string += started.elapsed();
     }
     hgvsc
+}
+
+/// Reproduce the release/116 `_var2transcript_slice_coords` behavior for a
+/// deletion that overlaps only part of a transcript.
+///
+/// VEP clamps the unshifted interval in transcript-slice coordinates and only
+/// then adds the non-negative HGVS 3' offset. In particular, substituting a
+/// precomputed shifted genomic interval before clamping is not equivalent at a
+/// transcript boundary.
+fn vep116_partial_overlap_deletion(
+    tx: &TranscriptFeature,
+    ref_allele: &str,
+    variant_start: i64,
+    variant_end: i64,
+    genomic_shift: Option<&HgvsGenomicShift>,
+) -> Option<(String, i64, i64)> {
+    let transcript_length = tx.end.checked_sub(tx.start)?.checked_add(1)?;
+    if transcript_length <= 0 {
+        return None;
+    }
+
+    let (slice_start, slice_end) = if tx.strand >= 0 {
+        (
+            variant_start.checked_sub(tx.start)?.checked_add(1)?,
+            variant_end.checked_sub(tx.start)?.checked_add(1)?,
+        )
+    } else {
+        (
+            tx.end.checked_sub(variant_end)?.checked_add(1)?,
+            tx.end.checked_sub(variant_start)?.checked_add(1)?,
+        )
+    };
+
+    // Release/116 rejects only variants wholly before or wholly after the
+    // transcript slice.
+    if (slice_start < 1 && slice_end < 1)
+        || (slice_start > transcript_length && slice_end > transcript_length)
+    {
+        return None;
+    }
+
+    let clamped_start = slice_start.clamp(1, transcript_length);
+    let clamped_end = slice_end.clamp(1, transcript_length);
+    let shift_offset = genomic_shift
+        .map(|shift| i64::try_from(shift.shift_length).ok())
+        .unwrap_or(Some(0))?;
+    let shifted_start = clamped_start.checked_add(shift_offset)?;
+    let shifted_end = clamped_end.checked_add(shift_offset)?;
+
+    // This is the separate guard in `hgvs_transcript`: a clamped partial
+    // overlap can still become invalid when its 3' shift overruns the slice.
+    if shifted_end > transcript_length {
+        return None;
+    }
+
+    let (genomic_start, genomic_end) = if tx.strand >= 0 {
+        (
+            tx.start.checked_add(shifted_start)?.checked_sub(1)?,
+            tx.start.checked_add(shifted_end)?.checked_sub(1)?,
+        )
+    } else {
+        (
+            tx.end.checked_sub(shifted_end)?.checked_add(1)?,
+            tx.end.checked_sub(shifted_start)?.checked_add(1)?,
+        )
+    };
+
+    // VEP extracts the reference from the clamped transcript slice. Cache
+    // annotation already carries that sequence as the deletion allele, so
+    // retain only the genomic-overlap portion when its span is exact.
+    let overlap_start = variant_start.max(tx.start);
+    let overlap_end = variant_end.min(tx.end);
+    let variant_span = variant_end.checked_sub(variant_start)?.checked_add(1)?;
+    let clamped_ref = if usize::try_from(variant_span).ok() == Some(ref_allele.len()) {
+        let start = usize::try_from(overlap_start.checked_sub(variant_start)?).ok()?;
+        let end = usize::try_from(overlap_end.checked_sub(variant_start)?.checked_add(1)?).ok()?;
+        ref_allele.get(start..end)?.to_string()
+    } else {
+        ref_allele.to_string()
+    };
+
+    Some((clamped_ref, genomic_start, genomic_end))
 }
 
 fn format_hgvsc_simple_substitution_fast(
@@ -557,13 +725,18 @@ pub(crate) fn hgvsc_uses_genomic_shift(
         return false;
     };
 
-    // When RefSeq BAM edit replay failed, VEP only suppresses transcript HGVS
-    // shifting when the transcript-space HGVS alleles no longer match the
-    // original shifted allele payload. Failed BAM-edit rows whose HGVS alleles
-    // still match the original genomic payload keep the shift.
+    // A failed RefSeq BAM edit removes the attempted `_rna_edit` attributes,
+    // but VEP still runs `_return_3prime()` against the remaining transcript
+    // state. Accept both representations that can therefore reach
+    // `hgvs_transcript()`: the original normalized allele and the allele
+    // rotated by the genomic 3' shift. The latter is also VEP's USED_REF for
+    // repeat deletions (for example NM_002457.5 at chr11:1094638).
     if is_native_refseq_transcript(tx) && tx.bam_edit_status.as_deref() == Some("failed") {
-        return ref_allele.eq_ignore_ascii_case(&shift.ref_orig_allele_string)
-            && alt_allele.eq_ignore_ascii_case(&shift.alt_orig_allele_string);
+        let ref_matches = ref_allele.eq_ignore_ascii_case(&shift.ref_orig_allele_string)
+            || ref_allele.eq_ignore_ascii_case(&shift.shifted_allele_string);
+        let alt_matches = alt_allele.eq_ignore_ascii_case(&shift.alt_orig_allele_string)
+            || alt_allele.eq_ignore_ascii_case(&shift.shifted_output_allele);
+        return ref_matches && alt_matches;
     }
 
     true
@@ -2835,6 +3008,158 @@ mod tests {
     }
 
     #[test]
+    fn test_format_hgvsc_partial_overlap_is_release_gated_and_strand_aware() {
+        let exon = make_exon();
+        let exons = [&exon];
+        let ref_allele = "A".repeat(16);
+
+        let forward = make_transcript("lncRNA", 1, None, None);
+        assert_eq!(
+            format_hgvsc_with_semantics(
+                &forward,
+                &exons,
+                None,
+                None,
+                &ref_allele,
+                "-",
+                80,
+                95,
+                None,
+                VepSemantics::V115,
+            ),
+            None
+        );
+        assert_eq!(
+            format_hgvsc_with_semantics(
+                &forward,
+                &exons,
+                None,
+                None,
+                &ref_allele,
+                "-",
+                80,
+                95,
+                None,
+                VepSemantics::V116,
+            )
+            .as_deref(),
+            Some("ENSTHGVS000001.1:n.1_6del")
+        );
+
+        let reverse = make_transcript("lncRNA", -1, None, None);
+        assert_eq!(
+            format_hgvsc_with_semantics(
+                &reverse,
+                &exons,
+                None,
+                None,
+                &ref_allele,
+                "-",
+                135,
+                150,
+                None,
+                VepSemantics::V116,
+            )
+            .as_deref(),
+            Some("ENSTHGVS000001.1:n.1_6del")
+        );
+    }
+
+    #[test]
+    fn test_format_hgvsc_partial_overlap_clamps_before_hgvs_offset() {
+        let tx = make_transcript("lncRNA", 1, None, None);
+        let exon = make_exon();
+        let exons = [&exon];
+        let ref_allele = "A".repeat(16);
+        let shift = HgvsGenomicShift {
+            strand: 1,
+            shift_length: 3,
+            start: 83,
+            end: 98,
+            shifted_allele_string: ref_allele.clone(),
+            shifted_compare_allele: ref_allele.clone(),
+            shifted_output_allele: "-".to_string(),
+            ref_orig_allele_string: ref_allele.clone(),
+            alt_orig_allele_string: "-".to_string(),
+            five_prime_flanking_seq: String::new(),
+            three_prime_flanking_seq: String::new(),
+            five_prime_context: String::new(),
+            three_prime_context: String::new(),
+        };
+
+        assert_eq!(
+            format_hgvsc_with_semantics(
+                &tx,
+                &exons,
+                None,
+                None,
+                &ref_allele,
+                "-",
+                80,
+                95,
+                Some(&shift),
+                VepSemantics::V116,
+            )
+            .as_deref(),
+            Some("ENSTHGVS000001.1:n.4_9del")
+        );
+    }
+
+    #[test]
+    fn test_format_hgvsc_partial_overlap_rejects_wholly_outside_and_shift_overrun() {
+        let tx = make_transcript("lncRNA", 1, None, None);
+        let exon = make_exon();
+        let exons = [&exon];
+        let ref_allele = "A".repeat(16);
+        assert_eq!(
+            format_hgvsc_with_semantics(
+                &tx,
+                &exons,
+                None,
+                None,
+                &ref_allele,
+                "-",
+                50,
+                65,
+                None,
+                VepSemantics::V116,
+            ),
+            None
+        );
+
+        let shift = HgvsGenomicShift {
+            strand: 1,
+            shift_length: 1,
+            start: 136,
+            end: 151,
+            shifted_allele_string: ref_allele.clone(),
+            shifted_compare_allele: ref_allele.clone(),
+            shifted_output_allele: "-".to_string(),
+            ref_orig_allele_string: ref_allele.clone(),
+            alt_orig_allele_string: "-".to_string(),
+            five_prime_flanking_seq: String::new(),
+            three_prime_flanking_seq: String::new(),
+            five_prime_context: String::new(),
+            three_prime_context: String::new(),
+        };
+        assert_eq!(
+            format_hgvsc_with_semantics(
+                &tx,
+                &exons,
+                None,
+                None,
+                &ref_allele,
+                "-",
+                135,
+                150,
+                Some(&shift),
+                VepSemantics::V116,
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn test_format_hgvsc_uses_negative_utr_coordinate() {
         let tx = make_transcript("protein_coding", 1, Some(100), Some(108));
         let exon = make_exon();
@@ -4071,6 +4396,38 @@ mod tests {
     fn make_nm_001172437_failed_bam_edit_transcript() -> (TranscriptFeature, [ExonFeature; 1]) {
         let (mut tx, exons) = make_nm_001172437_same_coordinate_multibase_edit_transcript();
         tx.bam_edit_status = Some("failed".to_string());
+        (tx, exons)
+    }
+
+    fn make_nm_002457_failed_bam_repeat_transcript() -> (TranscriptFeature, [ExonFeature; 1]) {
+        // Exact release/116 cache state needed for the chr11:1094638
+        // repeat-deletion residual. The selected mapper segment is sufficient
+        // to reproduce the cDNA/CDS coordinates around the variant.
+        let mut tx = make_transcript("protein_coding", 1, Some(1_074_902), Some(1_110_355));
+        tx.transcript_id = "NM_002457.5".to_string();
+        tx.version = Some(1);
+        tx.source = Some("BestRefSeq".to_string());
+        tx.source_cache = Some("RefSeq".to_string());
+        tx.start = 1_074_874;
+        tx.end = 1_110_508;
+        tx.cdna_coding_start = Some(29);
+        tx.cdna_coding_end = Some(12_502);
+        tx.bam_edit_status = Some("failed".to_string());
+        tx.has_non_polya_rna_edit = false;
+        tx.refseq_edits.clear();
+        tx.cdna_mapper_segments = vec![TranscriptCdnaMapperSegment {
+            genomic_start: 1_094_142,
+            genomic_end: 1_098_212,
+            cdna_start: 3_927,
+            cdna_end: 7_997,
+            ori: 1,
+        }];
+        let exons = [ExonFeature {
+            transcript_id: tx.transcript_id.clone(),
+            exon_number: 30,
+            start: 1_094_142,
+            end: 1_098_212,
+        }];
         (tx, exons)
     }
 
@@ -5384,6 +5741,82 @@ mod tests {
         assert_eq!(
             hgvsc_offset_for_output(&tx, &variant, "T", Some("NM_001172437.2:c.*2307del"),),
             Some(6)
+        );
+    }
+
+    #[test]
+    fn test_nm_002457_failed_bam_repeat_uses_shifted_used_ref_for_hgvsc() {
+        let (tx, exons_owned) = make_nm_002457_failed_bam_repeat_transcript();
+        let exons = exons_owned.iter().collect::<Vec<_>>();
+        let given_ref = "CCAACCACCACTCCCAGCCCT";
+        let used_ref = "CACCACTCCCAGCCCTCCAAC";
+        let shift = HgvsGenomicShift {
+            strand: 1,
+            shift_length: 47,
+            start: 1_094_686,
+            end: 1_094_706,
+            shifted_compare_allele: "-".to_string(),
+            shifted_allele_string: used_ref.to_string(),
+            shifted_output_allele: "-".to_string(),
+            ref_orig_allele_string: given_ref.to_string(),
+            alt_orig_allele_string: "-".to_string(),
+            five_prime_flanking_seq: String::new(),
+            three_prime_flanking_seq: String::new(),
+            five_prime_context: String::new(),
+            three_prime_context: String::new(),
+        };
+
+        assert_eq!(
+            format_hgvsc(
+                &tx,
+                &exons,
+                None,
+                None,
+                used_ref,
+                "-",
+                1_094_639,
+                1_094_659,
+                Some(&shift),
+            )
+            .as_deref(),
+            Some("NM_002457.5:c.4443_4463del")
+        );
+    }
+
+    #[test]
+    fn test_nm_002457_failed_bam_repeat_reports_47_base_hgvs_offset() {
+        let (tx, _) = make_nm_002457_failed_bam_repeat_transcript();
+        let given_ref = "CCAACCACCACTCCCAGCCCT";
+        let used_ref = "CACCACTCCCAGCCCTCCAAC";
+        let mut variant = VariantInput::from_vcf(
+            "11".to_string(),
+            1_094_638,
+            1_094_659,
+            format!("A{given_ref}"),
+            "A".to_string(),
+        );
+        assert_eq!(variant.ref_allele, given_ref);
+        assert_eq!(variant.start, 1_094_639);
+        assert_eq!(variant.end, 1_094_659);
+        variant.hgvs_shift_forward = Some(HgvsGenomicShift {
+            strand: 1,
+            shift_length: 47,
+            start: 1_094_686,
+            end: 1_094_706,
+            shifted_compare_allele: "-".to_string(),
+            shifted_allele_string: used_ref.to_string(),
+            shifted_output_allele: "-".to_string(),
+            ref_orig_allele_string: given_ref.to_string(),
+            alt_orig_allele_string: "-".to_string(),
+            five_prime_flanking_seq: String::new(),
+            three_prime_flanking_seq: String::new(),
+            five_prime_context: String::new(),
+            three_prime_context: String::new(),
+        });
+
+        assert_eq!(
+            hgvsc_offset_for_output(&tx, &variant, used_ref, Some("NM_002457.5:c.4443_4463del"),),
+            Some(47)
         );
     }
 

--- a/datafusion/bio-function-vep/src/hgvs.rs
+++ b/datafusion/bio-function-vep/src/hgvs.rs
@@ -2022,6 +2022,20 @@ pub fn format_hgvsp(
         }
     }
 
+    // VEP normalizes peptide terminators from `*` to BioPerl's `X` after
+    // `_clip_alleles()` and before converting the peptide strings to
+    // three-letter HGVS residues. That ordering is observable when an
+    // ambiguous affected peptide contains `X`: `*/X` becomes synonymous,
+    // while `*/YX` remains a delins ending in Ter instead of a stop-loss
+    // extension.
+    //
+    // Traceability:
+    // - Ensembl Variation
+    //   `TranscriptVariationAllele::_get_hgvs_protein_type()`
+    //   <https://github.com/Ensembl/ensembl-variation/blob/release/116/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L2041-L2077>
+    notation.ref_allele = notation.ref_allele.replace('*', "X");
+    notation.alt_allele = notation.alt_allele.replace('*', "X");
+
     format_hgvsp_notation(&protein_id, &notation, protein)
 }
 
@@ -2880,6 +2894,42 @@ mod tests {
             format_hgvsp(&translation, &protein, true),
             Some("ENSPHGVS000001.1:p.Ter3GlnextTer1".to_string())
         );
+    }
+
+    #[test]
+    fn test_format_hgvsp_ambiguous_terminal_peptides_follow_vep_x_normalization() {
+        let translation = make_translation();
+        let cases = [
+            (144, 144, "*", "X", "ENSPHGVS000001.1:p.Ter144="),
+            (
+                172,
+                173,
+                "S*",
+                "X",
+                "ENSPHGVS000001.1:p.Ser172_Ter173delinsTer",
+            ),
+            (760, 760, "*", "YX", "ENSPHGVS000001.1:p.Ter760delinsTyrTer"),
+        ];
+
+        for (start, end, ref_peptide, alt_peptide, expected) in cases {
+            let protein = ProteinHgvsData {
+                start,
+                end,
+                ref_peptide: ref_peptide.to_string(),
+                alt_peptide: alt_peptide.to_string(),
+                ref_translation: "MA*".to_string(),
+                alt_translation: "MAY*".to_string(),
+                alt_translation_extension: Some("MAY*".to_string()),
+                frameshift: false,
+                start_lost: false,
+                stop_lost: true,
+                native_refseq: false,
+            };
+            assert_eq!(
+                format_hgvsp(&translation, &protein, true),
+                Some(expected.to_string())
+            );
+        }
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/lib.rs
+++ b/datafusion/bio-function-vep/src/lib.rs
@@ -54,6 +54,7 @@ pub mod golden_benchmark;
 pub mod hgvs;
 pub mod lookup_provider;
 pub mod miss_worklist;
+pub(crate) mod motif_matrix;
 pub(crate) mod ordered_drain;
 #[cfg(feature = "parquet-cache")]
 pub mod parquet_cache;

--- a/datafusion/bio-function-vep/src/lib.rs
+++ b/datafusion/bio-function-vep/src/lib.rs
@@ -47,6 +47,8 @@ pub mod cache;
 #[cfg(feature = "cache-builder")]
 pub mod cache_builder;
 pub(crate) mod cache_common;
+#[cfg(feature = "parquet-cache")]
+pub mod cache_identity;
 pub(crate) mod cache_source;
 pub(crate) mod colocated;
 pub mod coordinate;
@@ -67,6 +69,7 @@ pub mod sift_decode;
 pub mod so_terms;
 pub mod transcript_consequence;
 pub mod vcf_sink;
+pub mod vep_semantics;
 pub(crate) mod window_planner;
 
 pub use sift_decode::{register_vep_sift_functions, vep_decode_sift_predictions_udf};

--- a/datafusion/bio-function-vep/src/motif_matrix.rs
+++ b/datafusion/bio-function-vep/src/motif_matrix.rs
@@ -150,8 +150,11 @@ impl MotifMatrix {
 /// `MotifFeatureVariationAllele::motif_start` / `motif_end` produce it.
 ///
 /// On the reverse strand both are mirrored, which puts `end` *before* `start`
-/// for multi-base variants. That is what Ensembl does, and the splice below
-/// keys off `start` either way.
+/// for multi-base variants. Ensembl release 116 deliberately still splices at
+/// `motif_start - 1`, not at the lower of the two mirrored coordinates:
+/// <https://github.com/Ensembl/ensembl-variation/blob/release/116/modules/Bio/EnsEMBL/Variation/MotifFeatureVariationAllele.pm#L211-L251>.
+/// Preserve that behavior even though it looks counter-intuitive; this module
+/// implements VEP concordance rather than an independent PWM correction.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct MotifPlacement {
     pub start: i64,
@@ -351,6 +354,30 @@ mod tests {
             .relative_sequence_similarity_score("ACTCTCCAGGGAAA")
             .unwrap();
         assert!((delta - (variant - reference)).abs() < 1e-12);
+    }
+
+    /// Release 116 reverse-complements the allele but still uses
+    /// `motif_start - 1` when `motif_end < motif_start` for a reverse-strand
+    /// MNV. Pin that exact VEP behavior rather than "correcting" the offset to
+    /// `min(start, end)`.
+    #[test]
+    fn score_delta_reverse_strand_mnv_uses_vep_116_motif_start() {
+        let matrix = ebf1_matrix();
+        let motif_seq = "ACTCTCCAGGGATT";
+        let placement = MotifPlacement { start: 8, end: 7 };
+        let delta = motif_score_delta(&matrix, motif_seq, 14, placement, "AC", "AA").unwrap();
+
+        let reference = matrix
+            .relative_sequence_similarity_score(motif_seq)
+            .unwrap();
+        let vep_variant = matrix
+            .relative_sequence_similarity_score("ACTCTCCAAGGATT")
+            .unwrap();
+        let lower_coordinate_variant = matrix
+            .relative_sequence_similarity_score("ACTCTCAAGGGATT")
+            .unwrap();
+        assert!((delta - (vep_variant - reference)).abs() < 1e-12);
+        assert!((delta - (lower_coordinate_variant - reference)).abs() > 1e-12);
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/motif_matrix.rs
+++ b/datafusion/bio-function-vep/src/motif_matrix.rs
@@ -1,0 +1,365 @@
+//! Position frequency matrix scoring behind VEP's `HIGH_INF_POS` and
+//! `MOTIF_SCORE_CHANGE`.
+//!
+//! Mirrors, in order:
+//! - `Bio::EnsEMBL::Funcgen::BindingMatrix::Converter` — the
+//!   frequencies → probabilities → {weights, bits} conversions,
+//! - `Bio::EnsEMBL::Funcgen::BindingMatrix` — `is_position_informative` and
+//!   `relative_sequence_similarity_score`,
+//! - `Bio::EnsEMBL::Variation::MotifFeatureVariationAllele::motif_score_delta`.
+//!
+//! Matrices arrive from the cache as the flat `binding_matrix_elements`
+//! encoding: `A,C,G,T` frequencies per position, positions joined by `;`.
+
+/// Pseudocount added to every frequency before normalising to probabilities.
+/// `Converter::from_frequencies_to_probabilities` defaults to 0.1.
+const PSEUDOCOUNT: f64 = 0.1;
+
+/// Background probability per nucleotide, the Converter's default expected
+/// frequency. Weights are `log2(observed / expected)`.
+const EXPECTED_FREQUENCY: f64 = 0.25;
+
+/// Information content, in bits, above which a position counts as informative.
+/// `BindingMatrix::is_position_informative` defaults to 1.5 and VEP never
+/// overrides it.
+const INFORMATIVE_THRESHOLD_BITS: f64 = 1.5;
+
+/// The unit `binding_matrix_elements` must be in for scoring to be meaningful.
+/// Ensembl caches only ship frequency matrices, and the Converter refuses any
+/// other unit outright.
+pub(crate) const FREQUENCIES_UNIT: &str = "Frequencies";
+
+/// A binding matrix as frequencies, one `[A, C, G, T]` column per position.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MotifMatrix {
+    columns: Vec<[f64; 4]>,
+}
+
+/// Index of a nucleotide in a matrix column, or `None` for anything outside
+/// `ACGT` (`N` and IUPAC codes included — Perl throws on those, we decline to
+/// score).
+fn base_index(base: u8) -> Option<usize> {
+    match base.to_ascii_uppercase() {
+        b'A' => Some(0),
+        b'C' => Some(1),
+        b'G' => Some(2),
+        b'T' => Some(3),
+        _ => None,
+    }
+}
+
+impl MotifMatrix {
+    /// Parses the flat cache encoding. Yields `None` if any column is
+    /// malformed, so a half-read matrix never produces a score.
+    pub(crate) fn parse(elements: &str) -> Option<Self> {
+        let mut columns = Vec::new();
+        for column in elements.split(';') {
+            let mut frequencies = [0.0f64; 4];
+            let mut count = 0usize;
+            for (index, value) in column.split(',').enumerate() {
+                if index >= 4 {
+                    return None;
+                }
+                frequencies[index] = value.trim().parse::<f64>().ok()?;
+                count += 1;
+            }
+            if count != 4 {
+                return None;
+            }
+            columns.push(frequencies);
+        }
+        (!columns.is_empty()).then_some(Self { columns })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.columns.len()
+    }
+
+    /// `Converter::from_frequencies_to_probabilities`:
+    /// `(frequency + pseudocount) / (column_sum + 4 * pseudocount)`.
+    fn probabilities(&self, index: usize) -> [f64; 4] {
+        let column = self.columns[index];
+        let sum: f64 = column.iter().sum();
+        let denominator = sum + 4.0 * PSEUDOCOUNT;
+        let mut probabilities = [0.0f64; 4];
+        for (slot, frequency) in probabilities.iter_mut().zip(column.iter()) {
+            *slot = (frequency + PSEUDOCOUNT) / denominator;
+        }
+        probabilities
+    }
+
+    /// `Converter::from_probabilities_to_weights`: `log2(p / 0.25)`.
+    fn weights(&self, index: usize) -> [f64; 4] {
+        let mut weights = self.probabilities(index);
+        for weight in weights.iter_mut() {
+            *weight = (*weight / EXPECTED_FREQUENCY).log2();
+        }
+        weights
+    }
+
+    /// `BindingMatrix::is_position_informative`, on a 1-based position.
+    ///
+    /// The bits matrix is `p * (2 - H)` per nucleotide with
+    /// `H = -sum(p * log2(p))`; the position is informative when those bits sum
+    /// above 1.5.
+    pub(crate) fn is_position_informative(&self, position: usize) -> bool {
+        if position < 1 || position > self.len() {
+            return false;
+        }
+        let probabilities = self.probabilities(position - 1);
+        let entropy: f64 = probabilities
+            .iter()
+            .map(|probability| -probability * probability.log2())
+            .sum();
+        let information_content = 2.0 - entropy;
+        let bits: f64 = probabilities
+            .iter()
+            .map(|probability| probability * information_content)
+            .sum();
+        bits > INFORMATIVE_THRESHOLD_BITS
+    }
+
+    /// `BindingMatrix::relative_sequence_similarity_score` on the log scale
+    /// (VEP never passes `$linear`).
+    ///
+    /// Perl throws when the sequence has the wrong length or non-`ACGT`
+    /// characters; both yield `None` here, which surfaces as an empty field
+    /// rather than a fatal error.
+    pub(crate) fn relative_sequence_similarity_score(&self, sequence: &str) -> Option<f64> {
+        let bases = sequence.as_bytes();
+        if bases.len() != self.len() {
+            return None;
+        }
+
+        let mut score = 0.0f64;
+        let mut minimum = 0.0f64;
+        let mut maximum = 0.0f64;
+        for (index, base) in bases.iter().enumerate() {
+            let weights = self.weights(index);
+            score += weights[base_index(*base)?];
+            minimum += weights.iter().copied().fold(f64::INFINITY, f64::min);
+            maximum += weights.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        }
+
+        let span = maximum - minimum;
+        (span != 0.0).then(|| (score - minimum) / span)
+    }
+}
+
+/// Where a variant sits inside a motif, in motif orientation, as
+/// `MotifFeatureVariationAllele::motif_start` / `motif_end` produce it.
+///
+/// On the reverse strand both are mirrored, which puts `end` *before* `start`
+/// for multi-base variants. That is what Ensembl does, and the splice below
+/// keys off `start` either way.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MotifPlacement {
+    pub start: i64,
+    pub end: i64,
+}
+
+/// `MotifFeatureVariationAllele::motif_score_delta`: the change in relative
+/// binding affinity between the reference and variant motif sequences.
+///
+/// `reference_allele` and `variant_allele` must already be in motif
+/// orientation (reverse-complemented for reverse-strand motifs) and in VEP's
+/// allele convention, where `-` marks an empty allele.
+///
+/// Yields `None` — an empty `MOTIF_SCORE_CHANGE` — whenever Ensembl bails out:
+/// an indel allele, a length change, a placement outside the motif, or a
+/// sequence the matrix cannot score.
+pub(crate) fn motif_score_delta(
+    matrix: &MotifMatrix,
+    motif_seq: &str,
+    motif_span_length: i64,
+    placement: MotifPlacement,
+    reference_allele: &str,
+    variant_allele: &str,
+) -> Option<f64> {
+    // "we can't call a score because the sequence will change length"
+    if reference_allele == "-"
+        || variant_allele == "-"
+        || reference_allele.len() != variant_allele.len()
+    {
+        return None;
+    }
+
+    let sequence_length = motif_seq.len() as i64;
+    let mut start = placement.start;
+    let mut allele = variant_allele;
+
+    // Ensembl trims the allele when the variant runs off either end of the
+    // motif. `motif_start` already rejects anything before position 1, so only
+    // the trailing overhang is reachable.
+    if placement.end > sequence_length {
+        let keep = sequence_length - start + 1;
+        if keep <= 0 {
+            return None;
+        }
+        allele = allele.get(..keep as usize)?;
+    }
+    if start < 1 {
+        allele = allele.get((1 - start) as usize..)?;
+        start = 1;
+    }
+
+    let allele_length = allele.len() as i64;
+    if allele_length > motif_span_length {
+        return None;
+    }
+
+    let reference_affinity = matrix.relative_sequence_similarity_score(motif_seq)?;
+
+    // Splice the variant allele in (0-based). Perl would grow the string if the
+    // replacement ran past the end and then discard the result on its
+    // length check; refuse up front instead.
+    let offset = (start - 1) as usize;
+    if offset + allele.len() > motif_seq.len() {
+        return None;
+    }
+    let mut variant_seq = String::with_capacity(motif_seq.len());
+    variant_seq.push_str(motif_seq.get(..offset)?);
+    variant_seq.push_str(allele);
+    variant_seq.push_str(motif_seq.get(offset + allele.len()..)?);
+
+    let variant_affinity = matrix.relative_sequence_similarity_score(&variant_seq)?;
+    Some(variant_affinity - reference_affinity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// ENSPFM0085 (EBF1), the release-116 matrix for the chr22 motifs used in
+    /// the parity runs.
+    fn ebf1_matrix() -> MotifMatrix {
+        MotifMatrix::parse(
+            "980,99,249,216;234,210,463,636;37,146,3,1544;5,1544,0,1;3,1544,9,61;\
+             0,1544,0,6;503,314,71,656;649,69,285,541;21,7,1544,0;63,2,1544,0;\
+             7,2,1544,15;1544,13,170,24;646,456,210,232;187,281,97,979",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_the_flat_cache_encoding() {
+        let matrix = MotifMatrix::parse("980,99,249,216;234,210,463,636").unwrap();
+        assert_eq!(matrix.len(), 2);
+        assert_eq!(matrix.columns[0], [980.0, 99.0, 249.0, 216.0]);
+        assert_eq!(matrix.columns[1], [234.0, 210.0, 463.0, 636.0]);
+    }
+
+    #[test]
+    fn refuses_malformed_matrices() {
+        assert_eq!(MotifMatrix::parse(""), None);
+        assert_eq!(MotifMatrix::parse("980,99,249"), None);
+        assert_eq!(MotifMatrix::parse("980,99,249,216,3"), None);
+        assert_eq!(MotifMatrix::parse("980,99,249,x"), None);
+    }
+
+    /// Position 4 of EBF1 is almost pure C (5,1544,0,1) and position 1 is
+    /// spread across all four bases, so one is informative and the other is
+    /// not.
+    #[test]
+    fn informative_positions_track_information_content() {
+        let matrix = ebf1_matrix();
+        assert!(matrix.is_position_informative(4));
+        assert!(!matrix.is_position_informative(1));
+    }
+
+    #[test]
+    fn positions_outside_the_matrix_are_not_informative() {
+        let matrix = ebf1_matrix();
+        assert!(!matrix.is_position_informative(0));
+        assert!(!matrix.is_position_informative(matrix.len() + 1));
+    }
+
+    /// The consensus sequence must score at or near 1, and a sequence built
+    /// from each position's rarest base at or near 0.
+    #[test]
+    fn relative_score_spans_zero_to_one() {
+        let matrix = ebf1_matrix();
+        let best = matrix.relative_sequence_similarity_score("ATCCCCTAGGGACT");
+        let worst = matrix.relative_sequence_similarity_score("GGGGGGGGTTTTGT");
+        let best = best.unwrap();
+        let worst = worst.unwrap();
+        assert!(best > worst);
+        assert!((0.0..=1.0).contains(&best));
+        assert!((0.0..=1.0).contains(&worst));
+    }
+
+    #[test]
+    fn relative_score_declines_wrong_length_or_ambiguous_sequence() {
+        let matrix = ebf1_matrix();
+        assert_eq!(matrix.relative_sequence_similarity_score("ACGT"), None);
+        assert_eq!(
+            matrix.relative_sequence_similarity_score("NCTCTCCAGGGATT"),
+            None
+        );
+    }
+
+    #[test]
+    fn score_delta_is_the_change_in_relative_affinity() {
+        let matrix = ebf1_matrix();
+        let motif_seq = "ACTCTCCAGGGATT";
+        let placement = MotifPlacement { start: 4, end: 4 };
+        let delta = motif_score_delta(&matrix, motif_seq, 14, placement, "C", "A").unwrap();
+
+        let reference = matrix
+            .relative_sequence_similarity_score(motif_seq)
+            .unwrap();
+        let variant = matrix
+            .relative_sequence_similarity_score("ACTATCCAGGGATT")
+            .unwrap();
+        assert!((delta - (variant - reference)).abs() < 1e-12);
+        // Replacing the near-invariant C at position 4 must lose affinity.
+        assert!(delta < 0.0);
+    }
+
+    #[test]
+    fn score_delta_declines_indels_and_length_changes() {
+        let matrix = ebf1_matrix();
+        let motif_seq = "ACTCTCCAGGGATT";
+        let placement = MotifPlacement { start: 4, end: 4 };
+        assert_eq!(
+            motif_score_delta(&matrix, motif_seq, 14, placement, "C", "-"),
+            None
+        );
+        assert_eq!(
+            motif_score_delta(&matrix, motif_seq, 14, placement, "-", "A"),
+            None
+        );
+        assert_eq!(
+            motif_score_delta(&matrix, motif_seq, 14, placement, "C", "AT"),
+            None
+        );
+    }
+
+    /// A variant whose allele runs past the motif end is trimmed to fit, the
+    /// way Ensembl trims it.
+    #[test]
+    fn score_delta_trims_an_allele_overhanging_the_motif() {
+        let matrix = ebf1_matrix();
+        let motif_seq = "ACTCTCCAGGGATT";
+        let placement = MotifPlacement { start: 13, end: 15 };
+        let delta = motif_score_delta(&matrix, motif_seq, 14, placement, "TTG", "AAA").unwrap();
+
+        let reference = matrix
+            .relative_sequence_similarity_score(motif_seq)
+            .unwrap();
+        let variant = matrix
+            .relative_sequence_similarity_score("ACTCTCCAGGGAAA")
+            .unwrap();
+        assert!((delta - (variant - reference)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn score_delta_declines_an_allele_longer_than_the_motif() {
+        let matrix = ebf1_matrix();
+        let placement = MotifPlacement { start: 1, end: 3 };
+        assert_eq!(
+            motif_score_delta(&matrix, "ACTCTCCAGGGATT", 2, placement, "ACT", "TGA"),
+            None
+        );
+    }
+}

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -1386,7 +1386,7 @@ impl TranscriptConsequenceEngine {
                                 };
                                 let codons = cc.codons.clone();
                                 let amino_acids = amino_acids_for_output(tx, tx_translation, cc);
-                                let protein_hgvs = protein_hgvs_for_output(
+                                let protein_hgvs = protein_hgvs_for_output_with_semantics(
                                     tx,
                                     tx_exons,
                                     tx_translation,
@@ -1395,13 +1395,14 @@ impl TranscriptConsequenceEngine {
                                     cc.protein_position_start
                                         .zip(cc.protein_position_end.or(cc.protein_position_start)),
                                     cc.protein_hgvs.as_ref(),
+                                    self.semantics,
                                     self.shift_hgvs,
                                 );
                                 (cds_pos, prot_pos, amino_acids, codons, protein_hgvs)
                             } else {
                                 // VEP can still emit HGVSp for HGVS-shifted indels whose
                                 // original consequence stayed coding_sequence_variant.
-                                let protein_hgvs = protein_hgvs_for_output(
+                                let protein_hgvs = protein_hgvs_for_output_with_semantics(
                                     tx,
                                     tx_exons,
                                     tx_translation,
@@ -1409,6 +1410,7 @@ impl TranscriptConsequenceEngine {
                                     original_allows_protein_hgvs,
                                     None,
                                     None,
+                                    self.semantics,
                                     self.shift_hgvs,
                                 );
                                 (None, None, None, None, protein_hgvs)
@@ -5966,11 +5968,49 @@ fn protein_hgvs_for_output(
     fallback: Option<&crate::hgvs::ProteinHgvsData>,
     shift_hgvs: bool,
 ) -> Option<crate::hgvs::ProteinHgvsData> {
+    protein_hgvs_for_output_with_semantics(
+        tx,
+        tx_exons,
+        tx_translation,
+        variant,
+        original_allows_protein_hgvs,
+        original_protein_bounds,
+        fallback,
+        crate::vep_semantics::VepSemantics::V115,
+        shift_hgvs,
+    )
+}
+
+fn protein_hgvs_for_output_with_semantics(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    tx_translation: Option<&TranslationFeature>,
+    variant: &VariantInput,
+    original_allows_protein_hgvs: bool,
+    original_protein_bounds: Option<(usize, usize)>,
+    fallback: Option<&crate::hgvs::ProteinHgvsData>,
+    semantics: crate::vep_semantics::VepSemantics,
+    shift_hgvs: bool,
+) -> Option<crate::hgvs::ProteinHgvsData> {
     // Ensembl only emits HGVSp when the original transcript variation is
     // coding (`$pre->{coding}`), even if HGVS 3' shifting later moves an
     // intronic indel into CDS coordinates for HGVSc.
     if !original_allows_protein_hgvs {
         return None;
+    }
+
+    // Release 116's stop-predicate changes expose ambiguous local terminal
+    // peptides such as `*/X`, `S*/X`, and `*/YX`. VEP's shifted TVA replay
+    // preserves that original local peptide window for protein HGVS. Keep the
+    // same window here instead of replacing it with a translated extension
+    // that drops the terminal `X`; `format_hgvsp()` then applies VEP's
+    // star-to-X normalization in the official order.
+    if semantics.vep116_stop_predicates()
+        && fallback.is_some_and(|protein| {
+            protein.ref_peptide.contains('*') && protein.alt_peptide.contains('X')
+        })
+    {
+        return fallback.cloned();
     }
 
     if !shift_hgvs {

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use coitrees::{COITree, GenericInterval, Interval, IntervalTree};
 
 use crate::hgvs::{HgvsGenomicShift, HgvscProfile};
+use crate::motif_matrix::{FREQUENCIES_UNIT, MotifMatrix, MotifPlacement, motif_score_delta};
 use crate::so_terms::{ALL_SO_TERMS, SoTerm};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -562,6 +563,16 @@ pub struct MotifFeature {
     /// BindingMatrix length; Ensembl VEP uses it to place a variant within a
     /// reverse-strand motif and to bounds-check MOTIF_POS.
     pub binding_matrix_length: Option<i32>,
+    /// Position frequency matrix, flattened as `A,C,G,T` per position with
+    /// positions joined by `;`. Drives `HIGH_INF_POS` and
+    /// `MOTIF_SCORE_CHANGE`; both stay empty without it.
+    pub binding_matrix_elements: Option<String>,
+    /// Unit of `binding_matrix_elements`. Scoring only applies to
+    /// "Frequencies", the only unit Ensembl caches ship.
+    pub binding_matrix_unit: Option<String>,
+    /// The motif's reference sequence in motif orientation, scored against the
+    /// matrix to obtain `MOTIF_SCORE_CHANGE`.
+    pub motif_seq: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -649,6 +660,13 @@ pub struct TranscriptConsequence {
     /// MOTIF_POS: 1-based offset of the variant within the motif, in motif
     /// orientation.
     pub motif_pos: Option<i64>,
+    /// HIGH_INF_POS: whether the variant sits in a high-information position of
+    /// the binding matrix. Emitted as Y/N for every MotifFeature consequence
+    /// whose matrix is known, `None` when it is not.
+    pub high_inf_pos: Option<bool>,
+    /// MOTIF_SCORE_CHANGE, already formatted to three decimals the way VEP's
+    /// `sprintf("%.3f", $delta)` does.
+    pub motif_score_change: Option<String>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -2109,26 +2127,125 @@ impl TranscriptConsequenceEngine {
         }
     }
 
-    /// 1-based offset of `variant` within a motif, in motif orientation.
+    /// Where `variant` falls inside a motif, in motif orientation, before
+    /// either end is bounds-checked.
     ///
-    /// Forward-strand motifs count from the motif start, reverse-strand motifs
-    /// from the motif end, matching Ensembl VEP's MOTIF_POS.
-    fn motif_position(variant: &VariantInput, m: &MotifFeature) -> Option<i64> {
-        // Mirrors MotifFeatureVariationAllele::motif_start in Ensembl VEP 116:
-        //   $mf_start = $vf->seq_region_start - $mf->seq_region_start + 1;
-        //   $mf_start = $matrix->length - $mf_start + 1 if $mf->strand < 0;
-        //   return undef if $mf_start > $mf->length or $mf_start < 1;
-        // The reverse-strand flip uses the *matrix* length, which equals the
-        // motif span only when the motif is not clipped; fall back to the span
-        // for caches predating the binding_matrix_length column.
+    /// Mirrors MotifFeatureVariationAllele::motif_start / motif_end in Ensembl
+    /// VEP 116:
+    ///   $mf_start = $vf->seq_region_start - $mf->seq_region_start + 1;
+    ///   $mf_start = $matrix->length - $mf_start + 1 if $mf->strand < 0;
+    /// The reverse-strand flip uses the *matrix* length, which equals the motif
+    /// span only when the motif is not clipped; fall back to the span for
+    /// caches predating the binding_matrix_length column. Note the flip leaves
+    /// `end` before `start` on the reverse strand — Ensembl does the same.
+    fn motif_placement(variant: &VariantInput, m: &MotifFeature) -> Option<MotifPlacement> {
         let strand = m.strand?;
         let motif_len = m.end - m.start + 1;
         let matrix_len = m.binding_matrix_length.map(i64::from).unwrap_or(motif_len);
-        let mut pos = variant.start - m.start + 1;
+        let mut start = variant.start - m.start + 1;
+        let mut end = variant.end - m.start + 1;
         if strand < 0 {
-            pos = matrix_len - pos + 1;
+            start = matrix_len - start + 1;
+            end = matrix_len - end + 1;
         }
+        Some(MotifPlacement { start, end })
+    }
+
+    /// 1-based offset of `variant` within a motif, in motif orientation.
+    ///
+    /// Forward-strand motifs count from the motif start, reverse-strand motifs
+    /// from the motif end, matching Ensembl VEP's MOTIF_POS. `motif_start`
+    /// bounds-checks against the motif span:
+    ///   return undef if $mf_start > $mf->length or $mf_start < 1;
+    fn motif_position(variant: &VariantInput, m: &MotifFeature) -> Option<i64> {
+        let motif_len = m.end - m.start + 1;
+        let pos = Self::motif_placement(variant, m)?.start;
         (pos >= 1 && pos <= motif_len).then_some(pos)
+    }
+
+    /// The motif's frequency matrix, if the cache carried a usable one.
+    ///
+    /// Ensembl's frequency-to-weights conversion is defined for frequency
+    /// matrices only, so an unexpected unit disables scoring rather than
+    /// producing a number that means something else.
+    fn motif_matrix(m: &MotifFeature) -> Option<MotifMatrix> {
+        match m.binding_matrix_unit.as_deref() {
+            None => {}
+            Some(unit) if unit.eq_ignore_ascii_case(FREQUENCIES_UNIT) => {}
+            Some(_) => return None,
+        }
+        MotifMatrix::parse(m.binding_matrix_elements.as_deref()?)
+    }
+
+    /// HIGH_INF_POS: whether the variant sits in a high-information position.
+    ///
+    /// `in_informative_position` scores true SNVs only — Ensembl returns 0
+    /// unless the variant spans a single base and neither side is an empty
+    /// allele — and every other MotifFeature consequence with a known matrix
+    /// still reports `N`.
+    fn motif_high_inf_pos(
+        variant: &VariantInput,
+        m: &MotifFeature,
+        matrix: &MotifMatrix,
+    ) -> Option<bool> {
+        let is_snv = variant.start == variant.end
+            && variant.ref_allele != "-"
+            && variant.alt_allele != "-"
+            && variant.alt_allele.len() == 1;
+        if !is_snv {
+            return Some(false);
+        }
+        let Some(position) = Self::motif_position(variant, m) else {
+            return Some(false);
+        };
+        Some(matrix.is_position_informative(position as usize))
+    }
+
+    /// MOTIF_SCORE_CHANGE, formatted the way VEP's `sprintf("%.3f", $delta)`
+    /// does. VEP only asks for a delta when the variant allele is plain DNA.
+    fn motif_score_change(
+        variant: &VariantInput,
+        m: &MotifFeature,
+        matrix: &MotifMatrix,
+    ) -> Option<String> {
+        if variant.alt_allele.is_empty()
+            || !variant
+                .alt_allele
+                .bytes()
+                .all(|b| matches!(b.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T'))
+        {
+            return None;
+        }
+
+        let motif_seq = m.motif_seq.as_deref()?;
+        let placement = Self::motif_placement(variant, m)?;
+        // motif_start rejects anything outside the motif; motif_end only
+        // rejects positions before it.
+        let motif_len = m.end - m.start + 1;
+        if placement.start < 1 || placement.start > motif_len || placement.end < 1 {
+            return None;
+        }
+
+        // Alleles are scored in motif orientation, as VEP's `feature_seq` is.
+        let strand = m.strand.unwrap_or(1);
+        let (reference, variant_allele) = if strand < 0 {
+            (
+                reverse_complement(&variant.ref_allele)?,
+                reverse_complement(&variant.alt_allele)?,
+            )
+        } else {
+            (variant.ref_allele.clone(), variant.alt_allele.clone())
+        };
+
+        let delta = motif_score_delta(
+            matrix,
+            motif_seq,
+            motif_len,
+            placement,
+            &reference,
+            &variant_allele,
+        )?;
+        Some(format!("{delta:.3}"))
     }
 
     fn append_tfbs_terms(
@@ -2176,6 +2293,7 @@ impl TranscriptConsequenceEngine {
             terms.insert(SoTerm::TfBindingSiteVariant);
             let mut ordered: Vec<SoTerm> = terms.into_iter().collect();
             ordered.sort_by_key(|t| t.rank());
+            let matrix = Self::motif_matrix(m);
             out.push(TranscriptConsequence {
                 transcript_id: Some(m.motif_id.clone()),
                 feature_type: FeatureType::MotifFeature,
@@ -2184,6 +2302,12 @@ impl TranscriptConsequenceEngine {
                 motif_transcription_factors: m.transcription_factors.clone(),
                 motif_strand: m.strand,
                 motif_pos: Self::motif_position(variant, m),
+                high_inf_pos: matrix
+                    .as_ref()
+                    .and_then(|matrix| Self::motif_high_inf_pos(variant, m, matrix)),
+                motif_score_change: matrix
+                    .as_ref()
+                    .and_then(|matrix| Self::motif_score_change(variant, m, matrix)),
                 ..Default::default()
             });
         }
@@ -2247,6 +2371,7 @@ impl TranscriptConsequenceEngine {
             terms.insert(SoTerm::TfBindingSiteVariant);
             let mut ordered: Vec<SoTerm> = terms.into_iter().collect();
             ordered.sort_by_key(|t| t.rank());
+            let matrix = Self::motif_matrix(m);
             out.push(TranscriptConsequence {
                 transcript_id: Some(m.motif_id.clone()),
                 feature_type: FeatureType::MotifFeature,
@@ -2255,6 +2380,12 @@ impl TranscriptConsequenceEngine {
                 motif_transcription_factors: m.transcription_factors.clone(),
                 motif_strand: m.strand,
                 motif_pos: Self::motif_position(variant, m),
+                high_inf_pos: matrix
+                    .as_ref()
+                    .and_then(|matrix| Self::motif_high_inf_pos(variant, m, matrix)),
+                motif_score_change: matrix
+                    .as_ref()
+                    .and_then(|matrix| Self::motif_score_change(variant, m, matrix)),
                 ..Default::default()
             });
         }
@@ -9209,6 +9340,9 @@ mod tests {
             transcription_factors: None,
             strand: None,
             binding_matrix_length: None,
+            binding_matrix_elements: None,
+            binding_matrix_unit: None,
+            motif_seq: None,
         }
     }
 
@@ -9230,6 +9364,9 @@ mod tests {
             transcription_factors: Some(transcription_factors.to_string()),
             strand: Some(strand),
             binding_matrix_length: Some((end - start + 1) as i32),
+            binding_matrix_elements: None,
+            binding_matrix_unit: None,
+            motif_seq: None,
         }
     }
 
@@ -22285,6 +22422,166 @@ mod tests {
             .collect();
         assert_eq!(by_id.get("ENSM00000588617"), Some(&Some(3)));
         assert_eq!(by_id.get("ENSM00000588616"), Some(&Some(21)));
+    }
+
+    /// ENSPFM0042 (CTCF), the release-116 matrix behind chr22:17037897.
+    const ENSPFM0042: &str = "5461,545,1745,4231;2613,450,11439,632;0,8101,0,668;\
+        64,0,12567,86;639,9651,8,46;45,10170,0,0;5877,5220,207,241;87,7119,0,3957;\
+        0,8928,1,0;39,48,23,14241;10634,290,1632,1371;91,1625,9894,774;\
+        186,5181,0,8026;2,0,8521,121;409,113,7515,2252;2682,4990,153,9808;\
+        4226,3598,2490,1308";
+
+    /// ENSPFM0510 (TBX21), the matrix behind the reverse-strand chr22:17088127
+    /// motifs.
+    const ENSPFM0510: &str = "121,2673,669,8917;359,3880,51,7751;6,11,50,10437;\
+        592,10452,589,12;8668,16,2607,46;11,11094,12,8;10304,128,73,26;2,11103,4,3;\
+        2064,9030,43,626;54,226,302,10463;341,5870,515,3943;4493,525,477,4449;\
+        3893,522,5666,338;10475,354,202,53;628,59,9016,2021;4,4,11092,6;\
+        24,72,131,10337;6,15,11024,9;54,2673,20,8608;16,606,10470,615;\
+        10432,65,10,5;7706,68,3935,335;8919,658,2618,116";
+
+    fn motif_with_pwm(
+        id: &str,
+        start: i64,
+        end: i64,
+        strand: i8,
+        elements: &str,
+        seq: &str,
+    ) -> MotifFeature {
+        let mut m = motif_with_matrix(id, "22", start, end, "ENSPFM", "TF", strand);
+        m.binding_matrix_elements = Some(elements.to_string());
+        m.binding_matrix_unit = Some("Frequencies".to_string());
+        m.motif_seq = Some(seq.to_string());
+        m
+    }
+
+    fn motif_consequence<'a>(
+        out: &'a [TranscriptConsequence],
+        id: &str,
+    ) -> &'a TranscriptConsequence {
+        out.iter()
+            .find(|a| {
+                a.feature_type == FeatureType::MotifFeature
+                    && a.transcript_id.as_deref() == Some(id)
+            })
+            .expect("motif consequence")
+    }
+
+    /// Real chr22:17037897 C>T against ENSM00000588585. VEP 116 reports
+    /// MOTIF_POS 5, HIGH_INF_POS Y, MOTIF_SCORE_CHANGE -0.045.
+    #[test]
+    fn motif_scoring_matches_vep_on_a_forward_strand_snv() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_pwm(
+            "ENSM00000588585",
+            17_037_893,
+            17_037_909,
+            1,
+            ENSPFM0042,
+            "ACCTCCACCTCCCGGTT",
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 17_037_897, 17_037_897, "C", "T"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000588585");
+        assert_eq!(consequence.motif_pos, Some(5));
+        assert_eq!(consequence.high_inf_pos, Some(true));
+        assert_eq!(consequence.motif_score_change.as_deref(), Some("-0.045"));
+    }
+
+    /// Real chr22:17088127 T>A against the reverse-strand ENSM00000588616.
+    /// VEP 116 reports MOTIF_POS 21, HIGH_INF_POS Y, MOTIF_SCORE_CHANGE -0.058
+    /// — the allele has to be reverse-complemented before it is scored.
+    #[test]
+    fn motif_scoring_matches_vep_on_a_reverse_strand_snv() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_pwm(
+            "ENSM00000588616",
+            17_088_125,
+            17_088_147,
+            -1,
+            ENSPFM0510,
+            "TAGCACTCATTAGCTGTGCGACC",
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 17_088_127, 17_088_127, "T", "A"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000588616");
+        assert_eq!(consequence.motif_pos, Some(21));
+        assert_eq!(consequence.high_inf_pos, Some(true));
+        assert_eq!(consequence.motif_score_change.as_deref(), Some("-0.058"));
+    }
+
+    /// A deletion is not a "true SNP", so HIGH_INF_POS reports N and
+    /// MOTIF_SCORE_CHANGE stays empty — the sequence would change length.
+    #[test]
+    fn motif_scoring_declines_indels() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_pwm(
+            "ENSM00000588585",
+            17_037_893,
+            17_037_909,
+            1,
+            ENSPFM0042,
+            "ACCTCCACCTCCCGGTT",
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 17_037_896, 17_037_897, "CC", "C"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000588585");
+        assert_eq!(consequence.high_inf_pos, Some(false));
+        assert_eq!(consequence.motif_score_change, None);
+    }
+
+    /// Caches built before the matrix columns landed leave both fields empty
+    /// rather than guessing.
+    #[test]
+    fn motif_scoring_is_absent_without_a_matrix() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_matrix(
+            "ENSM00000588585",
+            "22",
+            17_037_893,
+            17_037_909,
+            "ENSPFM0042",
+            "CTCF",
+            1,
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 17_037_897, 17_037_897, "C", "T"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000588585");
+        assert_eq!(consequence.motif_pos, Some(5));
+        assert_eq!(consequence.high_inf_pos, None);
+        assert_eq!(consequence.motif_score_change, None);
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -553,6 +553,12 @@ pub struct MotifFeature {
     pub chrom: String,
     pub start: i64,
     pub end: i64,
+    /// BindingMatrix stable id, surfaced as VEP's `MOTIF_NAME`.
+    pub binding_matrix: Option<String>,
+    /// Comma-separated TF names, surfaced as `TRANSCRIPTION_FACTORS`.
+    pub transcription_factors: Option<String>,
+    /// Motif orientation, surfaced as `STRAND` for motif consequences.
+    pub strand: Option<i8>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -630,6 +636,13 @@ pub struct TranscriptConsequence {
     /// USED_REF field: transcript-reference allele after RefSeq edit handling,
     /// emitted in VF/genomic orientation.
     pub used_ref: Option<String>,
+    /// MOTIF_NAME: BindingMatrix stable id, MotifFeature consequences only.
+    pub motif_name: Option<String>,
+    /// TRANSCRIPTION_FACTORS: comma-separated TF names, MotifFeature only.
+    pub motif_transcription_factors: Option<String>,
+    /// STRAND for MotifFeature consequences, which have no transcript to
+    /// derive orientation from.
+    pub motif_strand: Option<i8>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -2139,6 +2152,9 @@ impl TranscriptConsequenceEngine {
                 transcript_id: Some(m.motif_id.clone()),
                 feature_type: FeatureType::MotifFeature,
                 terms: ordered,
+                motif_name: m.binding_matrix.clone(),
+                motif_transcription_factors: m.transcription_factors.clone(),
+                motif_strand: m.strand,
                 ..Default::default()
             });
         }
@@ -2206,6 +2222,9 @@ impl TranscriptConsequenceEngine {
                 transcript_id: Some(m.motif_id.clone()),
                 feature_type: FeatureType::MotifFeature,
                 terms: ordered,
+                motif_name: m.binding_matrix.clone(),
+                motif_transcription_factors: m.transcription_factors.clone(),
+                motif_strand: m.strand,
                 ..Default::default()
             });
         }
@@ -9156,6 +9175,29 @@ mod tests {
             chrom: chrom.to_string(),
             start,
             end,
+            binding_matrix: None,
+            transcription_factors: None,
+            strand: None,
+        }
+    }
+
+    fn motif_with_matrix(
+        id: &str,
+        chrom: &str,
+        start: i64,
+        end: i64,
+        binding_matrix: &str,
+        transcription_factors: &str,
+        strand: i8,
+    ) -> MotifFeature {
+        MotifFeature {
+            motif_id: id.to_string(),
+            chrom: chrom.to_string(),
+            start,
+            end,
+            binding_matrix: Some(binding_matrix.to_string()),
+            transcription_factors: Some(transcription_factors.to_string()),
+            strand: Some(strand),
         }
     }
 
@@ -22129,5 +22171,44 @@ mod tests {
                 .iter()
                 .any(|a| a.feature_type == FeatureType::RegulatoryFeature)
         );
+    }
+
+    /// MOTIF_NAME / TRANSCRIPTION_FACTORS / STRAND must reach the consequence
+    /// from the cache row, matching Ensembl VEP for chr22:17088127.
+    #[test]
+    fn motif_consequence_carries_binding_matrix_metadata() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_matrix(
+            "ENSM00000588617",
+            "22",
+            17_088_125,
+            17_088_147,
+            "ENSPFM0510",
+            "TBX21",
+            1,
+        )];
+
+        let assignments = engine.evaluate_variant_with_context(
+            &var("22", 17_088_127, 17_088_127, "T", "A"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+
+        let motif_csq = assignments
+            .iter()
+            .find(|a| a.feature_type == FeatureType::MotifFeature)
+            .expect("expected a MotifFeature consequence");
+        assert_eq!(motif_csq.transcript_id.as_deref(), Some("ENSM00000588617"));
+        assert_eq!(motif_csq.motif_name.as_deref(), Some("ENSPFM0510"));
+        assert_eq!(
+            motif_csq.motif_transcription_factors.as_deref(),
+            Some("TBX21")
+        );
+        assert_eq!(motif_csq.motif_strand, Some(1));
     }
 }

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -559,6 +559,9 @@ pub struct MotifFeature {
     pub transcription_factors: Option<String>,
     /// Motif orientation, surfaced as `STRAND` for motif consequences.
     pub strand: Option<i8>,
+    /// BindingMatrix length; Ensembl VEP uses it to place a variant within a
+    /// reverse-strand motif and to bounds-check MOTIF_POS.
+    pub binding_matrix_length: Option<i32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2111,13 +2114,21 @@ impl TranscriptConsequenceEngine {
     /// Forward-strand motifs count from the motif start, reverse-strand motifs
     /// from the motif end, matching Ensembl VEP's MOTIF_POS.
     fn motif_position(variant: &VariantInput, m: &MotifFeature) -> Option<i64> {
+        // Mirrors MotifFeatureVariationAllele::motif_start in Ensembl VEP 116:
+        //   $mf_start = $vf->seq_region_start - $mf->seq_region_start + 1;
+        //   $mf_start = $matrix->length - $mf_start + 1 if $mf->strand < 0;
+        //   return undef if $mf_start > $mf->length or $mf_start < 1;
+        // The reverse-strand flip uses the *matrix* length, which equals the
+        // motif span only when the motif is not clipped; fall back to the span
+        // for caches predating the binding_matrix_length column.
         let strand = m.strand?;
-        let pos = if strand >= 0 {
-            variant.start - m.start + 1
-        } else {
-            m.end - variant.start + 1
-        };
-        (pos >= 1).then_some(pos)
+        let motif_len = m.end - m.start + 1;
+        let matrix_len = m.binding_matrix_length.map(i64::from).unwrap_or(motif_len);
+        let mut pos = variant.start - m.start + 1;
+        if strand < 0 {
+            pos = matrix_len - pos + 1;
+        }
+        (pos >= 1 && pos <= motif_len).then_some(pos)
     }
 
     fn append_tfbs_terms(
@@ -9197,6 +9208,7 @@ mod tests {
             binding_matrix: None,
             transcription_factors: None,
             strand: None,
+            binding_matrix_length: None,
         }
     }
 
@@ -9217,6 +9229,7 @@ mod tests {
             binding_matrix: Some(binding_matrix.to_string()),
             transcription_factors: Some(transcription_factors.to_string()),
             strand: Some(strand),
+            binding_matrix_length: Some((end - start + 1) as i32),
         }
     }
 
@@ -22272,5 +22285,52 @@ mod tests {
             .collect();
         assert_eq!(by_id.get("ENSM00000588617"), Some(&Some(3)));
         assert_eq!(by_id.get("ENSM00000588616"), Some(&Some(21)));
+    }
+
+    #[test]
+    fn motif_pos_uses_matrix_length_on_the_reverse_strand() {
+        // Matrix shorter than the motif span: VEP flips against the matrix
+        // length, so a naive end-based flip would disagree.
+        let engine = TranscriptConsequenceEngine::default();
+        let mut m = motif_with_matrix("ENSM_x", "22", 100, 120, "ENSPFM1", "TF", -1);
+        m.binding_matrix_length = Some(10);
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 103, 103, "A", "G"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[m],
+            &[],
+            &[],
+        );
+        let c = out
+            .iter()
+            .find(|a| a.feature_type == FeatureType::MotifFeature)
+            .unwrap();
+        // pos = 103-100+1 = 4; reverse: 10-4+1 = 7
+        assert_eq!(c.motif_pos, Some(7));
+    }
+
+    #[test]
+    fn motif_pos_is_none_out_of_bounds() {
+        let engine = TranscriptConsequenceEngine::default();
+        let mut m = motif_with_matrix("ENSM_y", "22", 100, 120, "ENSPFM1", "TF", -1);
+        m.binding_matrix_length = Some(2);
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 118, 118, "A", "G"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[m],
+            &[],
+            &[],
+        );
+        let c = out
+            .iter()
+            .find(|a| a.feature_type == FeatureType::MotifFeature)
+            .unwrap();
+        assert_eq!(c.motif_pos, None);
     }
 }

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -2097,14 +2097,8 @@ impl TranscriptConsequenceEngine {
         motifs: &[MotifFeature],
         structural: &[StructuralFeature],
     ) {
-        let mut terms = BTreeSet::new();
+        let mut sv_terms = BTreeSet::new();
         let chrom = normalize_chrom(&variant.chrom);
-        let overlaps_tfbs = motifs.iter().any(|m| {
-            normalize_chrom(&m.chrom) == chrom && feature_overlaps(variant, m.start, m.end)
-        });
-        if overlaps_tfbs {
-            terms.insert(SoTerm::TfBindingSiteVariant);
-        }
         for sv in structural {
             if normalize_chrom(&sv.chrom) != chrom
                 || !overlaps(variant.start, variant.end, sv.start, sv.end)
@@ -2116,16 +2110,41 @@ impl TranscriptConsequenceEngine {
             }
             match sv.event_kind {
                 SvEventKind::Ablation => {
-                    terms.insert(SoTerm::TfbsAblation);
+                    sv_terms.insert(SoTerm::TfbsAblation);
                 }
                 SvEventKind::Amplification => {
-                    terms.insert(SoTerm::TfbsAmplification);
+                    sv_terms.insert(SoTerm::TfbsAmplification);
                 }
                 SvEventKind::Elongation | SvEventKind::Truncation => {}
             }
         }
-        if !terms.is_empty() {
+
+        // VEP emits one CSQ entry per overlapping MotifFeature, each carrying
+        // its own stable id, mirroring the RegulatoryFeature path above.
+        let mut matched_motif = false;
+        let mut seen_motif_ids: HashSet<&str> = HashSet::new();
+        for m in motifs {
+            if normalize_chrom(&m.chrom) != chrom || !feature_overlaps(variant, m.start, m.end) {
+                continue;
+            }
+            if !seen_motif_ids.insert(m.motif_id.as_str()) {
+                continue;
+            }
+            matched_motif = true;
+            let mut terms: BTreeSet<SoTerm> = sv_terms.clone();
+            terms.insert(SoTerm::TfBindingSiteVariant);
             let mut ordered: Vec<SoTerm> = terms.into_iter().collect();
+            ordered.sort_by_key(|t| t.rank());
+            out.push(TranscriptConsequence {
+                transcript_id: Some(m.motif_id.clone()),
+                feature_type: FeatureType::MotifFeature,
+                terms: ordered,
+                ..Default::default()
+            });
+        }
+
+        if !sv_terms.is_empty() && !matched_motif {
+            let mut ordered: Vec<SoTerm> = sv_terms.into_iter().collect();
             ordered.sort_by_key(|t| t.rank());
             out.push(TranscriptConsequence {
                 feature_type: FeatureType::MotifFeature,
@@ -2143,7 +2162,7 @@ impl TranscriptConsequenceEngine {
         ctx: &PreparedContext<'_>,
         structural_hits: &[usize],
     ) {
-        let mut terms = BTreeSet::new();
+        let mut sv_terms = BTreeSet::new();
         let mut motif_hits = Vec::new();
         ctx.motif_index.collect_overlapping_indices(
             chrom,
@@ -2151,12 +2170,6 @@ impl TranscriptConsequenceEngine {
             variant.end,
             &mut motif_hits,
         );
-        if motif_hits.into_iter().any(|idx| {
-            let motif = ctx.motif_index.features[idx];
-            feature_overlaps(variant, motif.start, motif.end)
-        }) {
-            terms.insert(SoTerm::TfBindingSiteVariant);
-        }
         for &idx in structural_hits {
             let sv = ctx.structural_index.features[idx];
             if sv.feature_kind != SvFeatureKind::Tfbs {
@@ -2164,16 +2177,41 @@ impl TranscriptConsequenceEngine {
             }
             match sv.event_kind {
                 SvEventKind::Ablation => {
-                    terms.insert(SoTerm::TfbsAblation);
+                    sv_terms.insert(SoTerm::TfbsAblation);
                 }
                 SvEventKind::Amplification => {
-                    terms.insert(SoTerm::TfbsAmplification);
+                    sv_terms.insert(SoTerm::TfbsAmplification);
                 }
                 SvEventKind::Elongation | SvEventKind::Truncation => {}
             }
         }
-        if !terms.is_empty() {
+
+        // One CSQ entry per overlapping MotifFeature, matching Ensembl VEP.
+        let mut matched_motif = false;
+        let mut seen_motif_ids: HashSet<&str> = HashSet::new();
+        for idx in motif_hits {
+            let m = ctx.motif_index.features[idx];
+            if !feature_overlaps(variant, m.start, m.end) {
+                continue;
+            }
+            if !seen_motif_ids.insert(m.motif_id.as_str()) {
+                continue;
+            }
+            matched_motif = true;
+            let mut terms: BTreeSet<SoTerm> = sv_terms.clone();
+            terms.insert(SoTerm::TfBindingSiteVariant);
             let mut ordered: Vec<SoTerm> = terms.into_iter().collect();
+            ordered.sort_by_key(|t| t.rank());
+            out.push(TranscriptConsequence {
+                transcript_id: Some(m.motif_id.clone()),
+                feature_type: FeatureType::MotifFeature,
+                terms: ordered,
+                ..Default::default()
+            });
+        }
+
+        if !sv_terms.is_empty() && !matched_motif {
+            let mut ordered: Vec<SoTerm> = sv_terms.into_iter().collect();
             ordered.sort_by_key(|t| t.rank());
             out.push(TranscriptConsequence {
                 feature_type: FeatureType::MotifFeature,
@@ -21914,5 +21952,150 @@ mod tests {
             Some("ENSPDUP001.1:p.Ala3dup"),
             "In-frame insertion of Ala in Ala repeat should produce p.Ala3dup"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // MotifFeature: one CSQ entry per overlapping motif
+    // ------------------------------------------------------------------
+
+    /// Ensembl VEP emits one MotifFeature CSQ entry per overlapping motif,
+    /// each carrying its own stable id in the Feature column. Coordinates and
+    /// ids are taken from a real release-116 merged cache at chr22:17088127,
+    /// where VEP reports four motifs and this engine previously reported one
+    /// unidentified consequence.
+    #[test]
+    fn emits_one_consequence_per_overlapping_motif() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![
+            motif("ENSM00000588616", "22", 17_088_125, 17_088_147),
+            motif("ENSM00000588617", "22", 17_088_125, 17_088_147),
+            motif("ENSM00000588618", "22", 17_088_127, 17_088_149),
+            motif("ENSM00000588619", "22", 17_088_127, 17_088_149),
+        ];
+
+        let assignments = engine.evaluate_variant_with_context(
+            &var("22", 17_088_127, 17_088_127, "T", "A"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+
+        let mut ids: Vec<&str> = assignments
+            .iter()
+            .filter(|a| a.feature_type == FeatureType::MotifFeature)
+            .map(|a| a.transcript_id.as_deref().unwrap_or_default())
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![
+                "ENSM00000588616",
+                "ENSM00000588617",
+                "ENSM00000588618",
+                "ENSM00000588619"
+            ]
+        );
+
+        assert!(
+            assignments
+                .iter()
+                .filter(|a| a.feature_type == FeatureType::MotifFeature)
+                .all(|a| a.terms == vec![SoTerm::TfBindingSiteVariant])
+        );
+    }
+
+    /// A motif that does not overlap the variant must not produce an entry.
+    #[test]
+    fn skips_motifs_that_do_not_overlap_the_variant() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![
+            motif("ENSM_overlapping", "22", 150, 160),
+            motif("ENSM_elsewhere", "22", 900, 999),
+        ];
+
+        let assignments = engine.evaluate_variant_with_context(
+            &var("22", 155, 155, "A", "G"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+
+        let ids: Vec<&str> = assignments
+            .iter()
+            .filter(|a| a.feature_type == FeatureType::MotifFeature)
+            .map(|a| a.transcript_id.as_deref().unwrap_or_default())
+            .collect();
+        assert_eq!(ids, vec!["ENSM_overlapping"]);
+    }
+
+    /// Duplicate motif ids in the cache must collapse to a single entry, the
+    /// same way overlapping RegulatoryFeatures are de-duplicated.
+    #[test]
+    fn deduplicates_repeated_motif_ids() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![
+            motif("ENSM_dup", "22", 150, 160),
+            motif("ENSM_dup", "22", 150, 160),
+        ];
+
+        let assignments = engine.evaluate_variant_with_context(
+            &var("22", 155, 155, "A", "G"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+
+        assert_eq!(
+            assignments
+                .iter()
+                .filter(|a| a.feature_type == FeatureType::MotifFeature)
+                .count(),
+            1
+        );
+    }
+
+    /// TFBS ablation/amplification from structural variants must still be
+    /// emitted when no motif overlaps, mirroring the RegulatoryFeature path.
+    #[test]
+    fn emits_structural_tfbs_terms_without_overlapping_motifs() {
+        let engine = TranscriptConsequenceEngine::default();
+        let structural = vec![sv(
+            "tfbs_sv",
+            "22",
+            100,
+            200,
+            SvFeatureKind::Tfbs,
+            SvEventKind::Ablation,
+        )];
+
+        let assignments = engine.evaluate_variant_with_context(
+            &var("22", 100, 200, "A", "-"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &structural,
+        );
+
+        let motif_terms: Vec<&SoTerm> = assignments
+            .iter()
+            .filter(|a| a.feature_type == FeatureType::MotifFeature)
+            .flat_map(|a| a.terms.iter())
+            .collect();
+        assert!(motif_terms.contains(&&SoTerm::TfbsAblation));
     }
 }

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -1087,6 +1087,7 @@ pub struct TranscriptConsequenceEngine {
     upstream_distance: i64,
     downstream_distance: i64,
     shift_hgvs: bool,
+    semantics: crate::vep_semantics::VepSemantics,
 }
 
 impl Default for TranscriptConsequenceEngine {
@@ -1101,6 +1102,7 @@ impl TranscriptConsequenceEngine {
             upstream_distance,
             downstream_distance,
             shift_hgvs: false,
+            semantics: crate::vep_semantics::VepSemantics::V115,
         }
     }
 
@@ -1118,7 +1120,26 @@ impl TranscriptConsequenceEngine {
             upstream_distance,
             downstream_distance,
             shift_hgvs,
+            semantics: crate::vep_semantics::VepSemantics::V115,
         }
+    }
+
+    pub fn new_with_hgvs_shift_and_semantics(
+        upstream_distance: i64,
+        downstream_distance: i64,
+        shift_hgvs: bool,
+        semantics: crate::vep_semantics::VepSemantics,
+    ) -> Self {
+        Self {
+            upstream_distance,
+            downstream_distance,
+            shift_hgvs,
+            semantics,
+        }
+    }
+
+    pub fn semantics(&self) -> crate::vep_semantics::VepSemantics {
+        self.semantics
     }
 
     pub fn evaluate_variant(
@@ -1429,7 +1450,7 @@ impl TranscriptConsequenceEngine {
                             && hgvsc_detail_profile_enabled())
                         .then(HgvscProfile::default);
                         let hgvsc = if let Some(detail_profile) = hgvsc_detail_profile.as_mut() {
-                            crate::hgvs::format_hgvsc_profiled(
+                            crate::hgvs::format_hgvsc_profiled_with_semantics(
                                 tx,
                                 tx_exons_for_hgvsc,
                                 cdna_position.as_deref(),
@@ -1440,9 +1461,10 @@ impl TranscriptConsequenceEngine {
                                 variant.end,
                                 hgvs_shift,
                                 detail_profile,
+                                self.semantics,
                             )
                         } else {
-                            crate::hgvs::format_hgvsc(
+                            crate::hgvs::format_hgvsc_with_semantics(
                                 tx,
                                 tx_exons_for_hgvsc,
                                 cdna_position.as_deref(),
@@ -1452,6 +1474,7 @@ impl TranscriptConsequenceEngine {
                                 variant.start,
                                 variant.end,
                                 hgvs_shift,
+                                self.semantics,
                             )
                         };
                         if let (Some(started), Some(profile)) =
@@ -1738,11 +1761,10 @@ impl TranscriptConsequenceEngine {
         }
 
         // VEP's within_cds() uses inverted insertion coordinates (start > end)
-        // which naturally span the CDS boundary in overlap checks.  An insertion
-        // at exon.end+1 where the left flank (exon.end) is in the CDS is
-        // considered within CDS by VEP, even though it fails overlaps_exon.
-        // This handles transcripts where the last coding exon ends at the CDS
-        // boundary (no 3' UTR exon extension).
+        // which map the two insertion flanks independently. An insertion just
+        // outside an internal coding-exon boundary can therefore still be
+        // within CDS even though it fails overlaps_exon. The terminal CDS base
+        // itself is excluded by insertion_left_flank_in_cds.
         //
         // Traceability:
         // - Ensembl Variation `BaseTranscriptVariationAllele::within_cds()`
@@ -2604,9 +2626,9 @@ impl TranscriptConsequenceEngine {
     ///   coding_start <= pos  AND  coding_end >= pos+1
     /// i.e., the VCF padding base must be strictly before the last CDS base.
     ///
-    /// On **negative strand**, the 5' CDS end is at cds_end (genomic).
-    /// An insertion at cds_end+1 is in the 5'UTR, not the CDS.  VEP's
-    /// overlap returns FALSE (coding_end < vf.start).  Exclude this case.
+    /// Consequently an insertion after genomic `cds_end` is outside the CDS
+    /// on either strand. Transcript orientation decides whether that is 3' or
+    /// 5' UTR, but does not change the overlap inequality.
     ///
     /// Traceability:
     /// - Ensembl Variation `BaseTranscriptVariationAllele::_overlap_cds()`
@@ -2619,14 +2641,7 @@ impl TranscriptConsequenceEngine {
             return false;
         }
         let left_flank = variant.start.saturating_sub(1);
-        if left_flank < cds_start || left_flank > cds_end {
-            return false;
-        }
-        // On negative strand, the 5' CDS boundary is at cds_end (genomic).
-        // Insertions at cds_end+1 are in the 5'UTR — VEP's _overlap_cds
-        // returns FALSE for these.  On positive strand, cds_end is the 3'
-        // boundary and insertions there are within CDS.
-        if tx.strand < 0 && left_flank == cds_end {
+        if left_flank < cds_start || left_flank >= cds_end {
             return false;
         }
         true
@@ -2720,7 +2735,17 @@ impl TranscriptConsequenceEngine {
         // cannot be computed. Preserve those bounds here instead of dropping
         // the coding position fields entirely.
         if self.is_complex_indel(variant, tx_exons) {
-            return partial_coding_overlap_classification(tx, tx_exons, tx_translation, variant);
+            let mut classification =
+                partial_coding_overlap_classification(tx, tx_exons, tx_translation, variant);
+            if self.semantics.vep116_stop_predicates()
+                && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
+            {
+                terms.insert(SoTerm::StopRetainedVariant);
+                if let Some(classification) = classification.as_mut() {
+                    classification.stop_retained = true;
+                }
+            }
+            return classification;
         }
 
         // VEP's partial_codon predicate — exact replay:
@@ -2805,9 +2830,13 @@ impl TranscriptConsequenceEngine {
                 terms.insert(SoTerm::FrameshiftVariant);
             }
 
-            if let Some(classification) =
-                classify_coding_change(tx, tx_exons, tx_translation, variant)
-            {
+            if let Some(classification) = classify_coding_change_with_semantics(
+                tx,
+                tx_exons,
+                tx_translation,
+                variant,
+                self.semantics,
+            ) {
                 // VEP's frameshift predicate returns 0 when stop_retained
                 // is true. Override frameshift → inframe_insertion.
                 if classification.stop_retained && terms.contains(&SoTerm::FrameshiftVariant) {
@@ -2818,6 +2847,7 @@ impl TranscriptConsequenceEngine {
                         terms.insert(SoTerm::InframeDeletion);
                     }
                 }
+                apply_vep116_primary_indel_predicates(terms, &classification, self.semantics);
                 // VEP's inframe_insertion requires ref_pep to be an exact
                 // prefix OR suffix of alt_pep (pure insertion in the peptide).
                 // When the insertion disrupts a flanking codon, the containment
@@ -2892,8 +2922,13 @@ impl TranscriptConsequenceEngine {
             return None;
         }
 
-        if let Some(classification) = classify_coding_change(tx, tx_exons, tx_translation, variant)
-        {
+        if let Some(classification) = classify_coding_change_with_semantics(
+            tx,
+            tx_exons,
+            tx_translation,
+            variant,
+            self.semantics,
+        ) {
             let has_any = classification.has_any();
             apply_codon_classification(terms, &classification);
             if has_any {
@@ -4093,6 +4128,132 @@ fn mutated_cds_stop_preserved(
     is_stop_codon(&codon_at_stop)
 }
 
+/// VEP 116 `_overlaps_stop_codon_cil()` uses genomic coordinates and, for an
+/// insertion, extends the inverted variation interval by the inserted feature
+/// sequence length in transcript orientation.
+fn vep116_overlaps_stop_codon_cil(
+    tx: &TranscriptFeature,
+    variant: &VariantInput,
+    feature_seq_len: usize,
+) -> bool {
+    if tx.cds_end_nf {
+        return false;
+    }
+    let (Some(cds_start), Some(cds_end)) = (tx.cds_start, tx.cds_end) else {
+        return false;
+    };
+    let mut variant_start = variant.start;
+    let variant_end = variant.end;
+    if variant_end < variant_start && feature_seq_len > 0 {
+        let Ok(feature_seq_len) = i64::try_from(feature_seq_len) else {
+            return false;
+        };
+        if tx.strand >= 0 {
+            variant_start = variant_start.saturating_add(feature_seq_len);
+        } else {
+            variant_start = variant_start.saturating_sub(feature_seq_len);
+        }
+    }
+    let (stop_start, stop_end) = if tx.strand >= 0 {
+        (cds_end.saturating_sub(2), cds_end)
+    } else {
+        (cds_start, cds_start.saturating_add(2))
+    };
+    variant_end >= stop_start && variant_start <= stop_end
+}
+
+/// VEP 116's no-alt-peptide `stop_retained` branch. This is the source-level
+/// `_overlaps_stop_codon_cil && !_ins_del_stop_altered_cil` path: locate the
+/// edit in spliced cDNA/CDS coordinates (so introns do not inflate its length),
+/// splice it into translateable-sequence + 3' UTR, and test the original
+/// terminal-codon slot.
+fn vep116_stop_retained_without_alt_peptide(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    tx_translation: Option<&TranslationFeature>,
+    variant: &VariantInput,
+) -> bool {
+    let ref_seq = normalize_allele_seq(&variant.ref_allele);
+    let alt_seq = normalize_allele_seq(&variant.alt_allele);
+    if ref_seq.len() == alt_seq.len()
+        || !ref_seq
+            .bytes()
+            .chain(alt_seq.bytes())
+            .all(|base| matches!(base.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T' | b'N'))
+        || !vep116_overlaps_stop_codon_cil(tx, variant, alt_seq.len())
+    {
+        return false;
+    }
+
+    let Some(cds_seq) = reference_translateable_seq_for_vep(tx, tx_translation) else {
+        return false;
+    };
+    let mut combined = cds_seq.clone().into_bytes();
+    combined.extend_from_slice(three_prime_utr_seq(tx).unwrap_or_default().as_bytes());
+
+    let replacement = if tx.strand >= 0 {
+        alt_seq
+    } else {
+        let Some(reverse) = reverse_complement(&alt_seq) else {
+            return false;
+        };
+        reverse.to_ascii_uppercase()
+    };
+
+    let (edit_start, edit_len) = if variant.start > variant.end {
+        let anchor = if tx.strand >= 0 {
+            variant.end
+        } else {
+            variant.start
+        };
+        let Some(cds_idx) = genomic_to_cds_index(tx, tx_exons, anchor) else {
+            return false;
+        };
+        (cds_idx.saturating_add(1), 0)
+    } else {
+        let mut cdna_positions = Vec::new();
+        for exon in tx_exons {
+            let overlap_start = variant.start.max(exon.start);
+            let overlap_end = variant.end.min(exon.end);
+            if overlap_start > overlap_end {
+                continue;
+            }
+            for position in [overlap_start, overlap_end] {
+                if let Some(cdna) = genomic_to_cdna_index_for_transcript(tx, tx_exons, position) {
+                    cdna_positions.push(cdna);
+                }
+            }
+        }
+        let (Some(min_cdna), Some(max_cdna), Some(coding_start)) = (
+            cdna_positions.iter().min().copied(),
+            cdna_positions.iter().max().copied(),
+            tx.cdna_coding_start,
+        ) else {
+            return false;
+        };
+        let Some(edit_start) = min_cdna.checked_sub(coding_start) else {
+            return false;
+        };
+        (edit_start, max_cdna.saturating_sub(min_cdna) + 1)
+    };
+
+    if edit_start > combined.len() {
+        return false;
+    }
+    let edit_end = edit_start.saturating_add(edit_len).min(combined.len());
+    combined.splice(edit_start..edit_end, replacement.bytes());
+    if combined.len() < cds_seq.len() || cds_seq.len() < 3 {
+        return false;
+    }
+    let stop_start = cds_seq.len() - 3;
+    let Some(stop_codon) = combined.get(stop_start..stop_start + 3) else {
+        return false;
+    };
+    std::str::from_utf8(stop_codon)
+        .ok()
+        .is_some_and(is_stop_codon)
+}
+
 #[derive(Debug, Clone, Default)]
 struct CodingClassification {
     synonymous: bool,
@@ -4116,6 +4277,13 @@ struct CodingClassification {
     protein_position_end: Option<usize>,
     /// Peptide-context HGVS input used to replay Ensembl's protein formatter.
     protein_hgvs: Option<crate::hgvs::ProteinHgvsData>,
+    /// VEP `_get_peptide_alleles()` reference peptide for the affected local
+    /// codon window. Kept separately from the display `Amino_acids` value
+    /// because the release-116 stop predicates inspect this exact peptide.
+    affected_ref_peptide: Option<String>,
+    /// VEP `_get_peptide_alleles()` alternate peptide for the affected local
+    /// codon window.
+    affected_alt_peptide: Option<String>,
 }
 
 impl CodingClassification {
@@ -4128,6 +4296,92 @@ impl CodingClassification {
             || self.start_lost
             || self.start_retained
     }
+}
+
+fn apply_vep116_stop_predicate_flags(
+    class: &mut CodingClassification,
+    semantics: crate::vep_semantics::VepSemantics,
+    partial_terminal_codon: bool,
+) {
+    if !semantics.vep116_stop_predicates() {
+        return;
+    }
+    let alt_has_x = class
+        .affected_alt_peptide
+        .as_deref()
+        .is_some_and(|peptide| peptide.contains('X'));
+    if partial_terminal_codon || alt_has_x {
+        class.stop_lost = false;
+    }
+    if alt_has_x {
+        class.stop_retained = false;
+    }
+    if class.stop_lost {
+        class.stop_gained = false;
+    }
+}
+
+fn frameshift_under_semantics(
+    raw_frameshift: bool,
+    class: &CodingClassification,
+    semantics: crate::vep_semantics::VepSemantics,
+) -> bool {
+    raw_frameshift
+        && !(semantics.vep116_stop_predicates()
+            && class
+                .affected_ref_peptide
+                .as_deref()
+                .is_some_and(|peptide| peptide.starts_with('*')))
+}
+
+fn apply_vep116_primary_indel_predicates(
+    terms: &mut BTreeSet<SoTerm>,
+    class: &CodingClassification,
+    semantics: crate::vep_semantics::VepSemantics,
+) {
+    if !semantics.vep116_stop_predicates() {
+        return;
+    }
+    let ref_peptide = class.affected_ref_peptide.as_deref();
+    let alt_peptide = class.affected_alt_peptide.as_deref();
+
+    // VEP 116 VariationEffect.pm:
+    // - inframe_insertion is false when ref_pep == "*" && alt_pep == "*";
+    // - inframe_deletion is false when ref_pep == "*";
+    // - frameshift is false when the affected reference peptide starts "*".
+    if ref_peptide == Some("*") && alt_peptide == Some("*") {
+        terms.remove(&SoTerm::InframeInsertion);
+    }
+    if ref_peptide == Some("*") {
+        terms.remove(&SoTerm::InframeDeletion);
+    }
+    if ref_peptide.is_some_and(|peptide| peptide.starts_with('*')) {
+        terms.remove(&SoTerm::FrameshiftVariant);
+    }
+}
+
+fn vep116_ref_eq_alt_sequence_final_stop(
+    ref_translation: &[char],
+    translation_start: usize,
+    ref_peptide: &str,
+    alt_peptide: &str,
+) -> bool {
+    if ref_peptide == "X" && alt_peptide == "X" {
+        return false;
+    }
+    let mut mutated = ref_translation.to_vec();
+    let ref_len = ref_peptide.chars().count();
+    let replace_end = translation_start.saturating_add(ref_len).min(mutated.len());
+    let replacement = if alt_peptide == "-" {
+        Vec::new()
+    } else {
+        alt_peptide.chars().collect()
+    };
+    mutated.splice(translation_start..replace_end, replacement);
+    mutated.starts_with(ref_translation)
+        && mutated
+            .get(ref_translation.len())
+            .is_some_and(|residue| *residue == '*')
 }
 
 /// Traceability:
@@ -6006,6 +6260,22 @@ fn classify_coding_change(
     tx_translation: Option<&TranslationFeature>,
     variant: &VariantInput,
 ) -> Option<CodingClassification> {
+    classify_coding_change_with_semantics(
+        tx,
+        tx_exons,
+        tx_translation,
+        variant,
+        crate::vep_semantics::VepSemantics::V115,
+    )
+}
+
+fn classify_coding_change_with_semantics(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    tx_translation: Option<&TranslationFeature>,
+    variant: &VariantInput,
+    semantics: crate::vep_semantics::VepSemantics,
+) -> Option<CodingClassification> {
     let translation = tx_translation?;
     let cds_seq = reference_translateable_seq_for_vep(tx, Some(translation))?;
     let ref_genomic = normalize_allele_seq(&variant.ref_allele);
@@ -6015,13 +6285,14 @@ fn classify_coding_change(
 
     // Handle pure insertions (ref = "-") separately.
     if ref_len == 0 {
-        return classify_insertion(
+        return classify_insertion_with_semantics(
             tx,
             tx_exons,
             tx_translation,
             &cds_seq,
             variant,
             &alt_genomic,
+            semantics,
         );
     }
 
@@ -6223,12 +6494,12 @@ fn classify_coding_change(
         }
     }
 
-    let frameshift = !ref_len.abs_diff(alt_len).is_multiple_of(3);
+    let raw_frameshift = !ref_len.abs_diff(alt_len).is_multiple_of(3);
     let stop_might_be_disrupted = if let Some(old_stop_idx) = old_stop {
         let stop_nt_start = old_stop_idx.saturating_mul(3);
         let stop_nt_end = stop_nt_start.saturating_add(2);
         ranges_overlap_usize(start_idx, end_idx, stop_nt_start, stop_nt_end)
-            || (frameshift && start_idx <= stop_nt_end)
+            || (raw_frameshift && start_idx <= stop_nt_end)
     } else {
         false
     };
@@ -6289,6 +6560,28 @@ fn classify_coding_change(
     class.protein_position_start = Some(display_protein_position_start);
     class.protein_position_end = Some(display_protein_position_end);
 
+    // Capture the exact local peptide window consumed by VEP's stop-family
+    // predicates. The alternate window is widened/narrowed by the allele
+    // length delta, and partial codons become `X`.
+    let local_first_codon = start_idx / 3;
+    let local_last_codon = end_idx / 3;
+    let local_codon_start = local_first_codon.saturating_mul(3);
+    let local_ref_end = ((local_last_codon + 1) * 3).min(cds_seq.len());
+    let local_ref_codon = &cds_seq.as_bytes()[local_codon_start..local_ref_end];
+    let local_alt_len =
+        (local_ref_codon.len() as i64 + alt_len as i64 - ref_len as i64).max(0) as usize;
+    let local_alt_end = local_codon_start
+        .saturating_add(local_alt_len)
+        .min(mutated.len());
+    let local_alt_codon = &mutated[local_codon_start..local_alt_end];
+    class.affected_ref_peptide = local_peptide_from_codon_window(local_ref_codon);
+    class.affected_alt_peptide = local_peptide_from_codon_window(local_alt_codon);
+    let partial_terminal_codon = {
+        let codon_start = local_first_codon.saturating_mul(3);
+        let last_codon_len = cds_seq.len().saturating_sub(codon_start);
+        last_codon_len > 0 && last_codon_len < 3
+    };
+
     // Per-codon stop analysis.
     //
     // For same-length variants (SNVs/MNVs): the global first-stop comparison
@@ -6348,7 +6641,7 @@ fn classify_coding_change(
                 // - VEP codon() local window: TranscriptVariationAllele.pm L877
                 // - Partial codon → 'X': TranscriptVariationAllele.pm L774
                 // - stop_gained checks /\*/: VariationEffect.pm L1218
-                if !frameshift && old_aa != '*' && new_aa == '*' {
+                if !raw_frameshift && old_aa != '*' && new_aa == '*' {
                     class.stop_gained = true;
                 } else if old_aa == '*' && new_aa != '*' {
                     class.stop_lost = true;
@@ -6359,6 +6652,17 @@ fn classify_coding_change(
                 }
             }
         }
+    }
+
+    apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
+    if semantics.vep116_stop_predicates()
+        && class
+            .affected_alt_peptide
+            .as_deref()
+            .is_none_or(|peptide| peptide.is_empty() || peptide.contains('X'))
+        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
+    {
+        class.stop_retained = true;
     }
 
     if ref_len == alt_len {
@@ -6416,7 +6720,7 @@ fn classify_coding_change(
     let last_codon = end_idx / 3;
 
     // Amino acids
-    let frameshift = !ref_len.abs_diff(alt_len).is_multiple_of(3);
+    let frameshift = frameshift_under_semantics(raw_frameshift, &class, semantics);
     if first_codon < old_aas.len() {
         let (ref_start, ref_end) = if ref_len == alt_len && skip_global_stop_compare {
             (
@@ -6601,6 +6905,16 @@ fn classify_coding_change(
             class.stop_lost = true;
         }
     }
+    apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
+    if semantics.vep116_stop_predicates()
+        && class
+            .affected_alt_peptide
+            .as_deref()
+            .is_none_or(|peptide| peptide.is_empty() || peptide.contains('X'))
+        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
+    {
+        class.stop_retained = true;
+    }
 
     // For HGVS stop-loss / frameshift extension distance, translate the
     // mutated CDS + 3' UTR so that the new stop codon can be found even
@@ -6688,6 +7002,26 @@ fn classify_insertion(
     cds_seq: &str,
     variant: &VariantInput,
     alt_genomic: &str,
+) -> Option<CodingClassification> {
+    classify_insertion_with_semantics(
+        tx,
+        tx_exons,
+        tx_translation,
+        cds_seq,
+        variant,
+        alt_genomic,
+        crate::vep_semantics::VepSemantics::V115,
+    )
+}
+
+fn classify_insertion_with_semantics(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    tx_translation: Option<&TranslationFeature>,
+    cds_seq: &str,
+    variant: &VariantInput,
+    alt_genomic: &str,
+    semantics: crate::vep_semantics::VepSemantics,
 ) -> Option<CodingClassification> {
     let alt_len = alt_genomic.len();
     if alt_len == 0 {
@@ -6811,7 +7145,7 @@ fn classify_insertion(
     let pep_b = (display_cds_position_end + 2) / 3;
     let ins_at_boundary = if primary_anchor_cds.is_some() && alternate_anchor_cds.is_some() {
         pep_a != pep_b
-    } else if primary_anchor_cds.is_none() && alternate_anchor_cds.is_some() {
+    } else if primary_anchor_cds.is_some() != alternate_anchor_cds.is_some() {
         ins_point.is_multiple_of(3)
     } else {
         false
@@ -6939,17 +7273,48 @@ fn classify_insertion(
     } else {
         Vec::new()
     };
+    if codon_at < old_aas.len() {
+        let codon_start = codon_at * 3;
+        let ref_end = (codon_start + 3).min(effective_cds.len());
+        let alt_end = (codon_start + 3 + alt_len).min(mutated.len());
+        class.affected_ref_peptide =
+            local_peptide_from_codon_window(&effective_cds[codon_start..ref_end]);
+        class.affected_alt_peptide =
+            local_peptide_from_codon_window(&mutated[codon_start..alt_end]);
+    }
+    let partial_terminal_codon = {
+        let codon_start = codon_at.saturating_mul(3);
+        let last_codon_len = cds_seq.len().saturating_sub(codon_start);
+        last_codon_len > 0 && last_codon_len < 3
+    };
 
     // stop_retained: VEP's ref_eq_alt_sequence (VariationEffect.pm L1320-1355)
     if !class.stop_retained && codon_at < old_aas.len() {
         let ref_aa = old_aas[codon_at];
         // Condition 1: ref_pep == first alt AA AND alt contains '*'
-        if ref_aa != '*' && local_aas.first() == Some(&ref_aa) && local_aas.contains(&'*') {
+        if !semantics.vep116_stop_predicates()
+            && ref_aa != '*'
+            && local_aas.first() == Some(&ref_aa)
+            && local_aas.contains(&'*')
+        {
             class.stop_retained = true;
         }
         // Condition 3: both contain '*' at the same position
         if !class.stop_retained && ref_aa == '*' && local_aas.first() == Some(&'*') {
             class.stop_retained = true;
+        }
+        if !class.stop_retained && semantics.vep116_stop_predicates() {
+            if let (Some(ref_peptide), Some(alt_peptide)) = (
+                class.affected_ref_peptide.as_deref(),
+                class.affected_alt_peptide.as_deref(),
+            ) {
+                class.stop_retained = vep116_ref_eq_alt_sequence_final_stop(
+                    &old_aas,
+                    codon_at,
+                    ref_peptide,
+                    alt_peptide,
+                );
+            }
         }
     }
 
@@ -6982,13 +7347,24 @@ fn classify_insertion(
             class.stop_gained = true;
         }
     }
+    apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
+    if semantics.vep116_stop_predicates()
+        && class
+            .affected_alt_peptide
+            .as_deref()
+            .is_none_or(|peptide| peptide.is_empty() || peptide.contains('X'))
+        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
+    {
+        class.stop_retained = true;
+    }
 
     // When stop_retained, VEP overrides frameshift → inframe (regardless of alt_len % 3).
-    let frameshift = if class.stop_retained {
+    let raw_frameshift = if class.stop_retained {
         false
     } else {
         !alt_len.is_multiple_of(3)
     };
+    let frameshift = frameshift_under_semantics(raw_frameshift, &class, semantics);
 
     // Amino acids
     let first_codon = codon_at;
@@ -9439,6 +9815,194 @@ mod tests {
             version: None,
             protein_features: Vec::new(),
         }
+    }
+
+    #[test]
+    fn vep116_hunk1_rejects_inframe_insertion_when_both_peptides_are_stop() {
+        let class = CodingClassification {
+            affected_ref_peptide: Some("*".to_string()),
+            affected_alt_peptide: Some("*".to_string()),
+            ..Default::default()
+        };
+        let mut v115 = BTreeSet::from([SoTerm::InframeInsertion]);
+        let mut v116 = v115.clone();
+        apply_vep116_primary_indel_predicates(
+            &mut v115,
+            &class,
+            crate::vep_semantics::VepSemantics::V115,
+        );
+        apply_vep116_primary_indel_predicates(
+            &mut v116,
+            &class,
+            crate::vep_semantics::VepSemantics::V116,
+        );
+        assert!(v115.contains(&SoTerm::InframeInsertion));
+        assert!(!v116.contains(&SoTerm::InframeInsertion));
+    }
+
+    #[test]
+    fn vep116_hunk2_rejects_inframe_deletion_when_reference_peptide_is_stop() {
+        let class = CodingClassification {
+            affected_ref_peptide: Some("*".to_string()),
+            affected_alt_peptide: Some("-".to_string()),
+            ..Default::default()
+        };
+        let mut v115 = BTreeSet::from([SoTerm::InframeDeletion]);
+        let mut v116 = v115.clone();
+        apply_vep116_primary_indel_predicates(
+            &mut v115,
+            &class,
+            crate::vep_semantics::VepSemantics::V115,
+        );
+        apply_vep116_primary_indel_predicates(
+            &mut v116,
+            &class,
+            crate::vep_semantics::VepSemantics::V116,
+        );
+        assert!(v115.contains(&SoTerm::InframeDeletion));
+        assert!(!v116.contains(&SoTerm::InframeDeletion));
+    }
+
+    #[test]
+    fn vep116_hunk3_makes_stop_gained_and_stop_lost_mutually_exclusive() {
+        let base = CodingClassification {
+            stop_gained: true,
+            stop_lost: true,
+            affected_alt_peptide: Some("Y".to_string()),
+            ..Default::default()
+        };
+        let mut v115 = base.clone();
+        let mut v116 = base;
+        apply_vep116_stop_predicate_flags(
+            &mut v115,
+            crate::vep_semantics::VepSemantics::V115,
+            false,
+        );
+        apply_vep116_stop_predicate_flags(
+            &mut v116,
+            crate::vep_semantics::VepSemantics::V116,
+            false,
+        );
+        assert!(v115.stop_gained && v115.stop_lost);
+        assert!(!v116.stop_gained && v116.stop_lost);
+    }
+
+    #[test]
+    fn vep116_hunk4_rejects_stop_lost_for_partial_terminal_codon() {
+        let base = CodingClassification {
+            stop_lost: true,
+            affected_alt_peptide: Some("Y".to_string()),
+            ..Default::default()
+        };
+        let mut v115 = base.clone();
+        let mut v116 = base;
+        apply_vep116_stop_predicate_flags(
+            &mut v115,
+            crate::vep_semantics::VepSemantics::V115,
+            true,
+        );
+        apply_vep116_stop_predicate_flags(
+            &mut v116,
+            crate::vep_semantics::VepSemantics::V116,
+            true,
+        );
+        assert!(v115.stop_lost);
+        assert!(!v116.stop_lost);
+    }
+
+    #[test]
+    fn vep116_hunks5_and6_reject_x_for_stop_lost_and_stop_retained() {
+        let base = CodingClassification {
+            stop_lost: true,
+            stop_retained: true,
+            affected_alt_peptide: Some("YX".to_string()),
+            ..Default::default()
+        };
+        let mut v115 = base.clone();
+        let mut v116 = base;
+        apply_vep116_stop_predicate_flags(
+            &mut v115,
+            crate::vep_semantics::VepSemantics::V115,
+            false,
+        );
+        apply_vep116_stop_predicate_flags(
+            &mut v116,
+            crate::vep_semantics::VepSemantics::V116,
+            false,
+        );
+        assert!(v115.stop_lost && v115.stop_retained);
+        assert!(!v116.stop_lost && !v116.stop_retained);
+    }
+
+    #[test]
+    fn vep116_hunk7_uses_genomic_cil_interval_and_preserved_stop_slot() {
+        let mut plus = tx(
+            "T1",
+            "22",
+            1000,
+            1006,
+            1,
+            "protein_coding",
+            Some(1000),
+            Some(1005),
+        );
+        plus.cdna_coding_start = Some(1);
+        plus.cdna_coding_end = Some(6);
+        plus.three_prime_utr_seq = Some("A".to_string());
+        let exon = exon("T1", 1, 1000, 1006);
+        let exon_refs = vec![&exon];
+        let translation = translation("T1", Some(6), Some(2), None, Some("ATGTAA"));
+        let deletion = var("22", 1005, 1005, "A", "-");
+        assert!(vep116_stop_retained_without_alt_peptide(
+            &plus,
+            &exon_refs,
+            Some(&translation),
+            &deletion,
+        ));
+
+        // Release 115's unextended genomic interval overlaps this plus-strand
+        // stop window; release 116's CIL extension moves the insertion start
+        // beyond it.
+        let insertion = var("22", 1005, 1004, "-", "AAA");
+        let old_overlap = insertion.end >= 1003 && insertion.start <= 1005;
+        assert!(old_overlap);
+        assert!(!vep116_overlaps_stop_codon_cil(&plus, &insertion, 3));
+    }
+
+    #[test]
+    fn vep116_hunk8_removes_first_peptide_clause_and_keeps_anchored_final_stop() {
+        let old_first_peptide_clause = "A" == &"A*"[..1] && "A*".contains('*');
+        assert!(old_first_peptide_clause);
+        assert!(!vep116_ref_eq_alt_sequence_final_stop(
+            &['A', 'B', 'C', '*'],
+            0,
+            "A",
+            "A*",
+        ));
+        assert!(vep116_ref_eq_alt_sequence_final_stop(
+            &['A', 'B'],
+            2,
+            "",
+            "*",
+        ));
+    }
+
+    #[test]
+    fn vep116_hunk9_rejects_frameshift_when_reference_peptide_starts_stop() {
+        let class = CodingClassification {
+            affected_ref_peptide: Some("*Q".to_string()),
+            ..Default::default()
+        };
+        assert!(frameshift_under_semantics(
+            true,
+            &class,
+            crate::vep_semantics::VepSemantics::V115,
+        ));
+        assert!(!frameshift_under_semantics(
+            true,
+            &class,
+            crate::vep_semantics::VepSemantics::V116,
+        ));
     }
 
     fn patch_spliced_seq(len: usize, patches: &[(usize, &str)]) -> String {
@@ -12997,6 +13561,36 @@ mod tests {
         let c = classify_ins(cds, 1006, "AAA").unwrap();
         assert_eq!(c.protein_position_start, Some(2));
         assert_eq!(c.protein_position_end, Some(3));
+    }
+
+    #[test]
+    fn classify_insertion_primary_only_exon_boundary_keeps_protein_span() {
+        // chr16:5072071 G>GGTCT geometry: the left/primary flank is the
+        // final base of a coding exon and the right/alternate flank is
+        // intronic. CDS positions 222-223 straddle peptide positions 74-75.
+        let t = tx(
+            "T1",
+            "16",
+            990,
+            1400,
+            1,
+            "protein_coding",
+            Some(1000),
+            Some(1377),
+        );
+        let e1 = exon("T1", 1, 1000, 1221);
+        let e2 = exon("T1", 2, 1300, 1377);
+        let exons = [&e1, &e2];
+        let cds = format!("{}{}", "GCT".repeat(99), "TGA");
+        assert_eq!(cds.len(), 300);
+        let variant = var("16", 1222, 1222, "-", "GTCT");
+
+        let class = classify_insertion(&t, &exons, None, &cds, &variant, "GTCT")
+            .expect("primary-only coding-exon boundary must classify");
+        assert_eq!(class.cds_position_start, Some(222));
+        assert_eq!(class.cds_position_end, Some(223));
+        assert_eq!(class.protein_position_start, Some(74));
+        assert_eq!(class.protein_position_end, Some(75));
     }
 
     // ---- compute_cdna_position: insertion at exon boundary ----
@@ -20036,9 +20630,10 @@ mod tests {
     // ---------------------------------------------------------------
 
     #[test]
-    fn insertion_left_flank_in_cds_positive_strand() {
-        // Insertion just past CDS end: variant.start = cds_end + 1.
-        // Left flanking base (start - 1) is within CDS.
+    fn insertion_after_cds_end_is_not_in_cds_positive_strand() {
+        // VEP represents the insertion with inverted coordinates. Its CDS
+        // overlap requires the padding base plus one to remain within the CDS,
+        // so a left flank exactly at cds_end is already in the 3' UTR.
         let engine = TranscriptConsequenceEngine::default();
         let t = tx(
             "T1",
@@ -20052,8 +20647,8 @@ mod tests {
         );
         let v = var("22", 1101, 1101, "-", "G");
         assert!(
-            engine.insertion_left_flank_in_cds(&v, &t),
-            "Insertion at cds_end+1 should have left flank in CDS"
+            !engine.insertion_left_flank_in_cds(&v, &t),
+            "Insertion after cds_end must not be classified as coding"
         );
     }
 
@@ -20079,8 +20674,7 @@ mod tests {
     }
 
     #[test]
-    fn cds_boundary_insertion_gets_frameshift_and_coding_positions() {
-        // Issue #118: insertion at CDS end should enter coding path.
+    fn terminal_plus_strand_cds_boundary_insertion_is_three_prime_utr() {
         // CDS: ATG GAA TGA (9 bases, M E *), positions 1000-1008.
         // Exon: 1000-1020 (extends into UTR).
         // Insert "G" at position 1009 (just past CDS end).
@@ -20106,27 +20700,13 @@ mod tests {
             engine.evaluate_transcript_overlap(&v, &t, &exons_ref, Some(&tr));
         let term_set: std::collections::BTreeSet<_> = terms.iter().collect();
         assert!(
-            term_set.contains(&SoTerm::FrameshiftVariant)
-                || term_set.contains(&SoTerm::InframeInsertion),
-            "Insertion at CDS boundary should produce coding consequence, got: {:?}",
+            term_set.contains(&SoTerm::ThreePrimeUtrVariant),
+            "Insertion immediately after the terminal CDS base should be 3' UTR, got: {:?}",
             terms
         );
         assert!(
-            coding_class.is_some(),
-            "Coding classification should be present for CDS boundary insertion"
-        );
-        let cc = coding_class.unwrap();
-        assert!(
-            cc.cds_position_start.is_some(),
-            "CDS position start should be set"
-        );
-        assert!(
-            cc.cds_position_end.is_some(),
-            "CDS position end should be set"
-        );
-        assert!(
-            cc.protein_position_start.is_some(),
-            "Protein position start should be set"
+            coding_class.is_none(),
+            "3' UTR insertion must leave CDS/protein fields empty"
         );
     }
 
@@ -20265,11 +20845,9 @@ mod tests {
     }
 
     #[test]
-    fn cds_end_exon_boundary_insertion_enters_coding_path() {
-        // Issue #118: insertion at exon end where exon.end == cds_end.
-        // The exon does NOT extend into UTR, so overlaps_exon is FALSE.
-        // But VEP's within_cds() maps the left flank to CDS and gives
-        // coding consequences.
+    fn terminal_cds_end_exon_boundary_insertion_is_three_prime_utr() {
+        // At a terminal coding exon boundary, the insertion is outside CDS
+        // even when the exon itself has no UTR extension.
         //
         // Transcript: 990-1030, CDS: 1000-1008, Exon: 1000-1008
         // (exon ends exactly at CDS end — no UTR extension)
@@ -20295,36 +20873,31 @@ mod tests {
         let (terms, coding_class) =
             engine.evaluate_transcript_overlap(&v, &t, &exons_ref, Some(&tr));
         let term_set: std::collections::BTreeSet<_> = terms.iter().collect();
-        // 1bp insertion at the stop codon: local codon window includes '*',
-        // so stop_retained fires → frameshift overridden to inframe_insertion.
         assert!(
-            term_set.contains(&SoTerm::InframeInsertion),
-            "Exon-boundary CDS-end 1bp insertion at stop should get inframe_insertion (via stop_retained), got: {:?}",
+            term_set.contains(&SoTerm::ThreePrimeUtrVariant),
+            "Terminal exon-boundary insertion should be 3' UTR, got: {:?}",
             terms
         );
         assert!(
-            term_set.contains(&SoTerm::StopRetainedVariant),
-            "Should have stop_retained_variant, got: {:?}",
-            terms
-        );
-        // Should NOT have 3'UTR (VEP's _after_coding gates on !within_cds)
-        assert!(
-            !term_set.contains(&SoTerm::ThreePrimeUtrVariant),
-            "Should NOT have 3'UTR for CDS boundary insertion, got: {:?}",
+            !term_set.contains(&SoTerm::FrameshiftVariant)
+                && !term_set.contains(&SoTerm::InframeInsertion)
+                && !term_set.contains(&SoTerm::StopRetainedVariant),
+            "Terminal exon-boundary insertion must not retain coding terms, got: {:?}",
             terms
         );
         assert!(
-            coding_class.is_some(),
-            "Coding classification should be present"
+            coding_class.is_none(),
+            "Terminal exon-boundary insertion must not produce coding coordinates"
         );
     }
 
     // ---------------------------------------------------------------
     // Issue #118 — real-variant regression tests
     //
-    // Each test reproduces the exact pattern from the E2E mismatch
-    // report: an insertion at an exon boundary where exon.end ==
-    // cds_end, causing empty CDS/protein fields.
+    // Each test reproduces the exact pattern from the E2E mismatch report:
+    // an insertion after an internal coding exon. The padding base remains
+    // before the transcript's terminal cds_end, so these are distinct from
+    // the terminal CDS/3' UTR boundary regression above.
     // ---------------------------------------------------------------
 
     #[test]
@@ -20334,12 +20907,12 @@ mod tests {
         //      Protein_position=227, Amino_acids=R/SX, Codons=aga/agCa
         // vepyr (before fix): splice_region_variant only, all coding fields empty.
         //
-        // Simplified model: CDS = 12 bases (4 codons), exon ends at CDS end.
-        // Insert 1 base at exon.end + 1 → frameshift.
+        // Simplified model: the first coding exon is 12 bases and a second
+        // coding exon follows after the insertion boundary.
         let engine = TranscriptConsequenceEngine::default();
         // CDS: ATG GCT GAA AGA = M A E R (12 bases, positions 1000-1011)
         // Last codon "AGA" = Arg (R), matching VEP's ref amino acid.
-        let cds = "ATGGCTGAAAGA";
+        let cds = "ATGGCTGAAAGAGCTTGA";
         let mut t = tx(
             "T1",
             "1",
@@ -20348,16 +20921,16 @@ mod tests {
             1,
             "protein_coding",
             Some(1000),
-            Some(1011),
+            Some(1026),
         );
-        t.cdna_coding_end = Some(12);
-        t.spliced_seq = Some(format!("{cds}CCCGGG")); // CDS + UTR
-        // Exon ends exactly at CDS end — no UTR extension in this exon
-        let e = exon("T1", 1, 1000, 1011);
-        let exons_ref: Vec<&ExonFeature> = vec![&e];
-        let tr = translation("T1", Some(12), Some(4), Some("MAER"), Some(cds));
-        // Insert "G" at position 1012 (exon.end + 1 == cds_end + 1)
-        let v = var("1", 1012, 1012, "-", "G");
+        t.cdna_coding_end = Some(cds.len());
+        t.spliced_seq = Some(cds.to_string());
+        let e1 = exon("T1", 1, 1000, 1010);
+        let e2 = exon("T1", 2, 1020, 1026);
+        let exons_ref: Vec<&ExonFeature> = vec![&e1, &e2];
+        let tr = translation("T1", Some(cds.len()), Some(cds.len() / 3), None, Some(cds));
+        // Insert "G" immediately after the internal coding exon.
+        let v = var("1", 1011, 1011, "-", "G");
         let (terms, coding_class) =
             engine.evaluate_transcript_overlap(&v, &t, &exons_ref, Some(&tr));
         let term_set: std::collections::BTreeSet<_> = terms.iter().collect();
@@ -20374,8 +20947,8 @@ mod tests {
         );
 
         let cc = coding_class.expect("Coding classification must be present");
-        assert_eq!(cc.cds_position_start, Some(12), "CDS position start");
-        assert_eq!(cc.cds_position_end, Some(13), "CDS position end");
+        assert_eq!(cc.cds_position_start, Some(11), "CDS position start");
+        assert_eq!(cc.cds_position_end, Some(12), "CDS position end");
         assert_eq!(cc.protein_position_start, Some(4), "Protein position");
         assert!(
             cc.amino_acids.is_some(),
@@ -20397,11 +20970,11 @@ mod tests {
         //      Protein_position=40, Amino_acids=E/GEX, Codons=gaa/gGTGAaa
         // vepyr (before fix): splice_region_variant only, all coding fields empty.
         //
-        // Simplified model: CDS = 15 bases (5 codons), last codon = GAA (Glu).
-        // Insert 4 bases "GTGA" at exon.end + 1 → frameshift.
+        // Simplified model: the first coding exon is 15 bases and a second
+        // coding exon follows after the insertion boundary.
         let engine = TranscriptConsequenceEngine::default();
         // CDS: ATG GCT AAA GCT GAA = M A K A E (15 bases, positions 1000-1014)
-        let cds = "ATGGCTAAAGCTGAA";
+        let cds = "ATGGCTAAAGCTGAAGCTTGA";
         let mut t = tx(
             "T1",
             "1",
@@ -20410,15 +20983,16 @@ mod tests {
             1,
             "protein_coding",
             Some(1000),
-            Some(1014),
+            Some(1027),
         );
-        t.cdna_coding_end = Some(15);
-        t.spliced_seq = Some(format!("{cds}CCCGGGAAA")); // CDS + UTR
-        let e = exon("T1", 1, 1000, 1014);
-        let exons_ref: Vec<&ExonFeature> = vec![&e];
-        let tr = translation("T1", Some(15), Some(5), Some("MARAE"), Some(cds));
-        // Insert "GTGA" at position 1015 (exon.end + 1)
-        let v = var("1", 1015, 1015, "-", "GTGA");
+        t.cdna_coding_end = Some(cds.len());
+        t.spliced_seq = Some(cds.to_string());
+        let e1 = exon("T1", 1, 1000, 1012);
+        let e2 = exon("T1", 2, 1020, 1027);
+        let exons_ref: Vec<&ExonFeature> = vec![&e1, &e2];
+        let tr = translation("T1", Some(cds.len()), Some(cds.len() / 3), None, Some(cds));
+        // Insert "GTGA" immediately after the internal coding exon.
+        let v = var("1", 1013, 1013, "-", "GTGA");
         let (terms, coding_class) =
             engine.evaluate_transcript_overlap(&v, &t, &exons_ref, Some(&tr));
         let term_set: std::collections::BTreeSet<_> = terms.iter().collect();
@@ -20435,8 +21009,8 @@ mod tests {
         );
 
         let cc = coding_class.expect("Coding classification must be present");
-        assert_eq!(cc.cds_position_start, Some(15), "CDS position start");
-        assert_eq!(cc.cds_position_end, Some(16), "CDS position end");
+        assert_eq!(cc.cds_position_start, Some(13), "CDS position start");
+        assert_eq!(cc.cds_position_end, Some(14), "CDS position end");
         assert_eq!(cc.protein_position_start, Some(5), "Protein position");
         assert!(
             cc.amino_acids.is_some(),
@@ -20461,11 +21035,16 @@ mod tests {
         //      Codons=aac/aaAGTGCCGGCCGCGGGGCCCTGTCTATAAGc
         // vepyr (before fix): coding_sequence_variant only, all coding fields empty.
         //
-        // Simplified model: CDS = 12 bases (4 codons), last codon = AAC (Asn).
-        // Insert 29 bases at exon.end + 1 → frameshift.
-        let engine = TranscriptConsequenceEngine::default();
+        // Simplified model: the first coding exon is 12 bases and a second
+        // coding exon follows after the insertion boundary.
+        let engine = TranscriptConsequenceEngine::new_with_hgvs_shift_and_semantics(
+            5000,
+            5000,
+            false,
+            crate::vep_semantics::VepSemantics::V116,
+        );
         // CDS: ATG GCT GAA AAC = M A E N (12 bases, positions 1000-1011)
-        let cds = "ATGGCTGAAAAC";
+        let cds = "ATGGCTGAAAACGCTGCT";
         let mut t = tx(
             "T1",
             "1",
@@ -20474,15 +21053,16 @@ mod tests {
             1,
             "protein_coding",
             Some(1000),
-            Some(1011),
+            Some(1026),
         );
-        t.cdna_coding_end = Some(12);
-        t.spliced_seq = Some(format!("{cds}CCCGGGAAATTTCCCGGGAAATTT")); // CDS + UTR
-        let e = exon("T1", 1, 1000, 1011);
-        let exons_ref: Vec<&ExonFeature> = vec![&e];
-        let tr = translation("T1", Some(12), Some(4), Some("MAEN"), Some(cds));
-        // Insert 29 bases at position 1012 (exon.end + 1)
-        let v = var("1", 1012, 1012, "-", "CTTATAGACAGGGCCCCGCGGCCGGCACT");
+        t.cdna_coding_end = Some(cds.len());
+        t.spliced_seq = Some(cds.to_string());
+        let e1 = exon("T1", 1, 1000, 1010);
+        let e2 = exon("T1", 2, 1020, 1026);
+        let exons_ref: Vec<&ExonFeature> = vec![&e1, &e2];
+        let tr = translation("T1", Some(cds.len()), Some(cds.len() / 3), None, Some(cds));
+        // Insert 29 bases immediately after the internal coding exon.
+        let v = var("1", 1011, 1011, "-", "CTTATAGACAGGGCCCCGCGGCCGGCACT");
         let (terms, coding_class) =
             engine.evaluate_transcript_overlap(&v, &t, &exons_ref, Some(&tr));
         let term_set: std::collections::BTreeSet<_> = terms.iter().collect();
@@ -20499,8 +21079,8 @@ mod tests {
         );
 
         let cc = coding_class.expect("Coding classification must be present");
-        assert_eq!(cc.cds_position_start, Some(12), "CDS position start");
-        assert_eq!(cc.cds_position_end, Some(13), "CDS position end");
+        assert_eq!(cc.cds_position_start, Some(11), "CDS position start");
+        assert_eq!(cc.cds_position_end, Some(12), "CDS position end");
         assert_eq!(cc.protein_position_start, Some(4), "Protein position");
         assert!(
             cc.amino_acids.is_some(),
@@ -20561,11 +21141,9 @@ mod tests {
     }
 
     #[test]
-    fn issue_118_insertion_within_exon_extending_past_cds() {
-        // Test the overlaps_exon=true + ins_left_flank_in_cds path:
-        // insertion at cds_end+1 where the exon extends into UTR
-        // (overlaps_exon is TRUE because the insertion is within the exon).
-        // VEP's within_cds() returns TRUE because the left flank maps to CDS.
+    fn terminal_insertion_within_exon_is_three_prime_utr() {
+        // The exon extends into UTR, so overlaps_exon is true, but the
+        // insertion is after the terminal CDS base and must remain non-coding.
         let engine = TranscriptConsequenceEngine::default();
         // CDS: ATG GCT GAA TGA (12 bases), positions 1000-1011
         // Exon: 1000-1020 (extends 9 bases past CDS into UTR)
@@ -20591,27 +21169,21 @@ mod tests {
             engine.evaluate_transcript_overlap(&v, &t, &exons_ref, Some(&tr));
         let term_set: std::collections::BTreeSet<_> = terms.iter().collect();
 
-        // 1bp insertion at cds_end+1 (stop codon region): local codon window
-        // includes '*' → stop_retained → inframe_insertion override.
         assert!(
-            term_set.contains(&SoTerm::InframeInsertion),
-            "Within-exon CDS boundary 1bp insertion at stop should get inframe_insertion, got: {:?}",
+            term_set.contains(&SoTerm::ThreePrimeUtrVariant),
+            "Within-exon terminal CDS boundary insertion should be 3' UTR, got: {:?}",
             terms
         );
         assert!(
-            term_set.contains(&SoTerm::StopRetainedVariant),
-            "Should have stop_retained_variant, got: {:?}",
+            !term_set.contains(&SoTerm::InframeInsertion)
+                && !term_set.contains(&SoTerm::FrameshiftVariant)
+                && !term_set.contains(&SoTerm::StopRetainedVariant),
+            "Terminal UTR insertion must not emit coding terms, got: {:?}",
             terms
         );
         assert!(
-            coding_class.is_some(),
-            "Coding classification must be present for within-exon CDS boundary insertion"
-        );
-        let cc = coding_class.unwrap();
-        assert!(cc.cds_position_start.is_some(), "CDS position must be set");
-        assert!(
-            cc.protein_position_start.is_some(),
-            "Protein position must be set"
+            coding_class.is_none(),
+            "Terminal UTR insertion must leave coding fields empty"
         );
     }
 

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -2111,6 +2111,12 @@ impl TranscriptConsequenceEngine {
     /// Forward-strand motifs count from the motif start, reverse-strand motifs
     /// from the motif end, matching Ensembl VEP's MOTIF_POS.
     fn motif_position(variant: &VariantInput, m: &MotifFeature) -> Option<i64> {
+        // Ensembl VEP leaves MOTIF_POS empty for multi-base reference alleles;
+        // observed on chr22 @116 for ATCT>A and TACACACGTGTCCTCACACATGC>T,
+        // where VEP emits no value while every single-base case is populated.
+        if normalize_allele_seq(&variant.ref_allele).len() != 1 {
+            return None;
+        }
         let strand = m.strand?;
         let pos = if strand >= 0 {
             variant.start - m.start + 1
@@ -22272,5 +22278,34 @@ mod tests {
             .collect();
         assert_eq!(by_id.get("ENSM00000588617"), Some(&Some(3)));
         assert_eq!(by_id.get("ENSM00000588616"), Some(&Some(21)));
+    }
+
+    #[test]
+    fn motif_pos_is_empty_for_multi_base_reference_alleles() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_matrix(
+            "ENSM_del",
+            "22",
+            17_088_125,
+            17_088_147,
+            "ENSPFM0510",
+            "TBX21",
+            1,
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 17_088_127, 17_088_130, "ATCT", "A"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let m = out
+            .iter()
+            .find(|a| a.feature_type == FeatureType::MotifFeature)
+            .expect("motif consequence");
+        assert_eq!(m.motif_pos, None);
     }
 }

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -2111,12 +2111,6 @@ impl TranscriptConsequenceEngine {
     /// Forward-strand motifs count from the motif start, reverse-strand motifs
     /// from the motif end, matching Ensembl VEP's MOTIF_POS.
     fn motif_position(variant: &VariantInput, m: &MotifFeature) -> Option<i64> {
-        // Ensembl VEP leaves MOTIF_POS empty for multi-base reference alleles;
-        // observed on chr22 @116 for ATCT>A and TACACACGTGTCCTCACACATGC>T,
-        // where VEP emits no value while every single-base case is populated.
-        if normalize_allele_seq(&variant.ref_allele).len() != 1 {
-            return None;
-        }
         let strand = m.strand?;
         let pos = if strand >= 0 {
             variant.start - m.start + 1
@@ -22278,34 +22272,5 @@ mod tests {
             .collect();
         assert_eq!(by_id.get("ENSM00000588617"), Some(&Some(3)));
         assert_eq!(by_id.get("ENSM00000588616"), Some(&Some(21)));
-    }
-
-    #[test]
-    fn motif_pos_is_empty_for_multi_base_reference_alleles() {
-        let engine = TranscriptConsequenceEngine::default();
-        let motifs = vec![motif_with_matrix(
-            "ENSM_del",
-            "22",
-            17_088_125,
-            17_088_147,
-            "ENSPFM0510",
-            "TBX21",
-            1,
-        )];
-        let out = engine.evaluate_variant_with_context(
-            &var("22", 17_088_127, 17_088_130, "ATCT", "A"),
-            &[],
-            &[],
-            &[],
-            &[],
-            &motifs,
-            &[],
-            &[],
-        );
-        let m = out
-            .iter()
-            .find(|a| a.feature_type == FeatureType::MotifFeature)
-            .expect("motif consequence");
-        assert_eq!(m.motif_pos, None);
     }
 }

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -2163,6 +2163,21 @@ impl TranscriptConsequenceEngine {
         (pos >= 1 && pos <= motif_len).then_some(pos)
     }
 
+    /// Whether a plain deletion removes a motif outright, which Ensembl calls
+    /// TFBS_ablation.
+    ///
+    /// `VariationEffect::feature_ablation` is `complete_overlap_feature and
+    /// deletion`: the variant has to span the whole feature and shorten the
+    /// reference. It applies to ordinary sequence variants, not just to
+    /// structural ones, which is where vepyr had been reading it.
+    fn ablates_motif(variant: &VariantInput, m: &MotifFeature) -> bool {
+        let spans_feature = variant.start <= m.start && variant.end >= m.end;
+        let is_deletion = variant.ref_allele != "-"
+            && !variant.ref_allele.is_empty()
+            && (variant.alt_allele == "-" || variant.alt_allele.len() < variant.ref_allele.len());
+        spans_feature && is_deletion
+    }
+
     /// The motif's frequency matrix, if the cache carried a usable one.
     ///
     /// Ensembl's frequency-to-weights conversion is defined for frequency
@@ -2291,6 +2306,9 @@ impl TranscriptConsequenceEngine {
             matched_motif = true;
             let mut terms: BTreeSet<SoTerm> = sv_terms.clone();
             terms.insert(SoTerm::TfBindingSiteVariant);
+            if Self::ablates_motif(variant, m) {
+                terms.insert(SoTerm::TfbsAblation);
+            }
             let mut ordered: Vec<SoTerm> = terms.into_iter().collect();
             ordered.sort_by_key(|t| t.rank());
             let matrix = Self::motif_matrix(m);
@@ -2369,6 +2387,9 @@ impl TranscriptConsequenceEngine {
             matched_motif = true;
             let mut terms: BTreeSet<SoTerm> = sv_terms.clone();
             terms.insert(SoTerm::TfBindingSiteVariant);
+            if Self::ablates_motif(variant, m) {
+                terms.insert(SoTerm::TfbsAblation);
+            }
             let mut ordered: Vec<SoTerm> = terms.into_iter().collect();
             ordered.sort_by_key(|t| t.rank());
             let matrix = Self::motif_matrix(m);
@@ -22524,6 +22545,90 @@ mod tests {
         assert_eq!(consequence.motif_pos, Some(21));
         assert_eq!(consequence.high_inf_pos, Some(true));
         assert_eq!(consequence.motif_score_change.as_deref(), Some("-0.058"));
+    }
+
+    /// Real chr22:48837364, a 22 bp deletion spanning ENSM00000589970 whole.
+    /// VEP 116 reports TFBS_ablation alongside TF_binding_site_variant, which
+    /// lifts IMPACT from MODIFIER to MODERATE.
+    #[test]
+    fn deletion_spanning_a_motif_is_a_tfbs_ablation() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_matrix(
+            "ENSM00000589970",
+            "22",
+            48_837_370,
+            48_837_380,
+            "ENSPFM0042",
+            "CTCF",
+            1,
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 48_837_365, 48_837_386, "ACACACGTGTCCTCACACATGC", "-"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000589970");
+        assert!(consequence.terms.contains(&SoTerm::TfbsAblation));
+        assert!(consequence.terms.contains(&SoTerm::TfBindingSiteVariant));
+    }
+
+    /// A deletion that only clips the motif is not an ablation.
+    #[test]
+    fn partial_deletion_is_not_a_tfbs_ablation() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_matrix(
+            "ENSM00000589970",
+            "22",
+            48_837_370,
+            48_837_380,
+            "ENSPFM0042",
+            "CTCF",
+            1,
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 48_837_375, 48_837_377, "ACG", "-"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000589970");
+        assert!(!consequence.terms.contains(&SoTerm::TfbsAblation));
+    }
+
+    /// An insertion spanning the same span is not a deletion, so no ablation.
+    #[test]
+    fn insertion_over_a_motif_is_not_a_tfbs_ablation() {
+        let engine = TranscriptConsequenceEngine::default();
+        let motifs = vec![motif_with_matrix(
+            "ENSM00000589970",
+            "22",
+            48_837_370,
+            48_837_371,
+            "ENSPFM0042",
+            "CTCF",
+            1,
+        )];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 48_837_369, 48_837_372, "AC", "ACGTGT"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let consequence = motif_consequence(&out, "ENSM00000589970");
+        assert!(!consequence.terms.contains(&SoTerm::TfbsAblation));
     }
 
     /// A deletion is not a "true SNP", so HIGH_INF_POS reports N and

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -4254,6 +4254,44 @@ fn vep116_stop_retained_without_alt_peptide(
         .is_some_and(is_stop_codon)
 }
 
+/// VEP 116 `stop_lost()` falls back to `_ins_del_stop_altered()` when the
+/// local alternate peptide is missing or contains `X`. Unlike the
+/// stop-retained fallback, this path uses the ordinary (unextended) stop-codon
+/// overlap interval.
+fn vep116_stop_lost_without_unambiguous_alt_peptide(
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    tx_translation: Option<&TranslationFeature>,
+    variant: &VariantInput,
+) -> bool {
+    let ref_seq = normalize_allele_seq(&variant.ref_allele);
+    let alt_seq = normalize_allele_seq(&variant.alt_allele);
+    if tx.cds_end_nf
+        || ref_seq.len() == alt_seq.len()
+        || !ref_seq
+            .bytes()
+            .chain(alt_seq.bytes())
+            .all(|base| matches!(base.to_ascii_uppercase(), b'A' | b'C' | b'G' | b'T' | b'N'))
+    {
+        return false;
+    }
+
+    let (Some(cds_start), Some(cds_end)) = (tx.cds_start, tx.cds_end) else {
+        return false;
+    };
+    let (stop_start, stop_end) = if tx.strand >= 0 {
+        (cds_end.saturating_sub(2), cds_end)
+    } else {
+        (cds_start, cds_start.saturating_add(2))
+    };
+    if !overlaps(variant.start, variant.end, stop_start, stop_end) {
+        return false;
+    }
+
+    reference_translateable_seq_for_vep(tx, tx_translation)
+        .is_some_and(|cds_seq| !mutated_cds_stop_preserved(&cds_seq, variant, tx, tx_exons))
+}
+
 #[derive(Debug, Clone, Default)]
 struct CodingClassification {
     synonymous: bool,
@@ -4318,6 +4356,37 @@ fn apply_vep116_stop_predicate_flags(
     }
     if class.stop_lost {
         class.stop_gained = false;
+    }
+}
+
+fn apply_vep116_nucleotide_stop_fallbacks(
+    class: &mut CodingClassification,
+    semantics: crate::vep_semantics::VepSemantics,
+    partial_terminal_codon: bool,
+    tx: &TranscriptFeature,
+    tx_exons: &[&ExonFeature],
+    tx_translation: Option<&TranslationFeature>,
+    variant: &VariantInput,
+) {
+    if !semantics.vep116_stop_predicates() || partial_terminal_codon {
+        return;
+    }
+
+    let has_unambiguous_peptides = class.affected_ref_peptide.is_some()
+        && class
+            .affected_alt_peptide
+            .as_deref()
+            .is_some_and(|peptide| !peptide.is_empty() && !peptide.contains('X'));
+    if has_unambiguous_peptides {
+        return;
+    }
+
+    if vep116_stop_lost_without_unambiguous_alt_peptide(tx, tx_exons, tx_translation, variant) {
+        class.stop_gained = false;
+        class.stop_retained = false;
+        class.stop_lost = true;
+    } else if vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant) {
+        class.stop_retained = true;
     }
 }
 
@@ -6655,15 +6724,15 @@ fn classify_coding_change_with_semantics(
     }
 
     apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
-    if semantics.vep116_stop_predicates()
-        && class
-            .affected_alt_peptide
-            .as_deref()
-            .is_none_or(|peptide| peptide.is_empty() || peptide.contains('X'))
-        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
-    {
-        class.stop_retained = true;
-    }
+    apply_vep116_nucleotide_stop_fallbacks(
+        &mut class,
+        semantics,
+        partial_terminal_codon,
+        tx,
+        tx_exons,
+        tx_translation,
+        variant,
+    );
 
     if ref_len == alt_len {
         let use_display_peptide_window = skip_global_stop_compare;
@@ -6906,15 +6975,15 @@ fn classify_coding_change_with_semantics(
         }
     }
     apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
-    if semantics.vep116_stop_predicates()
-        && class
-            .affected_alt_peptide
-            .as_deref()
-            .is_none_or(|peptide| peptide.is_empty() || peptide.contains('X'))
-        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
-    {
-        class.stop_retained = true;
-    }
+    apply_vep116_nucleotide_stop_fallbacks(
+        &mut class,
+        semantics,
+        partial_terminal_codon,
+        tx,
+        tx_exons,
+        tx_translation,
+        variant,
+    );
 
     // For HGVS stop-loss / frameshift extension distance, translate the
     // mutated CDS + 3' UTR so that the new stop codon can be found even
@@ -7348,15 +7417,15 @@ fn classify_insertion_with_semantics(
         }
     }
     apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
-    if semantics.vep116_stop_predicates()
-        && class
-            .affected_alt_peptide
-            .as_deref()
-            .is_none_or(|peptide| peptide.is_empty() || peptide.contains('X'))
-        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
-    {
-        class.stop_retained = true;
-    }
+    apply_vep116_nucleotide_stop_fallbacks(
+        &mut class,
+        semantics,
+        partial_terminal_codon,
+        tx,
+        tx_exons,
+        tx_translation,
+        variant,
+    );
 
     // When stop_retained, VEP overrides frameshift → inframe (regardless of alt_len % 3).
     let raw_frameshift = if class.stop_retained {
@@ -9911,7 +9980,7 @@ mod tests {
     }
 
     #[test]
-    fn vep116_hunks5_and6_reject_x_for_stop_lost_and_stop_retained() {
+    fn vep116_hunks5_and6_route_x_peptides_to_nucleotide_stop_fallbacks() {
         let base = CodingClassification {
             stop_lost: true,
             stop_retained: true,
@@ -9932,6 +10001,40 @@ mod tests {
         );
         assert!(v115.stop_lost && v115.stop_retained);
         assert!(!v116.stop_lost && !v116.stop_retained);
+
+        let mut plus = tx(
+            "T1",
+            "22",
+            1000,
+            1011,
+            1,
+            "protein_coding",
+            Some(1000),
+            Some(1008),
+        );
+        plus.cdna_coding_start = Some(1);
+        plus.cdna_coding_end = Some(9);
+        plus.three_prime_utr_seq = Some("CCC".to_string());
+        let exon = exon("T1", 1, 1000, 1011);
+        let exon_refs = vec![&exon];
+        let translation = translation("T1", Some(9), Some(3), None, Some("ATGAAATAA"));
+        let insertion = var("22", 1007, 1007, "-", "T");
+        let mut fallback = CodingClassification {
+            affected_ref_peptide: Some("*".to_string()),
+            affected_alt_peptide: Some("LX".to_string()),
+            ..Default::default()
+        };
+        apply_vep116_nucleotide_stop_fallbacks(
+            &mut fallback,
+            crate::vep_semantics::VepSemantics::V116,
+            false,
+            &plus,
+            &exon_refs,
+            Some(&translation),
+            &insertion,
+        );
+        assert!(fallback.stop_lost);
+        assert!(!fallback.stop_retained);
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -643,6 +643,9 @@ pub struct TranscriptConsequence {
     /// STRAND for MotifFeature consequences, which have no transcript to
     /// derive orientation from.
     pub motif_strand: Option<i8>,
+    /// MOTIF_POS: 1-based offset of the variant within the motif, in motif
+    /// orientation.
+    pub motif_pos: Option<i64>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -2103,6 +2106,20 @@ impl TranscriptConsequenceEngine {
         }
     }
 
+    /// 1-based offset of `variant` within a motif, in motif orientation.
+    ///
+    /// Forward-strand motifs count from the motif start, reverse-strand motifs
+    /// from the motif end, matching Ensembl VEP's MOTIF_POS.
+    fn motif_position(variant: &VariantInput, m: &MotifFeature) -> Option<i64> {
+        let strand = m.strand?;
+        let pos = if strand >= 0 {
+            variant.start - m.start + 1
+        } else {
+            m.end - variant.start + 1
+        };
+        (pos >= 1).then_some(pos)
+    }
+
     fn append_tfbs_terms(
         &self,
         out: &mut Vec<TranscriptConsequence>,
@@ -2155,6 +2172,7 @@ impl TranscriptConsequenceEngine {
                 motif_name: m.binding_matrix.clone(),
                 motif_transcription_factors: m.transcription_factors.clone(),
                 motif_strand: m.strand,
+                motif_pos: Self::motif_position(variant, m),
                 ..Default::default()
             });
         }
@@ -2225,6 +2243,7 @@ impl TranscriptConsequenceEngine {
                 motif_name: m.binding_matrix.clone(),
                 motif_transcription_factors: m.transcription_factors.clone(),
                 motif_strand: m.strand,
+                motif_pos: Self::motif_position(variant, m),
                 ..Default::default()
             });
         }
@@ -22210,5 +22229,48 @@ mod tests {
             Some("TBX21")
         );
         assert_eq!(motif_csq.motif_strand, Some(1));
+    }
+
+    #[test]
+    fn motif_pos_counts_from_motif_orientation() {
+        let engine = TranscriptConsequenceEngine::default();
+        // Real chr22:17088127 motifs; VEP 116 reports MOTIF_POS 3 and 21.
+        let motifs = vec![
+            motif_with_matrix(
+                "ENSM00000588617",
+                "22",
+                17_088_125,
+                17_088_147,
+                "ENSPFM0510",
+                "TBX21",
+                1,
+            ),
+            motif_with_matrix(
+                "ENSM00000588616",
+                "22",
+                17_088_125,
+                17_088_147,
+                "ENSPFM0510",
+                "TBX21",
+                -1,
+            ),
+        ];
+        let out = engine.evaluate_variant_with_context(
+            &var("22", 17_088_127, 17_088_127, "T", "A"),
+            &[],
+            &[],
+            &[],
+            &[],
+            &motifs,
+            &[],
+            &[],
+        );
+        let by_id: std::collections::HashMap<_, _> = out
+            .iter()
+            .filter(|a| a.feature_type == FeatureType::MotifFeature)
+            .map(|a| (a.transcript_id.clone().unwrap_or_default(), a.motif_pos))
+            .collect();
+        assert_eq!(by_id.get("ENSM00000588617"), Some(&Some(3)));
+        assert_eq!(by_id.get("ENSM00000588616"), Some(&Some(21)));
     }
 }

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -6774,6 +6774,26 @@ fn classify_coding_change_with_semantics(
     let local_alt_codon = &mutated[local_codon_start..local_alt_end];
     class.affected_ref_peptide = local_peptide_from_codon_window(local_ref_codon);
     class.affected_alt_peptide = local_peptide_from_codon_window(local_alt_codon);
+    if skip_global_stop_compare {
+        // Failed RefSeq BAM edits can leave the genomic codon representation
+        // different from the trusted cached protein. VEP exposes that split
+        // for NM_173600.2 at chr12:40526308: Codons is `Tga/Cga`, but both
+        // reference and alternate `peptide()` values consumed by
+        // `_get_peptide_alleles()` are Arg (`R/R`), producing synonymous
+        // rather than stop_lost.
+        //
+        // `reference_aas_for_consequence()` already selected the cached RefSeq
+        // translation for `old_aas`; `new_aas` is the translated alternate
+        // CDS. Use those same peptide-space windows for the VEP 116 stop
+        // predicates while preserving the genomic codons for CSQ output.
+        let peptide_end = local_last_codon.saturating_add(1);
+        class.affected_ref_peptide = old_aas
+            .get(local_first_codon..peptide_end)
+            .map(|peptide| peptide.iter().collect());
+        class.affected_alt_peptide = new_aas
+            .get(local_first_codon..peptide_end)
+            .map(|peptide| peptide.iter().collect());
+    }
     let partial_terminal_codon = {
         let codon_start = local_first_codon.saturating_mul(3);
         let last_codon_len = cds_seq.len().saturating_sub(codon_start);
@@ -15249,6 +15269,21 @@ mod tests {
         let protein = c.protein_hgvs.as_ref().expect("protein hgvs");
         let formatted = crate::hgvs::format_hgvsp(&translation_for_hgvsp(&t, &tr), protein, true);
         assert_eq!(formatted.as_deref(), Some("NP_775871.2:p.Arg3="));
+
+        let v116 = classify_coding_change_with_semantics(
+            &t,
+            &exons_ref,
+            Some(&tr),
+            &v,
+            crate::vep_semantics::VepSemantics::V116,
+        )
+        .expect("VEP 116 classification");
+        assert_eq!(v116.affected_ref_peptide.as_deref(), Some("R"));
+        assert_eq!(v116.affected_alt_peptide.as_deref(), Some("R"));
+        assert!(
+            v116.synonymous && !v116.stop_lost,
+            "VEP 116 must apply stop predicates to the edited RefSeq peptide: {v116:?}"
+        );
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -6030,20 +6030,6 @@ fn protein_hgvs_for_output_with_semantics(
         return None;
     }
 
-    // In release 116, VEP's shifted TVA peptide replay retains ambiguous
-    // terminal windows such as `*/X`, `S*/X`, and `*/YX`. The release-116
-    // affected peptide window above is built by the same `codon()` /
-    // `peptide()` rules and is the exact state observed after VEP's
-    // `_return_3prime()` replay for these terminal alleles. Do not replace it
-    // with an extension-only translation that loses the terminal `X`.
-    if semantics.vep116_stop_predicates()
-        && fallback.is_some_and(|protein| {
-            protein.ref_peptide.contains('*') && protein.alt_peptide.contains('X')
-        })
-    {
-        return fallback.cloned();
-    }
-
     if !shift_hgvs {
         return fallback.cloned();
     }
@@ -6213,6 +6199,25 @@ fn protein_hgvs_for_output_with_semantics(
             let shifted_variant = protein_hgvs_shifted_variant(variant, shift, tx.strand);
             shifted_tva_coords_from_mapper(tx, tx_exons, translation, &shifted_variant)?;
         }
+    }
+
+    // In release 116, VEP's shifted TVA peptide replay retains ambiguous
+    // terminal windows such as `*/X`, `S*/X`, and `*/YX`. The release-116
+    // affected peptide window above is built by the same `codon()` /
+    // `peptide()` rules and is the exact state observed after VEP's
+    // `_return_3prime()` replay for these terminal alleles. Do not replace it
+    // with an extension-only translation that loses the terminal `X`.
+    //
+    // This preservation must run after the shifted translation-coordinate
+    // guard. `hgvs_protein()` calls `_return_3prime()` first and suppresses
+    // HGVSp when the shifted `translation_start/end` fall outside the CDS,
+    // even if the unshifted consequence peptide is an ambiguous `*/X`.
+    if semantics.vep116_stop_predicates()
+        && fallback.is_some_and(|protein| {
+            protein.ref_peptide.contains('*') && protein.alt_peptide.contains('X')
+        })
+    {
+        return fallback.cloned();
     }
 
     shifted_preferred.or_else(|| fallback.cloned())
@@ -18708,6 +18713,105 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn chr6_terminal_deletion_shifted_to_three_prime_utr_suppresses_hgvsp() {
+        // Minimal terminal-exon model for chr6:68956855 GA>G on
+        // ENST00001108876.1. Its final CDS base is at 68956856 and is followed
+        // by a nine-A 3' UTR ending at 68956865. VEP shifts the deleted A by
+        // nine bases to c.*9, where genomic2pep returns Gap.
+        let mut t = tx(
+            "ENST00001108876",
+            "6",
+            68_956_845,
+            68_956_865,
+            1,
+            "protein_coding",
+            Some(68_956_845),
+            Some(68_956_856),
+        );
+        t.cdna_coding_start = Some(1);
+        t.cdna_coding_end = Some(12);
+        t.spliced_seq = Some("ATGCCCAAATGAAAAAAAAAA".to_string());
+        t.translateable_seq = Some("ATGCCCAAATGA".to_string());
+        t.translation_stable_id = Some("ENSP00000778681".to_string());
+
+        let exons = vec![exon("ENST00001108876", 1, 68_956_845, 68_956_865)];
+        let exons_ref: Vec<&ExonFeature> = exons.iter().collect();
+        let tr = translation(
+            "ENST00001108876",
+            Some(12),
+            Some(4),
+            Some("MPK*"),
+            Some("ATGCCCAAATGA"),
+        );
+        let fallback = crate::hgvs::ProteinHgvsData {
+            start: 4,
+            end: 4,
+            ref_peptide: "*".to_string(),
+            alt_peptide: "X".to_string(),
+            ref_translation: "MPK*".to_string(),
+            alt_translation: "MPKX".to_string(),
+            alt_translation_extension: None,
+            frameshift: false,
+            start_lost: false,
+            stop_lost: false,
+            native_refseq: false,
+        };
+        let mut v =
+            VariantInput::from_vcf("6".into(), 68_956_855, 68_956_856, "GA".into(), "G".into());
+        v.hgvs_shift_forward = Some(crate::hgvs::HgvsGenomicShift {
+            strand: 1,
+            shift_length: 9,
+            start: 68_956_865,
+            end: 68_956_865,
+            shifted_allele_string: "A".to_string(),
+            shifted_compare_allele: "-".to_string(),
+            shifted_output_allele: "-".to_string(),
+            ref_orig_allele_string: "A".to_string(),
+            alt_orig_allele_string: "-".to_string(),
+            five_prime_flanking_seq: String::new(),
+            three_prime_flanking_seq: String::new(),
+            five_prime_context: String::new(),
+            three_prime_context: String::new(),
+        });
+
+        assert_eq!((v.start, v.end), (68_956_856, 68_956_856));
+        let shift = v.hgvs_shift_forward.as_ref().expect("forward HGVS shift");
+        let shifted = protein_hgvs_shifted_variant(&v, shift, t.strand);
+        assert_eq!((shifted.start, shifted.end), (68_956_865, 68_956_865));
+        assert_eq!(
+            genomic_to_cdna_index_for_hgvsp(&t, &exons_ref, shifted.start),
+            Some(21),
+            "the shifted deletion maps to c.*9"
+        );
+        assert_eq!(
+            shifted_tva_coords_from_mapper(&t, &exons_ref, &tr, &shifted),
+            None,
+            "the c.*9 position has no CDS or peptide coordinate"
+        );
+
+        for semantics in [
+            crate::vep_semantics::VepSemantics::V115,
+            crate::vep_semantics::VepSemantics::V116,
+        ] {
+            assert_eq!(
+                protein_hgvs_for_output_with_semantics(
+                    &t,
+                    &exons_ref,
+                    Some(&tr),
+                    &v,
+                    true,
+                    None,
+                    Some(&fallback),
+                    semantics,
+                    true,
+                ),
+                None,
+                "{semantics:?} must suppress HGVSp after the shift leaves the CDS"
+            );
+        }
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -4190,6 +4190,10 @@ fn vep116_stop_retained_without_alt_peptide(
     let Some(cds_seq) = reference_translateable_seq_for_vep(tx, tx_translation) else {
         return false;
     };
+    let leading_n_offset = cds_seq
+        .bytes()
+        .take_while(|base| base.eq_ignore_ascii_case(&b'N'))
+        .count();
     let mut combined = cds_seq.clone().into_bytes();
     combined.extend_from_slice(three_prime_utr_seq(tx).unwrap_or_default().as_bytes());
 
@@ -4211,32 +4215,36 @@ fn vep116_stop_retained_without_alt_peptide(
         let Some(cds_idx) = genomic_to_cds_index(tx, tx_exons, anchor) else {
             return false;
         };
-        (cds_idx.saturating_add(1), 0)
+        (
+            cds_idx.saturating_add(leading_n_offset).saturating_add(1),
+            0,
+        )
     } else {
-        let mut cdna_positions = Vec::new();
-        for exon in tx_exons {
-            let overlap_start = variant.start.max(exon.start);
-            let overlap_end = variant.end.min(exon.end);
-            if overlap_start > overlap_end {
-                continue;
-            }
-            for position in [overlap_start, overlap_end] {
-                if let Some(cdna) = genomic_to_cdna_index_for_transcript(tx, tx_exons, position) {
-                    cdna_positions.push(cdna);
-                }
-            }
-        }
-        let (Some(min_cdna), Some(max_cdna), Some(coding_start)) = (
-            cdna_positions.iter().min().copied(),
-            cdna_positions.iter().max().copied(),
-            tx.cdna_coding_start,
+        // VEP reads `$bvfo->cdna_start`, `$bvfo->cdna_end`, and
+        // `$bvfo->cds_start` directly. When either genomic endpoint cannot be
+        // mapped to cDNA, `_ins_del_stop_altered_cil()` returns 0; because
+        // `stop_retained()` negates that result, the stop is retained.
+        let (Some(cdna_at_start), Some(cdna_at_end)) = (
+            genomic_to_cdna_index_for_transcript(tx, tx_exons, variant.start),
+            genomic_to_cdna_index_for_transcript(tx, tx_exons, variant.end),
         ) else {
-            return false;
+            return true;
+        };
+        let (min_cdna, max_cdna) = if cdna_at_start <= cdna_at_end {
+            (cdna_at_start, cdna_at_end)
+        } else {
+            (cdna_at_end, cdna_at_start)
+        };
+        let Some(coding_start) = tx.cdna_coding_start else {
+            return true;
         };
         let Some(edit_start) = min_cdna.checked_sub(coding_start) else {
-            return false;
+            return true;
         };
-        (edit_start, max_cdna.saturating_sub(min_cdna) + 1)
+        (
+            edit_start.saturating_add(leading_n_offset),
+            max_cdna.saturating_sub(min_cdna) + 1,
+        )
     };
 
     if edit_start > combined.len() {
@@ -4422,10 +4430,11 @@ fn frameshift_under_semantics(
 ) -> bool {
     raw_frameshift
         && !(semantics.vep116_stop_predicates()
-            && class
-                .affected_ref_peptide
-                .as_deref()
-                .is_some_and(|peptide| peptide.starts_with('*')))
+            && (class.stop_retained
+                || class
+                    .affected_ref_peptide
+                    .as_deref()
+                    .is_some_and(|peptide| peptide.starts_with('*'))))
 }
 
 fn apply_vep116_primary_indel_predicates(
@@ -4494,6 +4503,12 @@ fn vep116_ref_eq_alt_sequence_for_class(
     ref_translation: &[char],
     translation_start: usize,
 ) -> bool {
+    // VEP passes `$bvfo->_peptide` here. Ensembl's transcript translation
+    // excludes the terminal stop, while our CDS translation retains it.
+    // Internal stops remain part of both representations.
+    let ref_translation = ref_translation
+        .strip_suffix(&['*'])
+        .unwrap_or(ref_translation);
     match (
         class.affected_ref_peptide.as_deref(),
         class.affected_alt_peptide.as_deref(),
@@ -4564,6 +4579,22 @@ fn build_protein_hgvs_data(
         stop_lost: class.stop_lost,
         native_refseq: false,
     })
+}
+
+fn vep116_ambiguous_terminal_hgvsp_alleles(
+    class: &CodingClassification,
+    semantics: crate::vep_semantics::VepSemantics,
+) -> Option<String> {
+    if !semantics.vep116_stop_predicates() {
+        return None;
+    }
+    let (Some(reference), Some(alternate)) = (
+        class.affected_ref_peptide.as_deref(),
+        class.affected_alt_peptide.as_deref(),
+    ) else {
+        return None;
+    };
+    (reference.contains('*') && alternate.contains('X')).then(|| format!("{reference}/{alternate}"))
 }
 
 /// Traceability:
@@ -5999,12 +6030,12 @@ fn protein_hgvs_for_output_with_semantics(
         return None;
     }
 
-    // Release 116's stop-predicate changes expose ambiguous local terminal
-    // peptides such as `*/X`, `S*/X`, and `*/YX`. VEP's shifted TVA replay
-    // preserves that original local peptide window for protein HGVS. Keep the
-    // same window here instead of replacing it with a translated extension
-    // that drops the terminal `X`; `format_hgvsp()` then applies VEP's
-    // star-to-X normalization in the official order.
+    // In release 116, VEP's shifted TVA peptide replay retains ambiguous
+    // terminal windows such as `*/X`, `S*/X`, and `*/YX`. The release-116
+    // affected peptide window above is built by the same `codon()` /
+    // `peptide()` rules and is the exact state observed after VEP's
+    // `_return_3prime()` replay for these terminal alleles. Do not replace it
+    // with an extension-only translation that loses the terminal `X`.
     if semantics.vep116_stop_predicates()
         && fallback.is_some_and(|protein| {
             protein.ref_peptide.contains('*') && protein.alt_peptide.contains('X')
@@ -7110,12 +7141,14 @@ fn classify_coding_change_with_semantics(
         .as_ref()
         .map(|seq| seq.chars().collect::<Vec<_>>())
         .unwrap_or_else(|| new_aas.clone());
-    let hgvs_amino_acids = class.amino_acids.clone().or_else(|| {
-        class
-            .codons
-            .as_deref()
-            .and_then(pep_allele_string_from_codon_allele_string)
-    });
+    let hgvs_amino_acids = vep116_ambiguous_terminal_hgvsp_alleles(&class, semantics)
+        .or_else(|| class.amino_acids.clone())
+        .or_else(|| {
+            class
+                .codons
+                .as_deref()
+                .and_then(pep_allele_string_from_codon_allele_string)
+        });
     class.protein_hgvs = build_protein_hgvs_data(
         &class,
         hgvs_amino_acids.as_deref(),
@@ -7653,12 +7686,14 @@ fn classify_insertion_with_semantics(
         .as_ref()
         .map(|seq| seq.chars().collect::<Vec<_>>())
         .unwrap_or_else(|| new_aas.clone());
-    let hgvs_amino_acids = class.amino_acids.clone().or_else(|| {
-        class
-            .codons
-            .as_deref()
-            .and_then(pep_allele_string_from_codon_allele_string)
-    });
+    let hgvs_amino_acids = vep116_ambiguous_terminal_hgvsp_alleles(&class, semantics)
+        .or_else(|| class.amino_acids.clone())
+        .or_else(|| {
+            class
+                .codons
+                .as_deref()
+                .and_then(pep_allele_string_from_codon_allele_string)
+        });
     class.protein_hgvs = build_protein_hgvs_data(
         &class,
         hgvs_amino_acids.as_deref(),
@@ -10180,14 +10215,14 @@ mod tests {
         plus.cdna_coding_start = Some(1);
         plus.cdna_coding_end = Some(6);
         plus.three_prime_utr_seq = Some("A".to_string());
-        let exon = exon("T1", 1, 1000, 1006);
-        let exon_refs = vec![&exon];
-        let translation = translation("T1", Some(6), Some(2), None, Some("ATGTAA"));
+        let exon_t1 = exon("T1", 1, 1000, 1006);
+        let exon_refs = vec![&exon_t1];
+        let translation_t1 = translation("T1", Some(6), Some(2), None, Some("ATGTAA"));
         let deletion = var("22", 1005, 1005, "A", "-");
         assert!(vep116_stop_retained_without_alt_peptide(
             &plus,
             &exon_refs,
-            Some(&translation),
+            Some(&translation_t1),
             &deletion,
         ));
 
@@ -10198,6 +10233,30 @@ mod tests {
         let old_overlap = insertion.end >= 1003 && insertion.start <= 1005;
         assert!(old_overlap);
         assert!(!vep116_overlaps_stop_codon_cil(&plus, &insertion, 3));
+
+        let mut partial_mapper = tx(
+            "T2",
+            "18",
+            1000,
+            1015,
+            1,
+            "protein_coding",
+            Some(1000),
+            Some(1012),
+        );
+        partial_mapper.cdna_coding_start = Some(1);
+        partial_mapper.cdna_coding_end = Some(6);
+        partial_mapper.three_prime_utr_seq = Some("CAT".to_string());
+        let partial_exons = [exon("T2", 1, 1000, 1002), exon("T2", 2, 1010, 1015)];
+        let partial_exon_refs: Vec<&ExonFeature> = partial_exons.iter().collect();
+        let partial_translation = translation("T2", Some(6), Some(2), None, Some("ATGTAA"));
+        let intron_to_stop_deletion = var("18", 1005, 1012, "AAAAAAAA", "-");
+        assert!(vep116_stop_retained_without_alt_peptide(
+            &partial_mapper,
+            &partial_exon_refs,
+            Some(&partial_translation),
+            &intron_to_stop_deletion,
+        ));
     }
 
     #[test]
@@ -10228,6 +10287,17 @@ mod tests {
             "Q*",
             "R*",
         ));
+
+        let terminal_insertion = CodingClassification {
+            affected_ref_peptide: Some("T".to_string()),
+            affected_alt_peptide: Some("TL*ARATQG".to_string()),
+            ..Default::default()
+        };
+        assert!(vep116_ref_eq_alt_sequence_for_class(
+            &terminal_insertion,
+            &['A', 'T', 'L', '*'],
+            1,
+        ));
     }
 
     #[test]
@@ -10246,6 +10316,48 @@ mod tests {
             &class,
             crate::vep_semantics::VepSemantics::V116,
         ));
+
+        let stop_retained_after_nonterminal_residue = CodingClassification {
+            stop_retained: true,
+            affected_ref_peptide: Some("S*".to_string()),
+            affected_alt_peptide: Some("X".to_string()),
+            ..Default::default()
+        };
+        assert!(frameshift_under_semantics(
+            true,
+            &stop_retained_after_nonterminal_residue,
+            crate::vep_semantics::VepSemantics::V115,
+        ));
+        assert!(!frameshift_under_semantics(
+            true,
+            &stop_retained_after_nonterminal_residue,
+            crate::vep_semantics::VepSemantics::V116,
+        ));
+    }
+
+    #[test]
+    fn vep116_hgvsp_keeps_ambiguous_terminal_peptide_window() {
+        let class = CodingClassification {
+            amino_acids: Some("*/Y".to_string()),
+            affected_ref_peptide: Some("*".to_string()),
+            affected_alt_peptide: Some("YX".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            vep116_ambiguous_terminal_hgvsp_alleles(
+                &class,
+                crate::vep_semantics::VepSemantics::V115,
+            ),
+            None,
+        );
+        assert_eq!(
+            vep116_ambiguous_terminal_hgvsp_alleles(
+                &class,
+                crate::vep_semantics::VepSemantics::V116,
+            )
+            .as_deref(),
+            Some("*/YX"),
+        );
     }
 
     fn patch_spliced_seq(len: usize, patches: &[(usize, &str)]) -> String {

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -4340,23 +4340,38 @@ fn apply_vep116_stop_predicate_flags(
     class: &mut CodingClassification,
     semantics: crate::vep_semantics::VepSemantics,
     partial_terminal_codon: bool,
+    ref_eq_alt_sequence: bool,
 ) {
     if !semantics.vep116_stop_predicates() {
         return;
     }
-    let alt_has_x = class
-        .affected_alt_peptide
-        .as_deref()
-        .is_some_and(|peptide| peptide.contains('X'));
-    if partial_terminal_codon || alt_has_x {
-        class.stop_lost = false;
-    }
-    if alt_has_x {
-        class.stop_retained = false;
-    }
-    if class.stop_lost {
-        class.stop_gained = false;
-    }
+    let ref_peptide = class.affected_ref_peptide.as_deref();
+    let alt_peptide = class.affected_alt_peptide.as_deref();
+
+    // Release 116 evaluates these predicates recursively in this order:
+    // stop_lost -> stop_retained -> stop_gained. Recompute them from the
+    // predicate inputs instead of amending flags produced by V115 heuristics.
+    let stop_lost = !partial_terminal_codon
+        && matches!(
+            (ref_peptide, alt_peptide),
+            (Some(reference), Some(alternate))
+                if !alternate.contains('X')
+                    && reference.contains('*')
+                    && !alternate.contains('*')
+        );
+    let stop_retained = !partial_terminal_codon
+        && !stop_lost
+        && alt_peptide.is_some_and(|alternate| {
+            !alternate.is_empty() && !alternate.contains('X') && ref_eq_alt_sequence
+        });
+    let stop_gained = !stop_retained
+        && !stop_lost
+        && ref_peptide.is_some_and(|reference| !reference.contains('*'))
+        && alt_peptide.is_some_and(|alternate| alternate.contains('*'));
+
+    class.stop_lost = stop_lost;
+    class.stop_retained = stop_retained;
+    class.stop_gained = stop_gained;
 }
 
 fn apply_vep116_nucleotide_stop_fallbacks(
@@ -4372,20 +4387,28 @@ fn apply_vep116_nucleotide_stop_fallbacks(
         return;
     }
 
-    let has_unambiguous_peptides = class.affected_ref_peptide.is_some()
+    let stop_lost_uses_peptides = class.affected_ref_peptide.is_some()
         && class
             .affected_alt_peptide
             .as_deref()
-            .is_some_and(|peptide| !peptide.is_empty() && !peptide.contains('X'));
-    if has_unambiguous_peptides {
-        return;
-    }
-
-    if vep116_stop_lost_without_unambiguous_alt_peptide(tx, tx_exons, tx_translation, variant) {
+            .is_some_and(|peptide| !peptide.contains('X'));
+    if !stop_lost_uses_peptides
+        && vep116_stop_lost_without_unambiguous_alt_peptide(tx, tx_exons, tx_translation, variant)
+    {
         class.stop_gained = false;
         class.stop_retained = false;
         class.stop_lost = true;
-    } else if vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant) {
+        return;
+    }
+
+    let stop_retained_uses_peptides = class
+        .affected_alt_peptide
+        .as_deref()
+        .is_some_and(|peptide| !peptide.is_empty() && !peptide.contains('X'));
+    if !stop_retained_uses_peptides
+        && vep116_stop_retained_without_alt_peptide(tx, tx_exons, tx_translation, variant)
+    {
+        class.stop_gained = false;
         class.stop_retained = true;
     }
 }
@@ -4438,6 +4461,16 @@ fn vep116_ref_eq_alt_sequence_final_stop(
     if ref_peptide == "X" && alt_peptide == "X" {
         return false;
     }
+    // VEP's early TranscriptVariationAllele clause: an insertion mapped
+    // beyond the cached reference translation retains the terminal stop when
+    // the alternate local peptide begins with one. The Rust index is 0-based,
+    // so `>= len` corresponds to Perl's 1-based `tl_start > length(ref_seq)`.
+    if translation_start >= ref_translation.len() {
+        return alt_peptide.starts_with('*');
+    }
+    let same_stop_index = ref_peptide
+        .find('*')
+        .is_some_and(|stop_index| alt_peptide.find('*') == Some(stop_index));
     let mut mutated = ref_translation.to_vec();
     let ref_len = ref_peptide.chars().count();
     let replace_end = translation_start.saturating_add(ref_len).min(mutated.len());
@@ -4447,10 +4480,30 @@ fn vep116_ref_eq_alt_sequence_final_stop(
         alt_peptide.chars().collect()
     };
     mutated.splice(translation_start..replace_end, replacement);
-    mutated.starts_with(ref_translation)
-        && mutated
-            .get(ref_translation.len())
-            .is_some_and(|residue| *residue == '*')
+    same_stop_index
+        || (mutated.starts_with(ref_translation)
+            && mutated
+                .get(ref_translation.len())
+                .is_some_and(|residue| *residue == '*'))
+}
+
+fn vep116_ref_eq_alt_sequence_for_class(
+    class: &CodingClassification,
+    ref_translation: &[char],
+    translation_start: usize,
+) -> bool {
+    match (
+        class.affected_ref_peptide.as_deref(),
+        class.affected_alt_peptide.as_deref(),
+    ) {
+        (Some(ref_peptide), Some(alt_peptide)) => vep116_ref_eq_alt_sequence_final_stop(
+            ref_translation,
+            translation_start,
+            ref_peptide,
+            alt_peptide,
+        ),
+        _ => false,
+    }
 }
 
 /// Traceability:
@@ -6723,7 +6776,14 @@ fn classify_coding_change_with_semantics(
         }
     }
 
-    apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
+    let vep116_ref_eq_alt_sequence =
+        vep116_ref_eq_alt_sequence_for_class(&class, &old_aas, local_first_codon);
+    apply_vep116_stop_predicate_flags(
+        &mut class,
+        semantics,
+        partial_terminal_codon,
+        vep116_ref_eq_alt_sequence,
+    );
     apply_vep116_nucleotide_stop_fallbacks(
         &mut class,
         semantics,
@@ -6974,7 +7034,12 @@ fn classify_coding_change_with_semantics(
             class.stop_lost = true;
         }
     }
-    apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
+    apply_vep116_stop_predicate_flags(
+        &mut class,
+        semantics,
+        partial_terminal_codon,
+        vep116_ref_eq_alt_sequence,
+    );
     apply_vep116_nucleotide_stop_fallbacks(
         &mut class,
         semantics,
@@ -7372,19 +7437,6 @@ fn classify_insertion_with_semantics(
         if !class.stop_retained && ref_aa == '*' && local_aas.first() == Some(&'*') {
             class.stop_retained = true;
         }
-        if !class.stop_retained && semantics.vep116_stop_predicates() {
-            if let (Some(ref_peptide), Some(alt_peptide)) = (
-                class.affected_ref_peptide.as_deref(),
-                class.affected_alt_peptide.as_deref(),
-            ) {
-                class.stop_retained = vep116_ref_eq_alt_sequence_final_stop(
-                    &old_aas,
-                    codon_at,
-                    ref_peptide,
-                    alt_peptide,
-                );
-            }
-        }
     }
 
     // stop_lost: VEP's stop_lost uses the same local peptide window and can
@@ -7416,7 +7468,14 @@ fn classify_insertion_with_semantics(
             class.stop_gained = true;
         }
     }
-    apply_vep116_stop_predicate_flags(&mut class, semantics, partial_terminal_codon);
+    let vep116_ref_eq_alt_sequence =
+        vep116_ref_eq_alt_sequence_for_class(&class, &old_aas, codon_at);
+    apply_vep116_stop_predicate_flags(
+        &mut class,
+        semantics,
+        partial_terminal_codon,
+        vep116_ref_eq_alt_sequence,
+    );
     apply_vep116_nucleotide_stop_fallbacks(
         &mut class,
         semantics,
@@ -9937,6 +9996,7 @@ mod tests {
         let base = CodingClassification {
             stop_gained: true,
             stop_lost: true,
+            affected_ref_peptide: Some("*".to_string()),
             affected_alt_peptide: Some("Y".to_string()),
             ..Default::default()
         };
@@ -9946,10 +10006,12 @@ mod tests {
             &mut v115,
             crate::vep_semantics::VepSemantics::V115,
             false,
+            false,
         );
         apply_vep116_stop_predicate_flags(
             &mut v116,
             crate::vep_semantics::VepSemantics::V116,
+            false,
             false,
         );
         assert!(v115.stop_gained && v115.stop_lost);
@@ -9957,9 +10019,30 @@ mod tests {
     }
 
     #[test]
+    fn vep116_stop_predicates_do_not_inherit_contradictory_v115_flags() {
+        let mut class = CodingClassification {
+            stop_gained: true,
+            stop_retained: true,
+            affected_ref_peptide: Some("Q".to_string()),
+            affected_alt_peptide: Some("R".to_string()),
+            ..Default::default()
+        };
+        apply_vep116_stop_predicate_flags(
+            &mut class,
+            crate::vep_semantics::VepSemantics::V116,
+            false,
+            false,
+        );
+        assert!(!class.stop_gained);
+        assert!(!class.stop_lost);
+        assert!(!class.stop_retained);
+    }
+
+    #[test]
     fn vep116_hunk4_rejects_stop_lost_for_partial_terminal_codon() {
         let base = CodingClassification {
             stop_lost: true,
+            affected_ref_peptide: Some("*".to_string()),
             affected_alt_peptide: Some("Y".to_string()),
             ..Default::default()
         };
@@ -9969,11 +10052,13 @@ mod tests {
             &mut v115,
             crate::vep_semantics::VepSemantics::V115,
             true,
+            false,
         );
         apply_vep116_stop_predicate_flags(
             &mut v116,
             crate::vep_semantics::VepSemantics::V116,
             true,
+            false,
         );
         assert!(v115.stop_lost);
         assert!(!v116.stop_lost);
@@ -9984,6 +10069,7 @@ mod tests {
         let base = CodingClassification {
             stop_lost: true,
             stop_retained: true,
+            affected_ref_peptide: Some("*".to_string()),
             affected_alt_peptide: Some("YX".to_string()),
             ..Default::default()
         };
@@ -9993,10 +10079,12 @@ mod tests {
             &mut v115,
             crate::vep_semantics::VepSemantics::V115,
             false,
+            false,
         );
         apply_vep116_stop_predicate_flags(
             &mut v116,
             crate::vep_semantics::VepSemantics::V116,
+            false,
             false,
         );
         assert!(v115.stop_lost && v115.stop_retained);
@@ -10073,7 +10161,7 @@ mod tests {
     }
 
     #[test]
-    fn vep116_hunk8_removes_first_peptide_clause_and_keeps_anchored_final_stop() {
+    fn vep116_hunk8_uses_all_release_116_sequence_equivalence_clauses() {
         let old_first_peptide_clause = "A" == &"A*"[..1] && "A*".contains('*');
         assert!(old_first_peptide_clause);
         assert!(!vep116_ref_eq_alt_sequence_final_stop(
@@ -10084,9 +10172,21 @@ mod tests {
         ));
         assert!(vep116_ref_eq_alt_sequence_final_stop(
             &['A', 'B'],
-            2,
+            3,
             "",
             "*",
+        ));
+        assert!(!vep116_ref_eq_alt_sequence_final_stop(
+            &['A', 'B'],
+            3,
+            "",
+            "Q",
+        ));
+        assert!(vep116_ref_eq_alt_sequence_final_stop(
+            &['A', 'Q', '*'],
+            1,
+            "Q*",
+            "R*",
         ));
     }
 

--- a/datafusion/bio-function-vep/src/transcript_consequence.rs
+++ b/datafusion/bio-function-vep/src/transcript_consequence.rs
@@ -22098,4 +22098,36 @@ mod tests {
             .collect();
         assert!(motif_terms.contains(&&SoTerm::TfbsAblation));
     }
+
+    /// Caches without MotifFeature data must be unaffected. Release 115 ships
+    /// no motif features at all (its `_reg.gz` bins contain RegulatoryFeature
+    /// only), so per-motif emission must stay inert there rather than change
+    /// existing output.
+    #[test]
+    fn emits_no_motif_consequence_when_cache_has_no_motifs() {
+        let engine = TranscriptConsequenceEngine::default();
+        let regulatory = vec![regulatory("ENSR001", "22", 100, 200)];
+
+        let assignments = engine.evaluate_variant_with_context(
+            &var("22", 155, 155, "A", "G"),
+            &[],
+            &[],
+            &[],
+            &regulatory,
+            &[],
+            &[],
+            &[],
+        );
+
+        assert!(
+            !assignments
+                .iter()
+                .any(|a| a.feature_type == FeatureType::MotifFeature)
+        );
+        assert!(
+            assignments
+                .iter()
+                .any(|a| a.feature_type == FeatureType::RegulatoryFeature)
+        );
+    }
 }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -400,6 +400,8 @@ pub struct AnnotateVcfConfig {
     pub pick_order: Option<String>,
     /// Use interval-overlap fallback for shifted indels.
     pub extended_probes: bool,
+    /// Optional assertion against embedded per-shard cache version metadata.
+    pub expected_cache_version: Option<String>,
     /// Path to indexed reference FASTA (required for `everything` / `hgvs`).
     pub reference_fasta_path: Option<String>,
     /// Enable HGVS notation.
@@ -466,6 +468,7 @@ impl Default for AnnotateVcfConfig {
             flag_pick_allele_gene: false,
             pick_order: None,
             extended_probes: false,
+            expected_cache_version: None,
             reference_fasta_path: None,
             hgvs: false,
             hgvsc: false,
@@ -535,6 +538,12 @@ impl AnnotateVcfConfig {
         }
         if self.extended_probes {
             opts.insert("extended_probes".into(), serde_json::Value::Bool(true));
+        }
+        if let Some(ref expected_cache_version) = self.expected_cache_version {
+            opts.insert(
+                "expected_cache_version".into(),
+                serde_json::Value::String(expected_cache_version.clone()),
+            );
         }
         if let Some(ref fasta) = self.reference_fasta_path {
             opts.insert(

--- a/datafusion/bio-function-vep/src/vep_semantics.rs
+++ b/datafusion/bio-function-vep/src/vep_semantics.rs
@@ -1,0 +1,132 @@
+//! Compiled Ensembl VEP/cache compatibility contract.
+//!
+//! This is the single canonical support matrix used by the annotation engine
+//! and exposed read-only to language bindings. Cache directory names are never
+//! consulted when resolving semantics.
+
+use datafusion::common::{DataFusionError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VepSemantics {
+    V115,
+    V116,
+}
+
+impl VepSemantics {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::V115 => "115",
+            Self::V116 => "116",
+        }
+    }
+
+    /// VEP 116 permits HGVS for variants that partially overlap a transcript.
+    pub const fn partial_overlap_hgvs(self) -> bool {
+        matches!(self, Self::V116)
+    }
+
+    /// VEP 116 changed the coordinated stop/inframe/frameshift predicates.
+    pub const fn vep116_stop_predicates(self) -> bool {
+        matches!(self, Self::V116)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SupportedVepTarget {
+    pub cache_version: &'static str,
+    pub vep_codebase_version: &'static str,
+    pub api_version: &'static str,
+    pub ensembl_core_revision: &'static str,
+    pub ensembl_variation_revision: &'static str,
+    pub semantics: VepSemantics,
+}
+
+pub const SUPPORTED_VEP_TARGETS: &[SupportedVepTarget] = &[
+    SupportedVepTarget {
+        cache_version: "115",
+        vep_codebase_version: "115.2",
+        api_version: "115",
+        ensembl_core_revision: "266b84d",
+        ensembl_variation_revision: "b7c2637",
+        semantics: VepSemantics::V115,
+    },
+    SupportedVepTarget {
+        cache_version: "116",
+        vep_codebase_version: "116.0",
+        api_version: "116",
+        ensembl_core_revision: "c0cf13d",
+        ensembl_variation_revision: "2fb834b",
+        semantics: VepSemantics::V116,
+    },
+];
+
+pub fn supported_vep_targets() -> &'static [SupportedVepTarget] {
+    SUPPORTED_VEP_TARGETS
+}
+
+pub fn target_for_cache_version(cache_version: &str) -> Result<&'static SupportedVepTarget> {
+    if cache_version.is_empty() || !cache_version.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(DataFusionError::Execution(format!(
+            "invalid VEP cache version '{cache_version}': expected a decimal Ensembl release"
+        )));
+    }
+    SUPPORTED_VEP_TARGETS
+        .iter()
+        .find(|target| target.cache_version == cache_version)
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "unsupported VEP cache version '{cache_version}'; supported cache versions: {}",
+                SUPPORTED_VEP_TARGETS
+                    .iter()
+                    .map(|target| target.cache_version)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn support_matrix_is_exact_and_unique() {
+        assert_eq!(SUPPORTED_VEP_TARGETS.len(), 2);
+        assert_eq!(
+            SUPPORTED_VEP_TARGETS
+                .iter()
+                .map(|target| (
+                    target.cache_version,
+                    target.vep_codebase_version,
+                    target.api_version,
+                    target.ensembl_core_revision,
+                    target.ensembl_variation_revision,
+                    target.semantics.as_str(),
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("115", "115.2", "115", "266b84d", "b7c2637", "115"),
+                ("116", "116.0", "116", "c0cf13d", "2fb834b", "116"),
+            ]
+        );
+    }
+
+    #[test]
+    fn cache_version_resolution_rejects_malformed_and_unsupported_values() {
+        assert_eq!(
+            target_for_cache_version("115").unwrap().semantics,
+            VepSemantics::V115
+        );
+        assert!(target_for_cache_version("115.2").is_err());
+        assert!(target_for_cache_version("v116").is_err());
+        assert!(target_for_cache_version("117").is_err());
+    }
+
+    #[test]
+    fn only_two_semantic_policy_gates_exist() {
+        assert!(!VepSemantics::V115.partial_overlap_hgvs());
+        assert!(!VepSemantics::V115.vep116_stop_predicates());
+        assert!(VepSemantics::V116.partial_overlap_hgvs());
+        assert!(VepSemantics::V116.vep116_stop_predicates());
+    }
+}


### PR DESCRIPTION
Fixes #201.

## Summary

This PR expands the VEP engine from the original per-motif fix into the exact runtime contract used by vepyr 0.2.0:

- define the supported pairs cache 115 → VEP 115.2 and cache 116 → VEP 116.0, including API/core/variation revisions and release-scoped semantics;
- resolve cache identity strictly from Parquet metadata and validate only the requested contig's participating manifest shards;
- reject missing, malformed, unsupported, mixed-release/source, and expected/detected conflicts before annotation;
- preserve cache identity through all full and low-level converted-cache builder paths;
- return projected empty VCF input without opening a cache shard, while retaining the missing-shard error for non-empty input;
- align stop-codon, partial-overlap HGVS, failed-BAM-edit, ClinVar, motif, and chr11/16/20 boundary behavior with the exact VEP 115.2/116.0 source;
- preserve VEP 116's exact reverse-strand MNV motif scoring behavior with an explicit regression test.

## Immutable released dependency graph

| Repository | Exact revision | State |
|---|---|---|
| datafusion-bio-formats | tag `v1.9.0` → `6564554619019535ffd3ace5aa650797a31eb8ed` | PR #224 merged as `379894cad6d676cbc163402a8b88f0dff11455e2`; release published |
| this PR | `b4996420cea2dc2d2b33b35ef75dcdafc553b376` | #203 head |
| vepyr qualification build | `cb964bb16d2171187eaf066d3fbc01012bc49b2a` | native release build |
| vepyr published evidence | `383344f` | biodatageeks/vepyr#41 |

The manifest and lockfile consume the immutable bio-formats release tag above; no local path patch is part of the qualified graph.

## Exact upstream alignment

| Cache | VEP image/codebase | Ensembl core | ensembl-variation |
|---|---|---|---|
| 115 | `ensemblorg/ensembl-vep:release_115.2` | `266b84d` | `b7c2637` |
| 116 | `ensemblorg/ensembl-vep:release_116.0` | `c0cf13d` | `2fb834b` |

The VEP 116 stop/HGVSp residuals and reverse-strand motif MNV behavior were checked against the exact release-116 source, not inferred from `main`.

## Verification

- complete suite: **906 executed tests passed, 1 ignored**
- `cargo fmt --all --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- PR `build-test`: pass
- PR `claude-review`: pass
- Claude: no remaining blocking issues
- Codex: no major issues
- unresolved review threads: zero
- downstream vepyr Python/integration: **1,032 passed, 2 skipped**
- downstream vepyr Rust: **4 passed**

## Downstream parity

The released dependency graph reran merged chr1–22 for both supported releases. Each compares **4,096,123** variants and all 86 fields; every structural, ordering, one-sided, field, field-order, and uncapped-ledger counter is zero:

- [VEP/cache 115 clean strict-gate summary](https://github.com/biodatageeks/vepyr/blob/383344f/e2e-testing/reports/fast_chr1_chr22_merged_115_summary_20260730_1206.md)
- [VEP/cache 116 clean strict-gate summary](https://github.com/biodatageeks/vepyr/blob/383344f/e2e-testing/reports/fast_chr1_chr22_merged_116_summary_20260730_1217.md)

The earlier single-binary six-profile qualification also remains exact for 115/116 × merged/Ensembl/RefSeq.

## Cache evidence

All six rebuilt caches passed complete footer/schema/release/source/row verification. Release 116 contains `clin_sig_ref_allele`; release 115 deliberately uses the absent-field path. All 999,828 release-116 motif rows have non-empty binding-matrix and transcription-factor values. All six published Google Drive directories pass a fresh one-way size check with zero differences.
