### PR TITLE
fix(pileup): emit half-open block ends when zero_based (#204)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ async fn main() -> datafusion::error::Result<()> {
     let ctx = SessionContext::new();
     register_pileup_functions(&ctx);
 
-    // 1-based coordinates (default, matches polars-bio)
+    // 1-based closed coordinates (default, matches polars-bio)
     let df = ctx.sql("SELECT * FROM depth('path/to/alignments.bam')").await?;
     df.show().await?;
 
-    // 0-based coordinates (explicit)
+    // 0-based half-open coordinates (explicit)
     let df = ctx.sql("SELECT * FROM depth('path/to/alignments.bam', true)").await?;
     df.show().await?;
 
@@ -176,7 +176,7 @@ SELECT * FROM depth('file.bam', false, true)   -- 1-based, per-base output
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
 | `path` | string | (required) | Path to BAM file |
-| `zero_based` | bool | `false` | Use 0-based coordinates |
+| `zero_based` | bool | `false` | Use 0-based half-open coordinates (BED-style). Default is 1-based closed |
 | `per_base` | bool | `false` | Emit one row per position instead of RLE blocks |
 
 #### Block output schema (default)
@@ -184,9 +184,20 @@ SELECT * FROM depth('file.bam', false, true)   -- 1-based, per-base output
 | Column | Type | Description |
 |--------|------|-------------|
 | `contig` | Utf8 | Chromosome/contig name |
-| `pos_start` | Int32 | Block start position (inclusive) |
-| `pos_end` | Int32 | Block end position (inclusive) |
+| `pos_start` | Int32 | Block start position (always inclusive) |
+| `pos_end` | Int32 | Block end position — **exclusive** when `zero_based=true`, inclusive when `zero_based=false` |
 | `coverage` | Int16 | Read depth in this block |
+
+The end convention follows the coordinate system, so a block covers the same
+bases either way:
+
+| `zero_based` | Interval | Bases covered | Example (a 10bp read at the start of a contig) |
+|--------------|----------|---------------|------------------------------------------------|
+| `true` | 0-based half-open `[start, end)` | `pos_end - pos_start` | `0, 10` — directly comparable to BED / `mosdepth` |
+| `false` | 1-based closed `[start, end]` | `pos_end - pos_start + 1` | `1, 10` — directly comparable to `samtools depth` |
+
+Expanding a block to per-position rows therefore runs to `pos_end` when
+`zero_based=true`, and to `pos_end + 1` when `zero_based=false`.
 
 #### Per-base output schema (`per_base=true`)
 
@@ -454,7 +465,7 @@ When `binary_cigar=true`, the CIGAR column has `DataType::Binary` (packed LE u32
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `zero_based` | `false` | 1-based coordinates (matches polars-bio default) |
+| `zero_based` | `false` | 1-based closed coordinates (matches polars-bio default); `true` gives 0-based half-open |
 | `per_base` | `false` | RLE block output; set `true` for one-row-per-position |
 | `binary_cigar` | `true` | Use binary CIGAR (zero-copy, no string parsing) |
 | `dense_mode` | `Auto` (dense) | Dense `i32[]` array accumulation with streaming emission |
@@ -465,7 +476,7 @@ To override specific fields:
 
 ```rust
 let config = PileupConfig {
-    zero_based: true,                       // 0-based coordinates
+    zero_based: true,                       // 0-based half-open coordinates
     per_base: true,                         // one row per position (requires dense mode)
     binary_cigar: false,                    // force string CIGAR (e.g., for debugging)
     dense_mode: DenseMode::Disable,         // force sparse BTreeMap accumulation

--- a/datafusion/bio-function-pileup/examples/dump_coverage.rs
+++ b/datafusion/bio-function-pileup/examples/dump_coverage.rs
@@ -104,12 +104,14 @@ async fn main() {
                 .unwrap();
 
             for i in 0..batch.num_rows() {
-                // Convert from 0-based closed to 0-based half-open (BED format)
+                // Printed verbatim: `--zero-based` output is already 0-based
+                // half-open (directly comparable to mosdepth's BED), and the
+                // default is 1-based closed (comparable to `samtools depth`).
                 println!(
                     "{}\t{}\t{}\t{}",
                     contigs.value(i),
                     starts.value(i),
-                    ends.value(i) + 1,
+                    ends.value(i),
                     covs.value(i)
                 );
             }

--- a/datafusion/bio-function-pileup/src/coverage.rs
+++ b/datafusion/bio-function-pileup/src/coverage.rs
@@ -115,6 +115,10 @@ pub fn all_events_to_record_batch(
 /// The key optimization: most positions have `delta == 0` and are skipped
 /// (~99.9% of positions for typical WES/WGS data).
 /// Zero-coverage gaps are NOT emitted.
+///
+/// `zero_based` selects the interval convention for `pos_end`, exactly as in
+/// [`events_to_coverage_blocks`]: half-open (exclusive) when `true`, closed
+/// (inclusive) when `false`.
 pub fn dense_depth_to_coverage_blocks(
     contig: &str,
     depth: &[i32],
@@ -154,7 +158,8 @@ pub fn dense_depth_to_coverage_blocks(
 
 /// Convert a dense depth slice to coverage blocks with a position offset.
 ///
-/// Same RLE logic as `dense_depth_to_coverage_blocks` but positions are
+/// Same RLE logic as [`dense_depth_to_coverage_blocks`] — including the
+/// `zero_based` interval convention for `pos_end` — but positions are
 /// shifted by `start_offset`, allowing callers to pass a sub-slice of
 /// the full depth array (the touched region) instead of the entire contig.
 pub fn dense_depth_to_coverage_blocks_bounded(

--- a/datafusion/bio-function-pileup/src/coverage.rs
+++ b/datafusion/bio-function-pileup/src/coverage.rs
@@ -39,8 +39,9 @@ fn block_end(next_pos: usize, zero_based: bool) -> i32 {
 /// Zero-coverage gaps are NOT emitted.
 ///
 /// `zero_based` selects the interval convention for `pos_end`: half-open
-/// (exclusive) when `true`, closed (inclusive) when `false`. See
-/// [`block_end`].
+/// (exclusive) when `true`, closed (inclusive) when `false`. Either way a
+/// block covers `pos_end - pos_start` (0-based) or `pos_end - pos_start + 1`
+/// (1-based) bases.
 pub fn events_to_coverage_blocks(
     contig: &str,
     events: &mut [(u32, i32)],

--- a/datafusion/bio-function-pileup/src/coverage.rs
+++ b/datafusion/bio-function-pileup/src/coverage.rs
@@ -16,13 +16,36 @@ pub struct CoverageBlock {
     pub coverage: i16,
 }
 
+/// Convert the position at which coverage changed into a block end.
+///
+/// A block runs up to but not including `next_pos`. 0-based output is
+/// half-open, so `next_pos` is the end as-is; 1-based output is closed, so the
+/// end is the last covered position. Either way the block spans
+/// `next_pos - block_start` bases.
+#[inline]
+fn block_end(next_pos: usize, zero_based: bool) -> i32 {
+    if zero_based {
+        next_pos as i32
+    } else {
+        (next_pos - 1) as i32
+    }
+}
+
 /// Convert per-contig events (Vec) to coverage blocks.
 ///
 /// Sorts the events in-place, merges same-position deltas, then walks with
 /// cumulative sum. For coordinate-sorted BAM input the Vec is nearly sorted,
 /// so `sort_unstable` (timsort) runs in ~O(n).
 /// Zero-coverage gaps are NOT emitted.
-pub fn events_to_coverage_blocks(contig: &str, events: &mut [(u32, i32)]) -> Vec<CoverageBlock> {
+///
+/// `zero_based` selects the interval convention for `pos_end`: half-open
+/// (exclusive) when `true`, closed (inclusive) when `false`. See
+/// [`block_end`].
+pub fn events_to_coverage_blocks(
+    contig: &str,
+    events: &mut [(u32, i32)],
+    zero_based: bool,
+) -> Vec<CoverageBlock> {
     if events.is_empty() {
         return Vec::new();
     }
@@ -48,7 +71,7 @@ pub fn events_to_coverage_blocks(contig: &str, events: &mut [(u32, i32)]) -> Vec
             blocks.push(CoverageBlock {
                 contig: Arc::clone(&contig_arc),
                 pos_start: block_start as i32,
-                pos_end: (pos - 1) as i32,
+                pos_end: block_end(pos as usize, zero_based),
                 coverage: prev_cov as i16,
             });
             if cov != 0 {
@@ -68,6 +91,7 @@ pub fn events_to_coverage_blocks(contig: &str, events: &mut [(u32, i32)]) -> Vec
 pub fn all_events_to_record_batch(
     contig_events: &mut HashMap<String, ContigEvents>,
     schema: &SchemaRef,
+    zero_based: bool,
 ) -> datafusion::common::Result<RecordBatch> {
     let mut all_blocks = Vec::new();
 
@@ -77,7 +101,7 @@ pub fn all_events_to_record_batch(
 
     for contig in &contigs {
         let events = &mut contig_events.get_mut(contig).unwrap().events;
-        let blocks = events_to_coverage_blocks(contig, events);
+        let blocks = events_to_coverage_blocks(contig, events, zero_based);
         all_blocks.extend(blocks);
     }
 
@@ -90,7 +114,11 @@ pub fn all_events_to_record_batch(
 /// The key optimization: most positions have `delta == 0` and are skipped
 /// (~99.9% of positions for typical WES/WGS data).
 /// Zero-coverage gaps are NOT emitted.
-pub fn dense_depth_to_coverage_blocks(contig: &str, depth: &[i32]) -> Vec<CoverageBlock> {
+pub fn dense_depth_to_coverage_blocks(
+    contig: &str,
+    depth: &[i32],
+    zero_based: bool,
+) -> Vec<CoverageBlock> {
     let contig_arc: Arc<str> = Arc::from(contig);
     let mut blocks = Vec::new();
     let mut cov: i32 = 0;
@@ -107,7 +135,7 @@ pub fn dense_depth_to_coverage_blocks(contig: &str, depth: &[i32]) -> Vec<Covera
             blocks.push(CoverageBlock {
                 contig: Arc::clone(&contig_arc),
                 pos_start: block_start as i32,
-                pos_end: (pos - 1) as i32,
+                pos_end: block_end(pos, zero_based),
                 coverage: prev_cov as i16,
             });
             if cov != 0 {
@@ -132,6 +160,7 @@ pub fn dense_depth_to_coverage_blocks_bounded(
     contig: &str,
     depth_slice: &[i32],
     start_offset: usize,
+    zero_based: bool,
 ) -> Vec<CoverageBlock> {
     let contig_arc: Arc<str> = Arc::from(contig);
     let mut blocks = Vec::new();
@@ -150,7 +179,7 @@ pub fn dense_depth_to_coverage_blocks_bounded(
             blocks.push(CoverageBlock {
                 contig: Arc::clone(&contig_arc),
                 pos_start: block_start as i32,
-                pos_end: (pos - 1) as i32,
+                pos_end: block_end(pos, zero_based),
                 coverage: prev_cov as i16,
             });
             if cov != 0 {
@@ -174,11 +203,13 @@ pub fn dense_depth_to_record_batch(
     contig: &str,
     depth: &DenseContigDepth,
     schema: &SchemaRef,
+    zero_based: bool,
 ) -> datafusion::common::Result<RecordBatch> {
     let blocks = dense_depth_to_coverage_blocks_bounded(
         contig,
         depth.touched_range(),
         depth.touched_start(),
+        zero_based,
     );
     coverage_blocks_to_record_batch(&blocks, schema)
 }
@@ -189,11 +220,13 @@ pub fn dense_depth_to_record_batches(
     depth: &DenseContigDepth,
     schema: &SchemaRef,
     batch_size: usize,
+    zero_based: bool,
 ) -> datafusion::common::Result<Vec<RecordBatch>> {
     let blocks = dense_depth_to_coverage_blocks_bounded(
         contig,
         depth.touched_range(),
         depth.touched_start(),
+        zero_based,
     );
     coverage_blocks_to_chunked_batches(&blocks, schema, batch_size)
 }
@@ -203,6 +236,7 @@ pub fn all_events_to_record_batches(
     contig_events: &mut HashMap<String, ContigEvents>,
     schema: &SchemaRef,
     batch_size: usize,
+    zero_based: bool,
 ) -> datafusion::common::Result<Vec<RecordBatch>> {
     let mut all_blocks = Vec::new();
 
@@ -211,7 +245,7 @@ pub fn all_events_to_record_batches(
 
     for contig in &contigs {
         let events = &mut contig_events.get_mut(contig).unwrap().events;
-        let blocks = events_to_coverage_blocks(contig, events);
+        let blocks = events_to_coverage_blocks(contig, events, zero_based);
         all_blocks.extend(blocks);
     }
 
@@ -373,7 +407,7 @@ mod tests {
     fn test_single_read() {
         let mut events = vec![(100u32, 1i32), (110, -1)];
 
-        let blocks = events_to_coverage_blocks("chr1", &mut events);
+        let blocks = events_to_coverage_blocks("chr1", &mut events, false);
         assert_eq!(
             blocks,
             vec![CoverageBlock {
@@ -390,7 +424,7 @@ mod tests {
         // Read1: [0, 10), Read2: [5, 15)
         let mut events = vec![(0u32, 1i32), (10, -1), (5, 1), (15, -1)];
 
-        let blocks = events_to_coverage_blocks("chr1", &mut events);
+        let blocks = events_to_coverage_blocks("chr1", &mut events, false);
         assert_eq!(
             blocks,
             vec![
@@ -421,7 +455,7 @@ mod tests {
         // Read1: [0, 5), Read2: [10, 15)
         let mut events = vec![(0u32, 1i32), (5, -1), (10, 1), (15, -1)];
 
-        let blocks = events_to_coverage_blocks("chr1", &mut events);
+        let blocks = events_to_coverage_blocks("chr1", &mut events, false);
         assert_eq!(
             blocks,
             vec![
@@ -447,7 +481,7 @@ mod tests {
         // Events: (0, +1), (5, -1), (8, +1), (13, -1)
         let mut events = vec![(0u32, 1i32), (5, -1), (8, 1), (13, -1)];
 
-        let blocks = events_to_coverage_blocks("chr1", &mut events);
+        let blocks = events_to_coverage_blocks("chr1", &mut events, false);
         assert_eq!(
             blocks,
             vec![
@@ -470,7 +504,7 @@ mod tests {
     #[test]
     fn test_empty_input() {
         let mut events = Vec::new();
-        let blocks = events_to_coverage_blocks("chr1", &mut events);
+        let blocks = events_to_coverage_blocks("chr1", &mut events, false);
         assert!(blocks.is_empty());
     }
 
@@ -533,7 +567,7 @@ mod tests {
         depth[100] = 1;
         depth[110] = -1;
 
-        let blocks = dense_depth_to_coverage_blocks("chr1", &depth);
+        let blocks = dense_depth_to_coverage_blocks("chr1", &depth, false);
         assert_eq!(
             blocks,
             vec![CoverageBlock {
@@ -554,7 +588,7 @@ mod tests {
         depth[10] += -1;
         depth[15] = -1;
 
-        let blocks = dense_depth_to_coverage_blocks("chr1", &depth);
+        let blocks = dense_depth_to_coverage_blocks("chr1", &depth, false);
         assert_eq!(
             blocks,
             vec![
@@ -589,7 +623,7 @@ mod tests {
         depth[10] = 1;
         depth[15] = -1;
 
-        let blocks = dense_depth_to_coverage_blocks("chr1", &depth);
+        let blocks = dense_depth_to_coverage_blocks("chr1", &depth, false);
         assert_eq!(
             blocks,
             vec![
@@ -612,7 +646,7 @@ mod tests {
     #[test]
     fn test_dense_empty() {
         let depth = vec![0i32; 100];
-        let blocks = dense_depth_to_coverage_blocks("chr1", &depth);
+        let blocks = dense_depth_to_coverage_blocks("chr1", &depth, false);
         assert!(blocks.is_empty());
     }
 
@@ -620,14 +654,14 @@ mod tests {
     fn test_dense_matches_sparse() {
         // Verify dense and sparse produce identical results
         let mut events = vec![(0u32, 1i32), (5, 1), (10, -1), (15, -1)];
-        let sparse_blocks = events_to_coverage_blocks("chr1", &mut events);
+        let sparse_blocks = events_to_coverage_blocks("chr1", &mut events, false);
 
         let mut depth = vec![0i32; 20];
         depth[0] = 1;
         depth[5] = 1;
         depth[10] = -1;
         depth[15] = -1;
-        let dense_blocks = dense_depth_to_coverage_blocks("chr1", &depth);
+        let dense_blocks = dense_depth_to_coverage_blocks("chr1", &depth, false);
 
         assert_eq!(sparse_blocks, dense_blocks);
     }
@@ -771,5 +805,247 @@ mod tests {
         assert_eq!(batches.len(), 4);
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 10);
+    }
+
+    // --- Tests for 0-based half-open block ends (issue #204) ---
+
+    #[test]
+    fn test_zero_based_single_read_end_is_exclusive() {
+        // One 10bp read at 0-based position 100 covers [100, 110)
+        let mut events = vec![(100u32, 1i32), (110, -1)];
+
+        let blocks = events_to_coverage_blocks("chr1", &mut events, true);
+        assert_eq!(
+            blocks,
+            vec![CoverageBlock {
+                contig: Arc::from("chr1"),
+                pos_start: 100,
+                pos_end: 110,
+                coverage: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_zero_based_adjacent_blocks_share_a_boundary() {
+        // Read1: [0, 10), Read2: [5, 15)
+        let mut events = vec![(0u32, 1i32), (10, -1), (5, 1), (15, -1)];
+
+        let blocks = events_to_coverage_blocks("chr1", &mut events, true);
+        assert_eq!(
+            blocks,
+            vec![
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 0,
+                    pos_end: 5,
+                    coverage: 1,
+                },
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 5,
+                    pos_end: 10,
+                    coverage: 2,
+                },
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 10,
+                    pos_end: 15,
+                    coverage: 1,
+                },
+            ]
+        );
+
+        // The defining property of half-open intervals: with no coverage gap
+        // between them, one block's end is the next block's start.
+        assert_eq!(blocks[0].pos_end, blocks[1].pos_start);
+        assert_eq!(blocks[1].pos_end, blocks[2].pos_start);
+    }
+
+    #[test]
+    fn test_zero_based_gap_between_reads_end_is_exclusive() {
+        // Read1: [0, 5), Read2: [10, 15)
+        let mut events = vec![(0u32, 1i32), (5, -1), (10, 1), (15, -1)];
+
+        let blocks = events_to_coverage_blocks("chr1", &mut events, true);
+        assert_eq!(
+            blocks,
+            vec![
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 0,
+                    pos_end: 5,
+                    coverage: 1,
+                },
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 10,
+                    pos_end: 15,
+                    coverage: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_zero_based_deletion_gap_end_is_exclusive() {
+        // 5M3D5M at position 0
+        let mut events = vec![(0u32, 1i32), (5, -1), (8, 1), (13, -1)];
+
+        let blocks = events_to_coverage_blocks("chr1", &mut events, true);
+        assert_eq!(
+            blocks,
+            vec![
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 0,
+                    pos_end: 5,
+                    coverage: 1,
+                },
+                CoverageBlock {
+                    contig: Arc::from("chr1"),
+                    pos_start: 8,
+                    pos_end: 13,
+                    coverage: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_zero_based_blocks_cover_the_same_bases_as_one_based() {
+        // The regression guard for issue #204: switching coordinate system must
+        // not change how many bases a block covers. A 1-based closed block spans
+        // `end - start + 1` bases; a 0-based half-open block spans `end - start`.
+        let events = vec![(0u32, 1i32), (5, 1), (10, -1), (15, -1)];
+
+        let closed = events_to_coverage_blocks("chr1", &mut events.clone(), false);
+        let half_open = events_to_coverage_blocks("chr1", &mut events.clone(), true);
+
+        assert_eq!(closed.len(), half_open.len());
+        assert!(!closed.is_empty());
+        for (c, h) in closed.iter().zip(&half_open) {
+            assert_eq!(c.pos_start, h.pos_start);
+            assert_eq!(c.coverage, h.coverage);
+            assert_eq!(
+                c.pos_end - c.pos_start + 1,
+                h.pos_end - h.pos_start,
+                "block width changed between coordinate systems"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dense_zero_based_end_is_exclusive() {
+        // One 10bp read at 0-based position 100 covers [100, 110)
+        let mut depth = vec![0i32; 120];
+        depth[100] = 1;
+        depth[110] = -1;
+
+        let blocks = dense_depth_to_coverage_blocks("chr1", &depth, true);
+        assert_eq!(
+            blocks,
+            vec![CoverageBlock {
+                contig: Arc::from("chr1"),
+                pos_start: 100,
+                pos_end: 110,
+                coverage: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_dense_bounded_zero_based_end_is_exclusive() {
+        // Same read, but scanned as a sub-slice starting at offset 100
+        let mut depth = vec![0i32; 20];
+        depth[0] = 1;
+        depth[10] = -1;
+
+        let blocks = dense_depth_to_coverage_blocks_bounded("chr1", &depth, 100, true);
+        assert_eq!(
+            blocks,
+            vec![CoverageBlock {
+                contig: Arc::from("chr1"),
+                pos_start: 100,
+                pos_end: 110,
+                coverage: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_dense_matches_sparse_zero_based() {
+        // Dense and sparse accumulation must agree in 0-based mode too
+        let mut events = vec![(0u32, 1i32), (5, 1), (10, -1), (15, -1)];
+        let sparse_blocks = events_to_coverage_blocks("chr1", &mut events, true);
+
+        let mut depth = vec![0i32; 20];
+        depth[0] = 1;
+        depth[5] = 1;
+        depth[10] = -1;
+        depth[15] = -1;
+        let dense_blocks = dense_depth_to_coverage_blocks("chr1", &depth, true);
+
+        assert_eq!(sparse_blocks, dense_blocks);
+    }
+
+    #[test]
+    fn test_dense_record_batches_zero_based_end_is_exclusive() {
+        // Through the DenseContigDepth path used by the physical operator
+        let mut contig_depth = DenseContigDepth::new(200);
+        contig_depth.depth[100] = 1;
+        contig_depth.depth[110] = -1;
+        contig_depth.update_bounds(100, 110);
+
+        let schema = crate::schema::coverage_output_schema(true);
+        let batches =
+            dense_depth_to_record_batches("chr1", &contig_depth, &schema, 1024, true).unwrap();
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 1);
+
+        let starts = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let ends = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(starts.value(0), 100);
+        assert_eq!(ends.value(0), 110);
+    }
+
+    #[test]
+    fn test_all_events_record_batches_zero_based_end_is_exclusive() {
+        // Through the sparse merge path used by the physical operator
+        let mut contig_events: HashMap<String, ContigEvents> = HashMap::new();
+        let entry = contig_events.entry("chr1".to_string()).or_default();
+        entry.push(100, 1);
+        entry.push(110, -1);
+
+        let schema = crate::schema::coverage_output_schema(true);
+        let batches =
+            all_events_to_record_batches(&mut contig_events, &schema, 1024, true).unwrap();
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 1);
+
+        let starts = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let ends = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(starts.value(0), 100);
+        assert_eq!(ends.value(0), 110);
     }
 }

--- a/datafusion/bio-function-pileup/src/physical_exec.rs
+++ b/datafusion/bio-function-pileup/src/physical_exec.rs
@@ -49,8 +49,10 @@ pub struct PileupConfig {
     /// The actual format is detected from the schema, but this flag controls what we request
     /// from the upstream `BamTableProvider`.
     pub binary_cigar: bool,
-    /// When `true`, output coordinates are 0-based (start inclusive, end inclusive).
-    /// When `false` (default), output coordinates are 1-based.
+    /// When `true`, output coordinates are 0-based half-open: `pos_start` is
+    /// inclusive and `pos_end` is exclusive.
+    /// When `false` (default), output coordinates are 1-based closed: both
+    /// `pos_start` and `pos_end` are inclusive.
     /// This also controls the coordinate system passed to the BAM reader.
     pub zero_based: bool,
     /// When `true`, emit one row per genomic position (like `samtools depth -a`)
@@ -357,7 +359,7 @@ fn merge_results(
     if !dense_results.is_empty() {
         merge_dense_results(dense_results, schema, batch_size, config)
     } else if !sparse_results.is_empty() {
-        merge_sparse_results(sparse_results, schema, batch_size)
+        merge_sparse_results(sparse_results, schema, batch_size, config)
     } else {
         StreamPhase::Done
     }
@@ -416,8 +418,13 @@ fn merge_dense_results(
         let mut pending_batches = VecDeque::new();
         for contig in &contigs {
             if let Some(depth) = merged_depths.get(contig)
-                && let Ok(batches) =
-                    coverage::dense_depth_to_record_batches(contig, depth, schema, batch_size)
+                && let Ok(batches) = coverage::dense_depth_to_record_batches(
+                    contig,
+                    depth,
+                    schema,
+                    batch_size,
+                    config.zero_based,
+                )
             {
                 pending_batches.extend(batches);
             }
@@ -435,6 +442,7 @@ fn merge_sparse_results(
     partitions: Vec<PartitionResult>,
     schema: &SchemaRef,
     batch_size: usize,
+    config: &PileupConfig,
 ) -> StreamPhase {
     let mut merged: HashMap<String, events::ContigEvents> = HashMap::new();
 
@@ -452,7 +460,8 @@ fn merge_sparse_results(
         return StreamPhase::Done;
     }
 
-    match coverage::all_events_to_record_batches(&mut merged, schema, batch_size) {
+    match coverage::all_events_to_record_batches(&mut merged, schema, batch_size, config.zero_based)
+    {
         Ok(batches) => StreamPhase::Emitting {
             pending_batches: VecDeque::from(batches),
             per_base_emitter: None,
@@ -695,8 +704,61 @@ mod tests {
 
         assert_eq!(contigs.value(0), "chr1");
         assert_eq!(starts.value(0), 0);
-        assert_eq!(ends.value(0), 9);
+        // 0-based half-open: a 10M read at 0 covers [0, 10)
+        assert_eq!(ends.value(0), 10);
         assert_eq!(covs.value(0), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_basic_coverage_one_based() {
+        // Same single 10bp read, but the reader hands us 1-based starts.
+        let batch = make_batch(vec![("chr1", 1, 11, 0, "10M", 60)]);
+        let schema = bam_schema();
+        let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+
+        let ctx = SessionContext::new();
+        ctx.register_table("reads", Arc::new(mem_table)).unwrap();
+
+        let df = ctx.table("reads").await.unwrap();
+        let plan = df.create_physical_plan().await.unwrap();
+
+        let pileup = PileupExec::new(
+            plan,
+            PileupConfig {
+                zero_based: false,
+                ..PileupConfig::default()
+            },
+        );
+        let task_ctx = ctx.task_ctx();
+        let stream = pileup.execute(0, task_ctx).unwrap();
+        let batches: Vec<RecordBatch> = stream
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 1);
+
+        let starts = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let ends = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+
+        // 1-based closed: a 10M read at 1 covers [1, 10]
+        assert_eq!(starts.value(0), 1);
+        assert_eq!(ends.value(0), 10);
+
+        // Same base count as the 0-based half-open case in test_basic_coverage
+        assert_eq!(ends.value(0) - starts.value(0) + 1, 10);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -833,7 +895,7 @@ mod tests {
     async fn test_multi_partition_merge_overlapping() {
         // Partition 0: chr1 read at [0, 10)
         // Partition 1: chr1 read at [5, 15)
-        // Merged: chr1 [0,4] cov=1, [5,9] cov=2, [10,14] cov=1
+        // Merged (0-based half-open): [0,5) cov=1, [5,10) cov=2, [10,15) cov=1
         let batch1 = make_batch(vec![("chr1", 0, 10, 0, "10M", 60)]);
         let batch2 = make_batch(vec![("chr1", 5, 15, 0, "10M", 60)]);
         let schema = bam_schema();
@@ -887,7 +949,7 @@ mod tests {
             .collect();
 
         assert_eq!(starts, vec![0, 5, 10]);
-        assert_eq!(ends, vec![4, 9, 14]);
+        assert_eq!(ends, vec![5, 10, 15]);
         assert_eq!(covs, vec![1, 2, 1]);
     }
 
@@ -947,7 +1009,8 @@ mod tests {
 
         assert_eq!(contigs.value(0), "chr1");
         assert_eq!(starts.value(0), 0);
-        assert_eq!(ends.value(0), 9);
+        // 0-based half-open: a 10M read at 0 covers [0, 10)
+        assert_eq!(ends.value(0), 10);
         assert_eq!(covs.value(0), 1);
     }
 

--- a/datafusion/bio-function-pileup/tests/mosdepth_compat.rs
+++ b/datafusion/bio-function-pileup/tests/mosdepth_compat.rs
@@ -1,3 +1,29 @@
+//! Golden-parity tests against mosdepth.
+//!
+//! The expected 0-based values below are real mosdepth output. Regenerate them
+//! with mosdepth 0.3.11:
+//!
+//! ```text
+//! mosdepth --fast-mode out tests/data/ovl.bam
+//! gunzip -c out.per-base.bed.gz
+//! MT      0       6       1
+//! MT      6       42      2
+//! MT      42      80      1
+//!
+//! mosdepth --fast-mode out tests/data/overlapping-pairs.bam
+//! gunzip -c out.per-base.bed.gz | awk '$4 != 0'
+//! 1       565173  565253  2
+//! ```
+//!
+//! `--fast-mode` matters: mosdepth's default deduplicates overlapping mate
+//! pairs, which this crate deliberately does not do, so without the flag the
+//! overlap region reads as coverage 1 instead of 2.
+//!
+//! mosdepth writes BED, which is 0-based half-open — the same convention the
+//! `zero_based` output uses. Cross-check with `samtools depth -a`, which is
+//! 1-based closed: it reports `MT [1,6] cov=1`, `[7,42] cov=2`, `[43,80]
+//! cov=1` for `ovl.bam`, i.e. the same intervals in the other convention.
+
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Int16Array, Int32Array, StringArray};
@@ -245,12 +271,13 @@ async fn test_ovl_fast_mode_sql_default_one_based() {
 /// Regression guard for issue #204: the two coordinate systems must describe
 /// the *same* intervals, just in different conventions.
 ///
-/// Ground truth from `samtools depth -a` on `ovl.bam` (1-based, closed):
-/// `MT [1,6] cov=1`, `MT [7,42] cov=2`, `MT [43,80] cov=1` — which as 0-based
-/// half-open BED is `[0,6)`, `[6,42)`, `[42,80)`.
+/// `mosdepth --fast-mode` on `ovl.bam` emits `MT [0,6)`, `[6,42)`, `[42,80)`;
+/// `samtools depth -a` reports the same intervals 1-based closed as `[1,6]`,
+/// `[7,42]`, `[43,80]`.
 ///
 /// Before the fix, 0-based output was closed rather than half-open, so every
-/// block silently covered one base fewer than its 1-based counterpart.
+/// block silently covered one base fewer than its 1-based counterpart — and
+/// matched neither reference tool.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zero_based_and_one_based_describe_the_same_intervals() {
     let bam_path = format!("{}/tests/data/ovl.bam", env!("CARGO_MANIFEST_DIR"));

--- a/datafusion/bio-function-pileup/tests/mosdepth_compat.rs
+++ b/datafusion/bio-function-pileup/tests/mosdepth_compat.rs
@@ -137,9 +137,9 @@ async fn test_ovl_fast_mode() {
         mt_rows
     );
 
-    assert_eq!(mt_rows[0], &("MT".to_string(), 0, 5, 1));
-    assert_eq!(mt_rows[1], &("MT".to_string(), 6, 41, 2));
-    assert_eq!(mt_rows[2], &("MT".to_string(), 42, 79, 1));
+    assert_eq!(mt_rows[0], &("MT".to_string(), 0, 6, 1));
+    assert_eq!(mt_rows[1], &("MT".to_string(), 6, 42, 2));
+    assert_eq!(mt_rows[2], &("MT".to_string(), 42, 80, 1));
 }
 
 /// Tests overlapping mate pairs (no overlap deduplication).
@@ -149,7 +149,7 @@ async fn test_ovl_fast_mode() {
 /// dedup), both reads contribute coverage, giving coverage=2.
 ///
 /// Mosdepth default mode deduplicates overlapping mates, yielding coverage=1.
-/// Our output (0-based closed): 1:565173-565252 → coverage=2
+/// Our output (0-based half-open): 1:[565173, 565253) → coverage=2
 #[tokio::test(flavor = "multi_thread")]
 async fn test_overlapping_pairs() {
     let bam_path = format!(
@@ -177,7 +177,7 @@ async fn test_overlapping_pairs() {
     );
 
     // Both mates align to same region — coverage=2 (no overlap dedup)
-    assert_eq!(chr1_rows[0], &("1".to_string(), 565173, 565252, 2));
+    assert_eq!(chr1_rows[0], &("1".to_string(), 565173, 565253, 2));
 }
 
 /// Test coverage via SQL UDTF: SELECT * FROM depth('path/to/file.bam', true)
@@ -195,9 +195,9 @@ async fn test_ovl_fast_mode_sql() {
     let mt_rows: Vec<_> = rows.iter().filter(|r| r.0 == "MT").collect();
 
     assert_eq!(mt_rows.len(), 3);
-    assert_eq!(mt_rows[0], &("MT".to_string(), 0, 5, 1));
-    assert_eq!(mt_rows[1], &("MT".to_string(), 6, 41, 2));
-    assert_eq!(mt_rows[2], &("MT".to_string(), 42, 79, 1));
+    assert_eq!(mt_rows[0], &("MT".to_string(), 0, 6, 1));
+    assert_eq!(mt_rows[1], &("MT".to_string(), 6, 42, 2));
+    assert_eq!(mt_rows[2], &("MT".to_string(), 42, 80, 1));
 }
 
 /// Test coverage via SQL UDTF for overlapping pairs.
@@ -218,7 +218,7 @@ async fn test_overlapping_pairs_sql() {
     let chr1_rows: Vec<_> = rows.iter().filter(|r| r.0 == "1").collect();
 
     assert_eq!(chr1_rows.len(), 1);
-    assert_eq!(chr1_rows[0], &("1".to_string(), 565173, 565252, 2));
+    assert_eq!(chr1_rows[0], &("1".to_string(), 565173, 565253, 2));
 }
 
 /// Test that the default coordinate system (1-based) works via SQL.
@@ -240,6 +240,48 @@ async fn test_ovl_fast_mode_sql_default_one_based() {
     assert_eq!(mt_rows[0], &("MT".to_string(), 1, 6, 1));
     assert_eq!(mt_rows[1], &("MT".to_string(), 7, 42, 2));
     assert_eq!(mt_rows[2], &("MT".to_string(), 43, 80, 1));
+}
+
+/// Regression guard for issue #204: the two coordinate systems must describe
+/// the *same* intervals, just in different conventions.
+///
+/// Ground truth from `samtools depth -a` on `ovl.bam` (1-based, closed):
+/// `MT [1,6] cov=1`, `MT [7,42] cov=2`, `MT [43,80] cov=1` — which as 0-based
+/// half-open BED is `[0,6)`, `[6,42)`, `[42,80)`.
+///
+/// Before the fix, 0-based output was closed rather than half-open, so every
+/// block silently covered one base fewer than its 1-based counterpart.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_zero_based_and_one_based_describe_the_same_intervals() {
+    let bam_path = format!("{}/tests/data/ovl.bam", env!("CARGO_MANIFEST_DIR"));
+
+    let ctx = SessionContext::new();
+    register_pileup_functions(&ctx);
+
+    let zero_based =
+        collect_coverage_sql(&ctx, &format!("SELECT * FROM depth('{bam_path}', true)")).await;
+    let one_based =
+        collect_coverage_sql(&ctx, &format!("SELECT * FROM depth('{bam_path}', false)")).await;
+
+    assert_eq!(zero_based.len(), one_based.len());
+    assert!(!zero_based.is_empty());
+
+    for (z, o) in zero_based.iter().zip(&one_based) {
+        assert_eq!(z.0, o.0, "contig differs");
+        assert_eq!(z.3, o.3, "coverage differs");
+
+        // 0-based start is the 1-based start minus one...
+        assert_eq!(z.1, o.1 - 1, "start conversion wrong for {z:?} vs {o:?}");
+        // ...while the half-open end equals the 1-based closed end.
+        assert_eq!(z.2, o.2, "end conversion wrong for {z:?} vs {o:?}");
+
+        // The invariant that actually broke: same number of bases covered.
+        assert_eq!(
+            z.2 - z.1,
+            o.2 - o.1 + 1,
+            "block width changed between coordinate systems: {z:?} vs {o:?}"
+        );
+    }
 }
 
 /// Helper to collect per-base coverage results from SQL UDTF.
@@ -446,7 +488,8 @@ async fn test_block_vs_per_base_consistency() {
 
     // For each block, verify all per-base positions within it have matching coverage
     for block in &mt_blocks {
-        for pos in block.1..=block.2 {
+        // Blocks are 0-based half-open, so pos_end is exclusive.
+        for pos in block.1..block.2 {
             let pb = mt_per_base.iter().find(|r| r.1 == pos).unwrap_or_else(|| {
                 panic!("Per-base missing position {pos}");
             });


### PR DESCRIPTION
Fixes #204. Downstream report: biodatageeks/polars-bio#427.

## The bug

`PileupConfig::zero_based` reached two places — the input provider (which shifts read starts down by one) and the output schema metadata — but never the coverage-block emitters. Those emitted a hardcoded **inclusive** end:

```rust
pos_end: (pos - 1) as i32,
```

at all three sites (`events_to_coverage_blocks`, `dense_depth_to_coverage_blocks`, `dense_depth_to_coverage_blocks_bounded`). Shifted-down starts plus an always-closed end meant 0-based output was **closed**, not half-open, so every block silently covered one base fewer than its 1-based counterpart.

## The fix

Thread `zero_based` from `PileupConfig` into the three emitters through a shared helper:

```rust
#[inline]
fn block_end(next_pos: usize, zero_based: bool) -> i32 {
    if zero_based { next_pos as i32 } else { (next_pos - 1) as i32 }
}
```

and pass `config.zero_based` at both production call sites in `physical_exec.rs` (`merge_dense_results`, `merge_sparse_results`).

`per_base` mode is unaffected — it emits a single `pos` column, so there is no interval end to get wrong.

## Verification against an independent reference

`samtools depth -a` on `tests/data/ovl.bam` reports these 1-based closed runs on MT:

```
[1,6] cov=1    [7,42] cov=2    [43,80] cov=1
```

As 0-based half-open BED that is `[0,6)`, `[6,42)`, `[42,80)` — exactly what the fixed code emits. The previous expectations of `[0,5]`, `[6,41]`, `[42,79]` matched neither convention.

End-to-end through polars-bio (built against this branch), the reporter's case in polars-bio#427 now returns their expected table exactly, and total covered bases agree across coordinate systems for the first time:

```
starts shifted -1 : True
ends unchanged    : True
coverage identical: True
widths match      : True
total bases       : 1-based 117 | 0-based half-open 117   (was 36)
```

## Test coverage

**New unit tests** (`src/coverage.rs`) — every one watched failing against the unfixed emitter first:

- `test_zero_based_single_read_end_is_exclusive`
- `test_zero_based_adjacent_blocks_share_a_boundary` — the defining half-open property: one block's end is the next block's start
- `test_zero_based_gap_between_reads_end_is_exclusive`
- `test_zero_based_deletion_gap_end_is_exclusive`
- `test_zero_based_blocks_cover_the_same_bases_as_one_based` — the width invariant that actually broke
- `test_dense_zero_based_end_is_exclusive`
- `test_dense_bounded_zero_based_end_is_exclusive`
- `test_dense_matches_sparse_zero_based` — dense and sparse accumulation agree in 0-based mode
- `test_dense_record_batches_zero_based_end_is_exclusive` and `test_all_events_record_batches_zero_based_end_is_exclusive` — both `RecordBatch` paths used by the operator

**New integration tests:**

- `physical_exec::test_basic_coverage_one_based` — the 1-based path had no coordinate assertion at all
- `mosdepth_compat::test_zero_based_and_one_based_describe_the_same_intervals` — runs both systems over real BAM data and asserts they describe the same intervals, with the samtools ground truth recorded in the doc comment

**Corrected tests that encoded the bug.** Three existing tests asserted closed ends under `zero_based: true` (`test_basic_coverage`, `test_basic_coverage_binary_cigar`, `test_multi_partition_merge_overlapping`), as did the `mosdepth_compat` block expectations. `test_block_vs_per_base_consistency` iterated block positions with `..=`, which double-counts the boundary once ends are exclusive; it now uses `..`.

97 tests pass; `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean, with and without default features.

## Breaking change

These public functions gain a `zero_based` parameter: `events_to_coverage_blocks`, `dense_depth_to_coverage_blocks`, `dense_depth_to_coverage_blocks_bounded`, `all_events_to_record_batch`, `all_events_to_record_batches`, `dense_depth_to_record_batch`, `dense_depth_to_record_batches`.

Adding the parameter rather than inferring the convention keeps the coordinate system explicit at every emitter, which is what let the flag get silently dropped in the first place. polars-bio calls the crate only through `PileupExec` / `PileupConfig`, so it needs no source change — just a version bump once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
