### PR TITLE
perf(vep): prefetch the contig context without spawning its lookup workers

### DIFF
--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -5257,7 +5257,7 @@ impl AnnotateProvider {
             target_partitions
         };
         // Stateful Merged/RefSeq now runs N grid-aligned sharded workers with
-        // bounded-overlap warm-up (design 2026-06-25 §5/§7): prepare_contig_context
+        // bounded-overlap warm-up (design 2026-06-25 §5/§7): contig preparation
         // re-partitions each contig on the global 5000-unit buffer grid and each
         // worker warm-starts its carried HGNC state before its seam, so the old
         // single-ordered-worker fallback is no longer needed. Fails closed via the
@@ -8898,7 +8898,8 @@ type SharedContigPipelineProfile = Arc<Mutex<ContigPipelineProfile>>;
 #[derive(Debug, Default)]
 struct ContigPipelineProfile {
     context_load: Duration,
-    /// Total wall of prepare_contig_context (everything before workers start).
+    /// Total wall of contig preparation, both halves (everything before workers
+    /// start). Includes any time the data half spent waiting as a prefetch.
     prepare_total: Duration,
     /// Prepare phase before context load: schema reads + lookup plan build + worker spawn.
     prepare_setup: Duration,
@@ -9898,8 +9899,54 @@ fn accumulate_boundaries(
     Ok((boundaries, global_row))
 }
 
+/// The prefetchable half of a contig's preparation: everything that reads data
+/// or builds read-only state, with no lookup worker spawned yet. Produced by
+/// `prepare_contig_data()` and consumed by `finish_contig_prepare()`, which
+/// builds the N per-worker `LookupProvider`s and spawns their workers.
+///
+/// The split is what makes prefetching cheap. `prepare_contig_data` costs one
+/// resident contig context (~1.7 GB on WGS, independent of worker count);
+/// `finish_contig_prepare` costs ~0.3 GB per worker. Running only the first
+/// half ahead of time keeps the prelude off the critical path without paying
+/// the per-worker startup footprint twice.
+struct ContigPreparedData {
+    session: Arc<SessionContext>,
+    config: ContigAnnotationConfig,
+    chrom: String,
+    /// Placeholder variation table name; the KvLookupExec resolves the real
+    /// dataset via the cache root.
+    var_table: String,
+    /// Schemas for the per-worker `LookupProvider`s built in the deferred half.
+    grid_vcf_schema: Schema,
+    grid_cache_schema: Schema,
+    /// True when the deferred half must build grid-aligned per-worker lookups
+    /// (stateful Merged/RefSeq at workers>1). Otherwise `lookup_partitions` is
+    /// already populated and the deferred half is a no-op.
+    stateful_parallel: bool,
+    /// Grid-aligned per-worker slices. Empty unless `stateful_parallel`.
+    slices: Vec<WorkerGridSlice>,
+    /// Whether the input VCF uses `chr`-prefixed names — a property of the file,
+    /// so resolved once per contig here rather than once per worker. Only
+    /// meaningful when `stateful_parallel`.
+    vcf_has_chr: bool,
+    /// Single-flight cell so every worker of this contig shares one decoded
+    /// variation shard footer + page index. Created empty here (nothing is
+    /// decoded until a worker first probes) and must not outlive the contig.
+    #[cfg(feature = "parquet-cache")]
+    shared_parquet_lookup_cell: Arc<crate::cache::lookup_exec::ParquetVariationLookupCell>,
+    /// Lookup workers already spawned by the non-grid paths. Empty when
+    /// `stateful_parallel`; the deferred half fills it.
+    lookup_partitions: VecDeque<LookupPartitionHandle>,
+    shared_context: Arc<SharedContigAnnotationContext>,
+    ephemeral_tables: Vec<String>,
+    /// Clone of the pipeline profile handle; the original was moved into
+    /// `shared_context`, and the deferred half still records into it.
+    profile_handle: Option<SharedContigPipelineProfile>,
+    t_contig: Instant,
+}
+
 /// Everything needed to start streaming annotation for a contig.
-/// Produced by `prepare_contig_context()`.
+/// Produced by `finish_contig_prepare()`.
 struct ContigReadyState {
     lookup_partitions: VecDeque<LookupPartitionHandle>,
     /// Grid-aligned per-worker slices, indexed by lookup-partition id. Empty for
@@ -10553,18 +10600,21 @@ struct ContigAnnotationStream {
     /// worker-minor) for the `threads>1` sharded-output path. Monotonic across
     /// contigs so `vcf_sink` concatenates shards in ascending = position order.
     next_global_shard_id: usize,
-    /// The next contig's `prepare_contig_context`, started while the current
-    /// contig annotates so its context load does not sit on the critical path.
+    /// The next contig's `prepare_contig_data`, started while the current contig
+    /// annotates so its context load does not sit on the critical path. Only the
+    /// data half runs ahead — `finish_contig_prepare` spawns the lookup workers
+    /// when the contig starts, so the prefetch adds one resident context and no
+    /// per-worker memory.
     ///
-    /// Safe to run ahead: `prepare_contig_context` depends only on its own
-    /// contig's data plus the session, builds read-only state, and emits no
-    /// rows. Shard ids are still assigned in stream order when a prepared
-    /// contig transitions to `AnnotatingParallel`, so output order is
-    /// unaffected. The contig is popped from `contigs` when the prefetch
-    /// starts, and carried here so the pairing cannot drift.
+    /// Safe to run ahead: `prepare_contig_data` depends only on its own contig's
+    /// data plus the session, builds read-only state, and emits no rows. Shard
+    /// ids are still assigned in stream order when a prepared contig transitions
+    /// to `AnnotatingParallel`, so output order is unaffected. The contig is
+    /// popped from `contigs` when the prefetch starts, and carried here so the
+    /// pairing cannot drift.
     prefetched_prepare: Option<(
         String,
-        tokio::task::JoinHandle<Result<Option<ContigReadyState>>>,
+        tokio::task::JoinHandle<Result<Option<ContigPreparedData>>>,
     )>,
 }
 
@@ -10608,27 +10658,38 @@ impl ContigAnnotationStream {
         let config = self.config.clone();
         let full_schema = self.full_schema.clone();
         let prefetch_chrom = chrom.clone();
+        // Only the data half runs ahead: the lookup workers are spawned by
+        // `finish_contig_prepare` when this contig actually starts, so the
+        // prefetch costs one resident context and no per-worker memory.
         let handle = tokio::spawn(async move {
-            prepare_contig_context(session, cache, prefetch_chrom, config, full_schema).await
+            prepare_contig_data(session, cache, prefetch_chrom, config, full_schema).await
         });
         self.prefetched_prepare = Some((chrom, handle));
     }
 
     /// Take the prefetched prepare for the contig that is next in order, if the
-    /// prefetch already covers it.
+    /// prefetch already covers it. Finishing the deferred half is part of the
+    /// returned future, so the caller sees the same `ContigReadyState` as on the
+    /// cold path.
     fn take_prefetched_prepare(&mut self) -> Option<PrepareFuture> {
         let (_chrom, handle) = self.prefetched_prepare.take()?;
         let fut: PrepareFuture = Box::pin(async move {
-            handle
+            let data = handle
                 .await
-                .map_err(|e| DataFusionError::External(Box::new(e)))?
+                .map_err(|e| DataFusionError::External(Box::new(e)))??;
+            match data {
+                Some(data) => finish_contig_prepare(data).await,
+                None => Ok(None),
+            }
         });
         Some(fut)
     }
 
     fn cleanup_registered_tables_on_drop(&mut self) {
-        // An in-flight prefetch holds spawned lookup tasks for a contig that
-        // will now never be annotated; drop it so they stop.
+        // An in-flight prefetch is loading context for a contig that will now
+        // never be annotated. It spawns no lookup workers of its own (those are
+        // deferred to `finish_contig_prepare`), but aborting still stops the
+        // in-flight context/count scans.
         if let Some((_, handle)) = self.prefetched_prepare.take() {
             handle.abort();
         }
@@ -12050,7 +12111,13 @@ impl Stream for ContigAnnotationStream {
                         let full_schema = self.full_schema.clone();
 
                         let fut: PrepareFuture = Box::pin(async move {
-                            prepare_contig_context(session, cache, chrom, config, full_schema).await
+                            let data =
+                                prepare_contig_data(session, cache, chrom, config, full_schema)
+                                    .await?;
+                            match data {
+                                Some(data) => finish_contig_prepare(data).await,
+                                None => Ok(None),
+                            }
                         });
                         fut
                     };
@@ -12645,13 +12712,18 @@ async fn count_contig_buffer_boundaries(
     accumulate_boundaries(&batches, input_buffer_size)
 }
 
-async fn prepare_contig_context(
+/// Prefetchable half of contig preparation: validate identity, read schemas,
+/// load the contig context concurrently with the grid count pass, load SIFT,
+/// build the shared indexes, and plan the per-worker grid slices — but spawn no
+/// grid lookup worker. `finish_contig_prepare()` does that when the contig
+/// actually starts.
+async fn prepare_contig_data(
     session: Arc<SessionContext>,
     cache: Arc<PartitionedAnnotationCache>,
     chrom: String,
     mut config: ContigAnnotationConfig,
     full_schema: SchemaRef,
-) -> Result<Option<ContigReadyState>> {
+) -> Result<Option<ContigPreparedData>> {
     let t_contig = profile_start!();
     let pipeline_profile =
         profiling_enabled().then(|| Arc::new(Mutex::new(ContigPipelineProfile::default())));
@@ -12735,7 +12807,6 @@ async fn prepare_contig_context(
             config.cache_source_type,
             CacheSourceType::Merged | CacheSourceType::RefSeq
         );
-    let mut grid_slices: Vec<WorkerGridSlice> = Vec::new();
     let grid_vcf_schema = vcf_schema.clone();
     let grid_cache_schema = cache_schema.clone();
     let mut provider = LookupProvider::new(
@@ -12952,28 +13023,143 @@ async fn prepare_contig_context(
     // pass finds the global 5000-unit buffer boundaries; each worker gets a
     // whole-buffer rank range with a bounded-overlap warm-up start, and a lookup
     // scan filtered to its `[scan_lo_pos, scan_hi_pos)` position window.
+    // Only the *planning* happens here. Building the N providers and spawning
+    // their workers is `finish_contig_prepare`'s job, so a prefetched contig
+    // never holds a second set of lookup workers resident.
+    let mut slices: Vec<WorkerGridSlice> = Vec::new();
+    let mut vcf_has_chr = false;
     if stateful_parallel {
         let (boundaries, _total_rows) =
             grid_count.expect("stateful_parallel implies the count future ran")?;
-        let slices = plan_grid_partitions(&boundaries, config.annotation_workers, overlap_width_bp);
+        slices = plan_grid_partitions(&boundaries, config.annotation_workers, overlap_width_bp);
         let _ = _total_rows;
-        let task_ctx = session.task_ctx();
-        // All workers of this contig probe the same variation shard, and the
-        // lookup is immutable once opened (its per-partition cursor is a
-        // stateless placeholder, and each probe opens its own file handle). Share
-        // one single-flight cell so the shard footer + page index are decoded
-        // once per contig rather than once per worker — the page index alone is
-        // ~0.5 GB for chr1, so per-worker loads dominated peak RSS. Scoped to
-        // this contig: it is rebuilt on the next `prepare_contig_context`.
-        #[cfg(feature = "parquet-cache")]
-        let shared_parquet_lookup_cell = Arc::new(tokio::sync::OnceCell::new());
         // Whether the input VCF uses `chr`-prefixed names is a property of the
         // file, not of a worker's range, so resolve it once for the contig. Each
         // resolution plans and executes a `SELECT chrom ... LIMIT 1` against a
         // target_partitions-wide scan, and the per-worker loop is serial, so doing
         // it per worker put N of those probes on the critical path.
-        let vcf_has_chr =
-            crate::lookup_provider::has_chr_prefix(&session, &config.vcf_table).await?;
+        vcf_has_chr = crate::lookup_provider::has_chr_prefix(&session, &config.vcf_table).await?;
+    }
+    // All workers of this contig probe the same variation shard, and the lookup
+    // is immutable once opened (its per-partition cursor is a stateless
+    // placeholder, and each probe opens its own file handle). Share one
+    // single-flight cell so the shard footer + page index are decoded once per
+    // contig rather than once per worker — the page index alone is ~0.5 GB for
+    // chr1, so per-worker loads dominated peak RSS. Created empty (nothing is
+    // decoded until a worker first probes) and scoped to this contig: it is
+    // rebuilt on the next `prepare_contig_data`.
+    #[cfg(feature = "parquet-cache")]
+    let shared_parquet_lookup_cell = Arc::new(tokio::sync::OnceCell::new());
+
+    // Open the per-contig custom-plugin registry when enabled and non-empty.
+    #[cfg(feature = "parquet-cache")]
+    let plugin_registry = match &config.plugin_cache_root {
+        Some(root) => {
+            let reg = crate::plugin_cache::registry::PluginRegistry::open(root, &chrom).await?;
+            if reg.is_empty() {
+                None
+            } else {
+                Some(Arc::new(reg))
+            }
+        }
+        None => None,
+    };
+
+    let shared_context = Arc::new(SharedContigAnnotationContext {
+        config: config.clone(),
+        profile: pipeline_profile,
+        base_transcripts,
+        overlap_width_bp,
+        base_translations: Arc::new(tl),
+        exons: Arc::new(ex),
+        indexes,
+        regulatory: Arc::new(rg),
+        motifs: Arc::new(mt),
+        // TODO: miRNA and structural features are not yet partitioned —
+        // these are rare and handled by the monolithic path only.
+        mirnas: Arc::new(Vec::new()),
+        structural: Arc::new(Vec::new()),
+        translateable_seq_by_tx: Arc::new(translateable_seq),
+        transcript_cache_regions,
+        tmp_provider: Arc::new(tmp_provider),
+        engine: Arc::new(engine),
+        #[cfg(feature = "parquet-cache")]
+        sift_prediction_store,
+        #[cfg(feature = "parquet-cache")]
+        plugin_registry,
+    });
+
+    // `pipeline_profile` was moved into the shared context above; use the cloned
+    // handle to record the shared-context build cost.
+    record_contig_profile(&profile_handle, |profile| {
+        profile.prepare_shared_ctx += shared_ctx_started.elapsed();
+    });
+    log_phase_rss(&chrom, "after_prepare_data");
+    // Marks the end of the *prefetchable* unit. What remains — the N provider
+    // builds and lookup-worker spawns in `finish_contig_prepare` — is
+    // deliberately left on the critical path so its per-worker footprint is only
+    // resident for the contig actually being annotated. The gap between this
+    // event and `prepare done` is the cost of that choice.
+    pipeline_trace::emit(
+        "prepare_data",
+        "done",
+        &[
+            ("chrom", TraceValue::Str(&chrom)),
+            ("elapsed", TraceValue::Duration(t_contig.elapsed())),
+        ],
+    );
+
+    Ok(Some(ContigPreparedData {
+        session,
+        config,
+        chrom,
+        var_table,
+        grid_vcf_schema,
+        grid_cache_schema,
+        stateful_parallel,
+        slices,
+        vcf_has_chr,
+        #[cfg(feature = "parquet-cache")]
+        shared_parquet_lookup_cell,
+        lookup_partitions,
+        shared_context,
+        ephemeral_tables,
+        profile_handle,
+        t_contig,
+    }))
+}
+
+/// Deferred half of contig preparation: build the grid-aligned per-worker
+/// `LookupProvider`s and spawn their lookup workers. Split out of
+/// `prepare_contig_data` because this is where the ~0.3 GB-per-worker startup
+/// footprint is paid — running it only when the contig actually starts keeps a
+/// prefetched contig down to one resident context.
+///
+/// A no-op for the non-grid paths, whose workers were already spawned (and
+/// deliberately left overlapping the context load) in `prepare_contig_data`.
+async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<ContigReadyState>> {
+    let ContigPreparedData {
+        session,
+        config,
+        chrom,
+        var_table,
+        grid_vcf_schema,
+        grid_cache_schema,
+        stateful_parallel,
+        slices,
+        vcf_has_chr,
+        #[cfg(feature = "parquet-cache")]
+        shared_parquet_lookup_cell,
+        mut lookup_partitions,
+        shared_context,
+        ephemeral_tables,
+        profile_handle,
+        t_contig,
+    } = data;
+
+    let mut grid_slices: Vec<WorkerGridSlice> = Vec::new();
+    if stateful_parallel {
+        let task_ctx = session.task_ctx();
         for (i, slice) in slices.iter().enumerate() {
             let mut wprovider = LookupProvider::new(
                 Arc::clone(&session),
@@ -13020,65 +13206,21 @@ async fn prepare_contig_context(
                 chrom.to_string(),
                 sink,
                 LOOKUP_PARTITION_QUEUE_BATCHES,
-                pipeline_profile.clone(),
+                profile_handle.clone(),
             ));
         }
         grid_slices = slices;
-        record_contig_profile(&pipeline_profile, |profile| {
+        record_contig_profile(&profile_handle, |profile| {
             profile.lookup_partitions = lookup_partitions.len();
         });
     }
 
-    // Open the per-contig custom-plugin registry when enabled and non-empty.
-    #[cfg(feature = "parquet-cache")]
-    let plugin_registry = match &config.plugin_cache_root {
-        Some(root) => {
-            let reg = crate::plugin_cache::registry::PluginRegistry::open(root, &chrom).await?;
-            if reg.is_empty() {
-                None
-            } else {
-                Some(Arc::new(reg))
-            }
-        }
-        None => None,
-    };
-
-    let shared_context = Arc::new(SharedContigAnnotationContext {
-        config: config.clone(),
-        profile: pipeline_profile,
-        base_transcripts,
-        overlap_width_bp,
-        base_translations: Arc::new(tl),
-        exons: Arc::new(ex),
-        indexes,
-        regulatory: Arc::new(rg),
-        motifs: Arc::new(mt),
-        // TODO: miRNA and structural features are not yet partitioned —
-        // these are rare and handled by the monolithic path only.
-        mirnas: Arc::new(Vec::new()),
-        structural: Arc::new(Vec::new()),
-        translateable_seq_by_tx: Arc::new(translateable_seq),
-        transcript_cache_regions,
-        tmp_provider: Arc::new(tmp_provider),
-        engine: Arc::new(engine),
-        #[cfg(feature = "parquet-cache")]
-        sift_prediction_store,
-        #[cfg(feature = "parquet-cache")]
-        plugin_registry,
-    });
-
-    // `pipeline_profile` was moved into the shared context above; use the cloned
-    // handle to record the shared-context build cost and the total prepare wall.
     record_contig_profile(&profile_handle, |profile| {
-        profile.prepare_shared_ctx += shared_ctx_started.elapsed();
         profile.prepare_total += t_contig.elapsed();
     });
     log_phase_rss(&chrom, "after_prepare");
-    // Marks the end of the prefetchable unit. Everything after this point
-    // (annotation-worker spawn, first window) needs the workers, so it cannot be
-    // moved off the critical path by prefetching. The gap between `context done`
-    // and this event is the provider-build + lookup-spawn tail, which is what a
-    // narrower prefetch would give back.
+    // Marks the end of contig preparation. Everything after this point
+    // (annotation-worker spawn, first window) belongs to annotation proper.
     pipeline_trace::emit(
         "prepare",
         "done",

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9902,13 +9902,15 @@ fn accumulate_boundaries(
 /// The prefetchable half of a contig's preparation: everything that reads data
 /// or builds read-only state, with no lookup worker spawned yet. Produced by
 /// `prepare_contig_data()` and consumed by `finish_contig_prepare()`, which
-/// builds the N per-worker `LookupProvider`s and spawns their workers.
+/// builds the per-worker `LookupProvider`s and spawns their workers — for both
+/// the grid path and the byte-budget path.
 ///
 /// The split is what makes prefetching cheap. `prepare_contig_data` costs one
 /// resident contig context (~1.7 GB on WGS, independent of worker count);
-/// `finish_contig_prepare` costs ~0.3 GB per worker. Running only the first
-/// half ahead of time keeps the prelude off the critical path without paying
-/// the per-worker startup footprint twice.
+/// `finish_contig_prepare` is what scales with worker count. Running only the
+/// first half ahead of time keeps the prelude off the critical path without
+/// paying the per-worker startup footprint twice: measured at 1.4-2.0 GB of
+/// peak RSS on a merged cache and 2.39 GB on an Ensembl cache at w=8.
 struct ContigPreparedData {
     session: Arc<SessionContext>,
     config: ContigAnnotationConfig,
@@ -9919,9 +9921,10 @@ struct ContigPreparedData {
     /// Schemas for the per-worker `LookupProvider`s built in the deferred half.
     grid_vcf_schema: Schema,
     grid_cache_schema: Schema,
-    /// True when the deferred half must build grid-aligned per-worker lookups
-    /// (stateful Merged/RefSeq at workers>1). Otherwise `lookup_partitions` is
-    /// already populated and the deferred half is a no-op.
+    /// Selects which lookup the deferred half builds: grid-aligned per-worker
+    /// scans (stateful Merged/RefSeq at workers>1) when true, otherwise the
+    /// byte-budget scan from `byte_budget_provider`. Either way the spawn
+    /// happens in `finish_contig_prepare`, never here.
     stateful_parallel: bool,
     /// Grid-aligned per-worker slices. Empty unless `stateful_parallel`.
     slices: Vec<WorkerGridSlice>,
@@ -9934,9 +9937,18 @@ struct ContigPreparedData {
     /// decoded until a worker first probes) and must not outlive the contig.
     #[cfg(feature = "parquet-cache")]
     shared_parquet_lookup_cell: Arc<crate::cache::lookup_exec::ParquetVariationLookupCell>,
-    /// Lookup workers already spawned by the non-grid paths. Empty when
-    /// `stateful_parallel`; the deferred half fills it.
+    /// Always empty here — `finish_contig_prepare` fills it for whichever path
+    /// applies. Kept in the struct so the deferred half has somewhere to push
+    /// without allocating a second deque.
     lookup_partitions: VecDeque<LookupPartitionHandle>,
+    /// Byte-budget lookup provider, carried so the non-grid paths spawn their
+    /// workers in the deferred half too. `None` only if the deferred half has
+    /// already consumed it.
+    byte_budget_provider: Option<LookupProvider>,
+    /// Colocated sink for the single-stream (non-partitioned) lookup path.
+    byte_budget_fallback_sink: ColocatedSink,
+    /// Whether the byte-budget path partitions its lookup scan.
+    byte_budget_parallel_lookup: bool,
     shared_context: Arc<SharedContigAnnotationContext>,
     ephemeral_tables: Vec<String>,
     /// Clone of the pipeline profile handle; the original was moved into
@@ -12715,8 +12727,8 @@ async fn count_contig_buffer_boundaries(
 /// Prefetchable half of contig preparation: validate identity, read schemas,
 /// load the contig context concurrently with the grid count pass, load SIFT,
 /// build the shared indexes, and plan the per-worker grid slices — but spawn no
-/// grid lookup worker. `finish_contig_prepare()` does that when the contig
-/// actually starts.
+/// lookup worker at all, on any path. `finish_contig_prepare()` does that when
+/// the contig actually starts.
 async fn prepare_contig_data(
     session: Arc<SessionContext>,
     cache: Arc<PartitionedAnnotationCache>,
@@ -12829,68 +12841,17 @@ async fn prepare_contig_data(
         }
     }
     let parallel_lookup = cache_enabled;
-    let mut lookup_partitions = if stateful_parallel {
-        // Deferred: grid-aligned per-worker lookup scans are spawned after the
-        // context load below (once overlap_width_bp is known). The `provider`
-        // built above is unused on this path.
-        VecDeque::new()
-    } else if parallel_lookup {
-        let session_state = session.state();
-        let mut plan = provider.scan(&session_state, None, &[], None).await?;
-        let mut partition_count = plan.output_partitioning().partition_count().max(1);
-        let partition_coloc_sinks: Vec<ColocatedSink> = if config.flags.check_existing {
-            let sinks = (0..partition_count)
-                .map(|_| Arc::new(Mutex::new(HashMap::new())) as ColocatedSink)
-                .collect::<Vec<_>>();
-            provider.set_partition_colocated_sinks(sinks.clone());
-            plan = provider.scan(&session_state, None, &[], None).await?;
-            partition_count = plan.output_partitioning().partition_count().max(1);
-            if partition_count > sinks.len() {
-                return Err(DataFusionError::Execution(format!(
-                    "lookup plan produced {partition_count} partitions but only {} colocated sinks were configured",
-                    sinks.len()
-                )));
-            }
-            sinks
-        } else {
-            Vec::new()
-        };
-
-        let task_ctx = session.task_ctx();
-        let mut handles = VecDeque::with_capacity(partition_count);
-        for partition_id in 0..partition_count {
-            let sink = partition_coloc_sinks
-                .get(partition_id)
-                .cloned()
-                .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
-            handles.push_back(spawn_lookup_partition_worker(
-                Arc::clone(&plan),
-                Arc::clone(&task_ctx),
-                partition_id,
-                partition_id,
-                chrom.to_string(),
-                sink,
-                LOOKUP_PARTITION_QUEUE_BATCHES,
-                pipeline_profile.clone(),
-            ));
-        }
-        handles
-    } else {
-        if config.flags.check_existing {
-            provider.set_colocated_sink(Arc::clone(&fallback_coloc_sink));
-        }
-        let session_state = session.state();
-        let plan = provider.scan(&session_state, None, &[], None).await?;
-        let lookup_stream = plan.execute(0, session.task_ctx())?;
-        VecDeque::from([spawn_lookup_stream_worker(
-            lookup_stream,
-            plan.schema(),
-            chrom.to_string(),
-            fallback_coloc_sink,
-            LOOKUP_PARTITION_QUEUE_BATCHES,
-            pipeline_profile.clone(),
-        )])
-    };
+    // No lookup worker is spawned here. Both the grid path and the byte-budget
+    // path spawn in `finish_contig_prepare`, so a prefetched contig carries no
+    // lookup workers whatever the cache source type.
+    //
+    // The byte-budget spawn used to sit here, before the context load, so that
+    // each worker's build+probe (which happens on first poll) overlapped it.
+    // Measured on an Ensembl cache at w=8 (n=3), giving that overlap up costs
+    // +3.55s wall (+7.0%) and buys back 2.39 GB of peak RSS (-24.2%) — the same
+    // trade the grid path already makes, at a better memory ratio. CPU *falls*
+    // 4.4%, so the extra wall time is idle wait, not extra work.
+    let mut lookup_partitions: VecDeque<LookupPartitionHandle> = VecDeque::new();
     record_contig_profile(&pipeline_profile, |profile| {
         profile.lookup_partitions = lookup_partitions.len();
     });
@@ -13122,6 +13083,9 @@ async fn prepare_contig_data(
         #[cfg(feature = "parquet-cache")]
         shared_parquet_lookup_cell,
         lookup_partitions,
+        byte_budget_provider: Some(provider),
+        byte_budget_fallback_sink: fallback_coloc_sink,
+        byte_budget_parallel_lookup: parallel_lookup,
         shared_context,
         ephemeral_tables,
         profile_handle,
@@ -13129,14 +13093,18 @@ async fn prepare_contig_data(
     }))
 }
 
-/// Deferred half of contig preparation: build the grid-aligned per-worker
-/// `LookupProvider`s and spawn their lookup workers. Split out of
-/// `prepare_contig_data` because this is where the ~0.3 GB-per-worker startup
-/// footprint is paid — running it only when the contig actually starts keeps a
-/// prefetched contig down to one resident context.
+/// Deferred half of contig preparation: build the per-worker `LookupProvider`s
+/// and spawn their lookup workers. Split out of `prepare_contig_data` because
+/// this is where the per-worker startup footprint is paid — running it only when
+/// the contig actually starts keeps a prefetched contig down to one resident
+/// context.
 ///
-/// A no-op for the non-grid paths, whose workers were already spawned (and
-/// deliberately left overlapping the context load) in `prepare_contig_data`.
+/// Handles both lookup strategies: grid-aligned per-worker scans when
+/// `stateful_parallel`, otherwise the byte-budget scan. The byte-budget spawn
+/// used to run before the context load so its build+probe overlapped it; giving
+/// that overlap up costs ~7% wall on an Ensembl cache at w=8 and returns 2.39 GB
+/// of peak RSS, so prefetch now carries no lookup workers whatever the cache
+/// source type.
 async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<ContigReadyState>> {
     let ContigPreparedData {
         session,
@@ -13151,6 +13119,9 @@ async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<Contig
         #[cfg(feature = "parquet-cache")]
         shared_parquet_lookup_cell,
         mut lookup_partitions,
+        byte_budget_provider,
+        byte_budget_fallback_sink,
+        byte_budget_parallel_lookup,
         shared_context,
         ephemeral_tables,
         profile_handle,
@@ -13210,6 +13181,65 @@ async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<Contig
             ));
         }
         grid_slices = slices;
+        record_contig_profile(&profile_handle, |profile| {
+            profile.lookup_partitions = lookup_partitions.len();
+        });
+    } else if let Some(mut provider) = byte_budget_provider {
+        // Byte-budget path (Ensembl source, or any source at workers==1).
+        if byte_budget_parallel_lookup {
+            let session_state = session.state();
+            let mut plan = provider.scan(&session_state, None, &[], None).await?;
+            let mut partition_count = plan.output_partitioning().partition_count().max(1);
+            let partition_coloc_sinks: Vec<ColocatedSink> = if config.flags.check_existing {
+                let sinks = (0..partition_count)
+                    .map(|_| Arc::new(Mutex::new(HashMap::new())) as ColocatedSink)
+                    .collect::<Vec<_>>();
+                provider.set_partition_colocated_sinks(sinks.clone());
+                plan = provider.scan(&session_state, None, &[], None).await?;
+                partition_count = plan.output_partitioning().partition_count().max(1);
+                if partition_count > sinks.len() {
+                    return Err(DataFusionError::Execution(format!(
+                        "lookup plan produced {partition_count} partitions but only {} colocated sinks were configured",
+                        sinks.len()
+                    )));
+                }
+                sinks
+            } else {
+                Vec::new()
+            };
+            let task_ctx = session.task_ctx();
+            for partition_id in 0..partition_count {
+                let sink = partition_coloc_sinks
+                    .get(partition_id)
+                    .cloned()
+                    .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
+                lookup_partitions.push_back(spawn_lookup_partition_worker(
+                    Arc::clone(&plan),
+                    Arc::clone(&task_ctx),
+                    partition_id,
+                    partition_id,
+                    chrom.to_string(),
+                    sink,
+                    LOOKUP_PARTITION_QUEUE_BATCHES,
+                    profile_handle.clone(),
+                ));
+            }
+        } else {
+            if config.flags.check_existing {
+                provider.set_colocated_sink(Arc::clone(&byte_budget_fallback_sink));
+            }
+            let session_state = session.state();
+            let plan = provider.scan(&session_state, None, &[], None).await?;
+            let lookup_stream = plan.execute(0, session.task_ctx())?;
+            lookup_partitions.push_back(spawn_lookup_stream_worker(
+                lookup_stream,
+                plan.schema(),
+                chrom.to_string(),
+                byte_budget_fallback_sink,
+                LOOKUP_PARTITION_QUEUE_BATCHES,
+                profile_handle.clone(),
+            ));
+        }
         record_contig_profile(&profile_handle, |profile| {
             profile.lookup_partitions = lookup_partitions.len();
         });


### PR DESCRIPTION
## Summary

`abf19a5` prefetches the next contig's whole `prepare_contig_context` while the
current contig annotates. That function ends by building N `LookupProvider`s and
spawning N lookup workers, so a prefetched contig cost a second per-worker
startup footprint on top of its context: **+3.81 GB peak RSS at w=8** on WGS, of
which only ~1.7 GB is the context itself.

This splits the prefetched unit in two:

- **`prepare_contig_data`** — identity validation, schema reads, the context load
  joined with the grid count pass, the SIFT store, shared indexes, grid-slice
  planning, `vcf_has_chr`, and the shared Parquet lookup cell. This is what the
  prefetch now spawns.
- **`finish_contig_prepare`** — builds the per-worker providers and spawns their
  lookup workers. Runs only when the contig actually starts.

Both `PrepareFuture` construction sites compose the two halves, so `StreamState`,
shard-id assignment and the assembler are unchanged. A new `prepare_data done`
trace event marks the end of the prefetchable part, so the cost of the deferral
stays measurable alongside the existing `prepare done`.

## Measured (HG002 WGS, 4,096,123 variants, merged 116 cache, plain output)

Same-machine A/B against the parent commit:

| workers | `abf19a5` | this branch | Δ wall | Δ peak RSS |
|---|---|---|---|---|
| 4 | 116.8s / 8.81 GB | 102.1s / 6.81 GB | −14.7s | **−2.00 GB** |
| 8 | 64.1s / 10.84 GB | 70.9s / 9.41 GB | +6.8s | **−1.43 GB** |

Memory recovery is consistent at 1.4–2.0 GB. The wall-clock deltas sit inside
this machine's run-to-run spread (the same baseline commit measured 85s and
116.8s at w=4 in two different sessions), so they should not be read as a
speedup or a regression.

Note the recovery does **not** scale with worker count the way the original
estimate (~0.31 GB × N) predicted — it is larger at w=4 than w=8. The saving is
real in both cases, but the per-worker attribution behind that estimate is not
quite right.

Trace evidence that the split is live (5-contig run, w=8):

```
t=  595ms  prepare done       chr1   <- chr1 starts annotating, prefetch fires
t=  617ms  context start      chr2
t= 1089ms  prepare_data done  chr2   <- context built, NO workers spawned
t= 5576ms  prepare done       chr2   <- workers spawned when chr2 starts
```

The deferred phase costs 27.6ms on chr1 (the cold-path contig that never waits).

## Verification

**Ensembl VEP ground-truth parity — 88/88 contigs, 0 mismatches.** Release 116
and 115, merged profile, at w=1 and w=4, all 22 autosomes, against the exact
pinned VEP references. 86/86 CSQ fields at 100% on every contig; 4,096,123
variants per run. Zero one-sided variants, CSQ count/order mismatches, or
mismatch-ledger rows.

**Prefetch parity — 44/44 contigs byte-identical.** The parity harness feeds
vepyr one contig per call, so prefetch never fires there. Annotating all 22
contigs in a single pass at w=4 (21 prefetch handoffs) reproduces each contig's
body bytes exactly, for both releases. Chained with the above, this covers
`take_prefetched_prepare` against ground truth.

Also: `cargo fmt --check`, `cargo clippy --all-targets`, and 882 lib tests green.
WGS output stays byte-exact at 29,410,585,470 bytes with all records matching.

## Scope

Limited to the stateful Merged/RefSeq grid path. The non-grid paths spawn their
lookup workers *before* the context load on purpose, so build+probe overlaps it;
deferring those would serialise a path this change does not measure. Consequence:
an Ensembl-source cache at workers>1 still carries per-worker memory inside the
prefetched half.

## Worker-scaling sweep (HG002 WGS, release 116, plain output)

Full sweep on this branch at w=1,2,4,8,10,12,16 for both merged and RefSeq
caches. All 14 runs passed the integrity check: `status=ok`, 4,096,123 records,
`records_match_vep=true`, and byte-exact output (29,410,585,470 merged /
10,881,926,113 RefSeq).

### merged — vs the archived `vepyr_merged_worker_scaling_plain` baseline

| workers | baseline | this branch | Δ wall | Δ peak RSS | speedup vs w=1 |
|---|---|---|---|---|---|
| 1 | 299.3s / 4.01 GB | 269.5s / 3.65 GB | −29.8s | −0.35 GB | 1.00x |
| 2 | 177.5s / 5.34 GB | 157.1s / 5.55 GB | −20.4s | +0.21 GB | 1.72x |
| 4 | 144.6s / 7.13 GB | 102.2s / 6.78 GB | −42.4s | −0.35 GB | 2.64x |
| 8 | 98.8s / 10.58 GB | 86.3s / 9.09 GB | −12.5s | −1.50 GB | 3.12x |
| 10 | — | 80.3s / 9.20 GB | — | — | 3.36x |
| 12 | — | **69.5s / 9.90 GB** | — | — | **3.88x** |
| 16 | 88.4s / 14.94 GB | 73.4s / 10.16 GB | −15.1s | **−4.78 GB** | 3.67x |

Faster at all five comparable points, and lower peak RSS at four of five. The
memory saving grows with worker count (negligible at w<=4, −1.50 GB at w=8,
−4.78 GB at w=16), which is the shape expected when per-worker footprint is what
is being recovered rather than a constant overhead.

### RefSeq

No RefSeq scaling baseline exists on the benchmark machine, so these are
standalone numbers with nothing to diff against.

| workers | wall | peak RSS | speedup vs w=1 |
|---|---|---|---|
| 1 | 178.3s | 2.99 GB | 1.00x |
| 2 | 97.0s | 4.23 GB | 1.84x |
| 4 | 62.7s | 5.22 GB | 2.84x |
| 8 | 44.9s | 6.14 GB | 3.97x |
| 10 | 41.6s | 6.56 GB | 4.29x |
| 12 | **40.8s** | 7.13 GB | **4.37x** |
| 16 | 45.4s | 8.68 GB | 3.93x |

### Reading these numbers

**Both cache types peak at w=12 and regress at w=16** (merged 69.5s -> 73.4s,
RefSeq 40.8s -> 45.4s). That matches the M3 Max's 12 performance cores: the four
efficiency cores cost more in contention than they contribute. `w=12` is the
configuration worth publishing; `w=10` is close behind on less memory.

**The merged deltas are not attributable to this PR alone.** The baseline's
engine commit is not recorded in its metrics or `summary.tsv`, and it clearly
predates `abf19a5` — its w=4 is 144.6s where a same-machine A/B measured
`abf19a5` at 116.8s. The comparison therefore spans all four stacked commits
(`6d91488`, `86d790a`, `f018e48`, `abf19a5`) plus this one. The isolated A/B
against the direct parent is the table earlier in this description.

**w=10 and w=12 have no baseline** — the archived sweep covers 1, 2, 4, 8, 16
only, so those two rows are new measurements rather than comparisons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADdScQbxGtk9PzSSCUbpsS
