### PR TITLE
perf(vep): defer the byte-budget lookup spawn to contig start too

### DIFF
--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9902,13 +9902,15 @@ fn accumulate_boundaries(
 /// The prefetchable half of a contig's preparation: everything that reads data
 /// or builds read-only state, with no lookup worker spawned yet. Produced by
 /// `prepare_contig_data()` and consumed by `finish_contig_prepare()`, which
-/// builds the N per-worker `LookupProvider`s and spawns their workers.
+/// builds the per-worker `LookupProvider`s and spawns their workers — for both
+/// the grid path and the byte-budget path.
 ///
 /// The split is what makes prefetching cheap. `prepare_contig_data` costs one
 /// resident contig context (~1.7 GB on WGS, independent of worker count);
-/// `finish_contig_prepare` costs ~0.3 GB per worker. Running only the first
-/// half ahead of time keeps the prelude off the critical path without paying
-/// the per-worker startup footprint twice.
+/// `finish_contig_prepare` is what scales with worker count. Running only the
+/// first half ahead of time keeps the prelude off the critical path without
+/// paying the per-worker startup footprint twice: measured at 1.4-2.0 GB of
+/// peak RSS on a merged cache and 2.39 GB on an Ensembl cache at w=8.
 struct ContigPreparedData {
     session: Arc<SessionContext>,
     config: ContigAnnotationConfig,
@@ -9919,9 +9921,10 @@ struct ContigPreparedData {
     /// Schemas for the per-worker `LookupProvider`s built in the deferred half.
     grid_vcf_schema: Schema,
     grid_cache_schema: Schema,
-    /// True when the deferred half must build grid-aligned per-worker lookups
-    /// (stateful Merged/RefSeq at workers>1). Otherwise `lookup_partitions` is
-    /// already populated and the deferred half is a no-op.
+    /// Selects which lookup the deferred half builds: grid-aligned per-worker
+    /// scans (stateful Merged/RefSeq at workers>1) when true, otherwise the
+    /// byte-budget scan from `byte_budget_provider`. Either way the spawn
+    /// happens in `finish_contig_prepare`, never here.
     stateful_parallel: bool,
     /// Grid-aligned per-worker slices. Empty unless `stateful_parallel`.
     slices: Vec<WorkerGridSlice>,
@@ -9934,8 +9937,9 @@ struct ContigPreparedData {
     /// decoded until a worker first probes) and must not outlive the contig.
     #[cfg(feature = "parquet-cache")]
     shared_parquet_lookup_cell: Arc<crate::cache::lookup_exec::ParquetVariationLookupCell>,
-    /// Lookup workers already spawned by the non-grid paths. Empty when
-    /// `stateful_parallel`; the deferred half fills it.
+    /// Always empty here — `finish_contig_prepare` fills it for whichever path
+    /// applies. Kept in the struct so the deferred half has somewhere to push
+    /// without allocating a second deque.
     lookup_partitions: VecDeque<LookupPartitionHandle>,
     /// Byte-budget lookup provider, carried so the non-grid paths spawn their
     /// workers in the deferred half too. `None` only if the deferred half has
@@ -12723,8 +12727,8 @@ async fn count_contig_buffer_boundaries(
 /// Prefetchable half of contig preparation: validate identity, read schemas,
 /// load the contig context concurrently with the grid count pass, load SIFT,
 /// build the shared indexes, and plan the per-worker grid slices — but spawn no
-/// grid lookup worker. `finish_contig_prepare()` does that when the contig
-/// actually starts.
+/// lookup worker at all, on any path. `finish_contig_prepare()` does that when
+/// the contig actually starts.
 async fn prepare_contig_data(
     session: Arc<SessionContext>,
     cache: Arc<PartitionedAnnotationCache>,
@@ -13089,14 +13093,18 @@ async fn prepare_contig_data(
     }))
 }
 
-/// Deferred half of contig preparation: build the grid-aligned per-worker
-/// `LookupProvider`s and spawn their lookup workers. Split out of
-/// `prepare_contig_data` because this is where the ~0.3 GB-per-worker startup
-/// footprint is paid — running it only when the contig actually starts keeps a
-/// prefetched contig down to one resident context.
+/// Deferred half of contig preparation: build the per-worker `LookupProvider`s
+/// and spawn their lookup workers. Split out of `prepare_contig_data` because
+/// this is where the per-worker startup footprint is paid — running it only when
+/// the contig actually starts keeps a prefetched contig down to one resident
+/// context.
 ///
-/// A no-op for the non-grid paths, whose workers were already spawned (and
-/// deliberately left overlapping the context load) in `prepare_contig_data`.
+/// Handles both lookup strategies: grid-aligned per-worker scans when
+/// `stateful_parallel`, otherwise the byte-budget scan. The byte-budget spawn
+/// used to run before the context load so its build+probe overlapped it; giving
+/// that overlap up costs ~7% wall on an Ensembl cache at w=8 and returns 2.39 GB
+/// of peak RSS, so prefetch now carries no lookup workers whatever the cache
+/// source type.
 async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<ContigReadyState>> {
     let ContigPreparedData {
         session,

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9937,6 +9937,14 @@ struct ContigPreparedData {
     /// Lookup workers already spawned by the non-grid paths. Empty when
     /// `stateful_parallel`; the deferred half fills it.
     lookup_partitions: VecDeque<LookupPartitionHandle>,
+    /// Byte-budget lookup provider, carried so the non-grid paths spawn their
+    /// workers in the deferred half too. `None` only if the deferred half has
+    /// already consumed it.
+    byte_budget_provider: Option<LookupProvider>,
+    /// Colocated sink for the single-stream (non-partitioned) lookup path.
+    byte_budget_fallback_sink: ColocatedSink,
+    /// Whether the byte-budget path partitions its lookup scan.
+    byte_budget_parallel_lookup: bool,
     shared_context: Arc<SharedContigAnnotationContext>,
     ephemeral_tables: Vec<String>,
     /// Clone of the pipeline profile handle; the original was moved into
@@ -12829,68 +12837,17 @@ async fn prepare_contig_data(
         }
     }
     let parallel_lookup = cache_enabled;
-    let mut lookup_partitions = if stateful_parallel {
-        // Deferred: grid-aligned per-worker lookup scans are spawned after the
-        // context load below (once overlap_width_bp is known). The `provider`
-        // built above is unused on this path.
-        VecDeque::new()
-    } else if parallel_lookup {
-        let session_state = session.state();
-        let mut plan = provider.scan(&session_state, None, &[], None).await?;
-        let mut partition_count = plan.output_partitioning().partition_count().max(1);
-        let partition_coloc_sinks: Vec<ColocatedSink> = if config.flags.check_existing {
-            let sinks = (0..partition_count)
-                .map(|_| Arc::new(Mutex::new(HashMap::new())) as ColocatedSink)
-                .collect::<Vec<_>>();
-            provider.set_partition_colocated_sinks(sinks.clone());
-            plan = provider.scan(&session_state, None, &[], None).await?;
-            partition_count = plan.output_partitioning().partition_count().max(1);
-            if partition_count > sinks.len() {
-                return Err(DataFusionError::Execution(format!(
-                    "lookup plan produced {partition_count} partitions but only {} colocated sinks were configured",
-                    sinks.len()
-                )));
-            }
-            sinks
-        } else {
-            Vec::new()
-        };
-
-        let task_ctx = session.task_ctx();
-        let mut handles = VecDeque::with_capacity(partition_count);
-        for partition_id in 0..partition_count {
-            let sink = partition_coloc_sinks
-                .get(partition_id)
-                .cloned()
-                .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
-            handles.push_back(spawn_lookup_partition_worker(
-                Arc::clone(&plan),
-                Arc::clone(&task_ctx),
-                partition_id,
-                partition_id,
-                chrom.to_string(),
-                sink,
-                LOOKUP_PARTITION_QUEUE_BATCHES,
-                pipeline_profile.clone(),
-            ));
-        }
-        handles
-    } else {
-        if config.flags.check_existing {
-            provider.set_colocated_sink(Arc::clone(&fallback_coloc_sink));
-        }
-        let session_state = session.state();
-        let plan = provider.scan(&session_state, None, &[], None).await?;
-        let lookup_stream = plan.execute(0, session.task_ctx())?;
-        VecDeque::from([spawn_lookup_stream_worker(
-            lookup_stream,
-            plan.schema(),
-            chrom.to_string(),
-            fallback_coloc_sink,
-            LOOKUP_PARTITION_QUEUE_BATCHES,
-            pipeline_profile.clone(),
-        )])
-    };
+    // No lookup worker is spawned here. Both the grid path and the byte-budget
+    // path spawn in `finish_contig_prepare`, so a prefetched contig carries no
+    // lookup workers whatever the cache source type.
+    //
+    // The byte-budget spawn used to sit here, before the context load, so that
+    // each worker's build+probe (which happens on first poll) overlapped it.
+    // Measured on an Ensembl cache at w=8 (n=3), giving that overlap up costs
+    // +3.55s wall (+7.0%) and buys back 2.39 GB of peak RSS (-24.2%) — the same
+    // trade the grid path already makes, at a better memory ratio. CPU *falls*
+    // 4.4%, so the extra wall time is idle wait, not extra work.
+    let mut lookup_partitions: VecDeque<LookupPartitionHandle> = VecDeque::new();
     record_contig_profile(&pipeline_profile, |profile| {
         profile.lookup_partitions = lookup_partitions.len();
     });
@@ -13122,6 +13079,9 @@ async fn prepare_contig_data(
         #[cfg(feature = "parquet-cache")]
         shared_parquet_lookup_cell,
         lookup_partitions,
+        byte_budget_provider: Some(provider),
+        byte_budget_fallback_sink: fallback_coloc_sink,
+        byte_budget_parallel_lookup: parallel_lookup,
         shared_context,
         ephemeral_tables,
         profile_handle,
@@ -13151,6 +13111,9 @@ async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<Contig
         #[cfg(feature = "parquet-cache")]
         shared_parquet_lookup_cell,
         mut lookup_partitions,
+        byte_budget_provider,
+        byte_budget_fallback_sink,
+        byte_budget_parallel_lookup,
         shared_context,
         ephemeral_tables,
         profile_handle,
@@ -13210,6 +13173,65 @@ async fn finish_contig_prepare(data: ContigPreparedData) -> Result<Option<Contig
             ));
         }
         grid_slices = slices;
+        record_contig_profile(&profile_handle, |profile| {
+            profile.lookup_partitions = lookup_partitions.len();
+        });
+    } else if let Some(mut provider) = byte_budget_provider {
+        // Byte-budget path (Ensembl source, or any source at workers==1).
+        if byte_budget_parallel_lookup {
+            let session_state = session.state();
+            let mut plan = provider.scan(&session_state, None, &[], None).await?;
+            let mut partition_count = plan.output_partitioning().partition_count().max(1);
+            let partition_coloc_sinks: Vec<ColocatedSink> = if config.flags.check_existing {
+                let sinks = (0..partition_count)
+                    .map(|_| Arc::new(Mutex::new(HashMap::new())) as ColocatedSink)
+                    .collect::<Vec<_>>();
+                provider.set_partition_colocated_sinks(sinks.clone());
+                plan = provider.scan(&session_state, None, &[], None).await?;
+                partition_count = plan.output_partitioning().partition_count().max(1);
+                if partition_count > sinks.len() {
+                    return Err(DataFusionError::Execution(format!(
+                        "lookup plan produced {partition_count} partitions but only {} colocated sinks were configured",
+                        sinks.len()
+                    )));
+                }
+                sinks
+            } else {
+                Vec::new()
+            };
+            let task_ctx = session.task_ctx();
+            for partition_id in 0..partition_count {
+                let sink = partition_coloc_sinks
+                    .get(partition_id)
+                    .cloned()
+                    .unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
+                lookup_partitions.push_back(spawn_lookup_partition_worker(
+                    Arc::clone(&plan),
+                    Arc::clone(&task_ctx),
+                    partition_id,
+                    partition_id,
+                    chrom.to_string(),
+                    sink,
+                    LOOKUP_PARTITION_QUEUE_BATCHES,
+                    profile_handle.clone(),
+                ));
+            }
+        } else {
+            if config.flags.check_existing {
+                provider.set_colocated_sink(Arc::clone(&byte_budget_fallback_sink));
+            }
+            let session_state = session.state();
+            let plan = provider.scan(&session_state, None, &[], None).await?;
+            let lookup_stream = plan.execute(0, session.task_ctx())?;
+            lookup_partitions.push_back(spawn_lookup_stream_worker(
+                lookup_stream,
+                plan.schema(),
+                chrom.to_string(),
+                byte_budget_fallback_sink,
+                LOOKUP_PARTITION_QUEUE_BATCHES,
+                profile_handle.clone(),
+            ));
+        }
         record_contig_profile(&profile_handle, |profile| {
             profile.lookup_partitions = lookup_partitions.len();
         });


### PR DESCRIPTION
Stacked on #206 (`perf/narrow-contig-prefetch-split`). Review that first.

## Problem

#206 moved the **grid** path's lookup-worker spawn into `finish_contig_prepare`,
so a prefetched contig no longer carries a duplicate set of workers. The
byte-budget path was left alone, and the two gates do not line up:

- prefetch fires under `if config.annotation_workers > 1` — source type irrelevant
- the deferred half only acts under `if stateful_parallel`, which additionally
  requires `Merged | RefSeq`

So on an **Ensembl-source cache at workers>1**, prefetch still runs but
`finish_contig_prepare` is a no-op, because `lookup_partitions` was already
filled by the byte-budget branch *before* the context load. Those caches got
none of #206's benefit.

## Change

Carry the `LookupProvider` (plus its fallback colocated sink and the
`parallel_lookup` flag) in `ContigPreparedData`, and spawn in the deferred half
for both paths. A prefetched contig now holds no lookup workers whatever the
cache source type.

## The trade, measured

The byte-budget spawn sat before the context load deliberately — build+probe
happens on first poll, so spawning early overlapped it with the context load.
I did not assume that overlap was cheap to lose; I measured it.

Ensembl cache, HG002 WGS, w=8, **n=3 per arm**, all three differences with
disjoint ranges:

| metric | before | after | delta | \|d\|/sd |
|---|---|---|---|---|
| wall | 50.3s | 53.9s | +3.55s (+7.0%) | 2.2 |
| CPU | 385s | 368s | −16.7s (−4.4%) | 12.0 |
| **peak RSS** | **9.88 GB** | **7.49 GB** | **−2.39 GB (−24.2%)** | 8.9 |

CPU *falls*, so the added wall time is idle wait for the lookup to warm rather
than extra work. The memory saving exceeds the 1.43–2.00 GB the grid split
recovered on merged, because the byte-budget path spawns `target_partitions`
workers rather than `annotation_workers`.

This is the same shape of trade #206 already makes — a few percent of wall for a
large slice of peak RSS — at a better ratio.

n=3 is not decoration: at w>=8 this machine's wall spread is 5–15%, and single-run
comparisons in this investigation produced two conclusions that repeats later
overturned.

## Verification

Byte-identical output on every gate:

- merged chr21 @ w=1 and w=8 → `aa686ea955e2c561bda37bc2f1d88092`
- merged chr1 @ w=16 → `230e0c5c792e9ecd5a7c537d9d664219`
- merged 5-contig @ w=16 (prefetch handoff at every boundary) reproduces all
  five contigs' standalone MD5s
- Ensembl chr21 @ w=8 → `d9bcfe559b2b6de8e3d714f35084ef57`, and the same contig
  sliced out of a 5-contig single-pass run matches it — so the Ensembl prefetch
  path this PR changes is covered, not just the cold path
- output byte-count identical across all six A/B runs (20,778,630,899)

`cargo fmt --check`, `cargo clippy --all-targets`, 882 lib tests green.

## Ensembl ground-truth parity — done, 44/44 clean

The gap this PR was opened with is now closed. Release 116, `--profile ensembl`,
chr1-22, at w=1 and w=4, against `HG002_annotated_wgs_everything_hgvs_vep.vcf.gz`:

| run | contigs | mismatches |
|---|---|---|
| `ensembl 116 w=1` | 22/22 | **0** |
| `ensembl 116 w=4` | 22/22 | **0** |

**44/44 contigs, 0 mismatches, 0 warnings.** Each contig's count sums every
failure category — one-sided variants both directions, CSQ entry count, CSQ
ordering, one-sided CSQ entries, field mismatch counts, the three equality
buckets, and the mismatch-ledger row count.

w=4 is the load-bearing arm: prefetch only fires at `annotation_workers > 1`, so
that is where the deferred byte-budget spawn actually changes behaviour. This is
the first time an Ensembl-source cache has been compared against Ensembl VEP on
this line of work — #206's 88/88 and 44/44 were all merged or RefSeq.

Run against this branch's build, verified by MD5 before starting (Ensembl chr21
@ w=8 -> `d9bcfe559b2b6de8e3d714f35084ef57`) so the binary under test provably
matched the checkout.

## Caveats

As with #206, these runs use `HG002_normalized.vcf.gz` rather than the canonical
`HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz`, and vepyr carries a local path
`[patch]` to the engine checkout. `verify_parity_gate.py` rejects both, so this
is a rigorous regression result rather than a release qualification.

Release 115 Ensembl is not covered — 116 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADdScQbxGtk9PzSSCUbpsS
