### PR TITLE
perf(vep): overlap the next contig's prepare with the current contig's annotation

### DIFF
--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -8904,9 +8904,13 @@ type SharedContigPipelineProfile = Arc<Mutex<ContigPipelineProfile>>;
 #[derive(Debug, Default)]
 struct ContigPipelineProfile {
     context_load: Duration,
-    /// Total wall of prepare_contig_context (everything before workers start).
+    /// Total wall of contig preparation, both halves (everything before workers
+    /// start): `prepare_contig_data` + `activate_contig_lookups`, recorded as
+    /// two spans so the halves stay attributable when they run apart.
     prepare_total: Duration,
-    /// Prepare phase before context load: schema reads + lookup plan build + worker spawn.
+    /// Data-phase prelude before the context load: identity validation + schema
+    /// reads. The lookup plan build and worker spawn moved to
+    /// `activate_contig_lookups` and are accounted in `prepare_total` only.
     prepare_setup: Duration,
     /// Building the shared annotation context (indexes, cache regions) after loads.
     prepare_shared_ctx: Duration,
@@ -10071,8 +10075,50 @@ fn accumulate_boundaries_inner(
     Ok((boundaries, global_row, positions))
 }
 
+/// The data half of a contig's preparation: everything that reads data or
+/// builds read-only state, with no lookup worker spawned yet. Produced by
+/// `prepare_contig_data()` and consumed by `activate_contig_lookups()`, which
+/// builds the `LookupProvider`s and spawns their workers.
+///
+/// The split exists so the data half can later be run ahead of the contig that
+/// needs it: it costs one resident contig context (independent of worker
+/// count), while activation costs a per-worker startup footprint that must only
+/// be resident for the contig actually being annotated.
+struct ContigPreparedData {
+    chrom: String,
+    /// Post identity-validation config (`vep_semantics` resolved from the
+    /// contig's cache shards).
+    config: ContigAnnotationConfig,
+    cache: Arc<PartitionedAnnotationCache>,
+    /// Profile handle passed to the spawned lookup workers. Same `Arc` as
+    /// `profile_handle`; kept separate so activation mirrors the pre-split code.
+    pipeline_profile: Option<SharedContigPipelineProfile>,
+    /// Clone of the pipeline profile handle; the original was moved into
+    /// `shared_context`, and activation still records into it.
+    profile_handle: Option<SharedContigPipelineProfile>,
+    ephemeral_tables: Vec<String>,
+    shared_context: Arc<SharedContigAnnotationContext>,
+    /// Grid-aligned per-worker slices, already planned. Empty unless
+    /// `stateful_parallel`.
+    grid_slices: Vec<WorkerGridSlice>,
+    /// True when activation must build grid-aligned per-worker lookups
+    /// (stateful Merged/RefSeq at workers>1) instead of the byte-budget path.
+    stateful_parallel: bool,
+    /// Placeholder variation table name; the KvLookupExec resolves the real
+    /// dataset via the cache root.
+    var_table: String,
+    /// Schemas for the `LookupProvider`s built during activation.
+    vcf_schema: Schema,
+    cache_schema: Schema,
+    /// Colocated sink used by the serial (single-partition) lookup arm.
+    fallback_coloc_sink: ColocatedSink,
+    /// Contig wall-clock start, carried through to `ContigReadyState` for the
+    /// downstream contig END timing.
+    t_contig: Instant,
+}
+
 /// Everything needed to start streaming annotation for a contig.
-/// Produced by `prepare_contig_context()`.
+/// Produced by `activate_contig_lookups()`.
 struct ContigReadyState {
     lookup_partitions: VecDeque<LookupPartitionHandle>,
     /// Grid-aligned per-worker slices, indexed by lookup-partition id. Empty for
@@ -12712,22 +12758,55 @@ async fn count_contig_buffer_boundaries(
     accumulate_boundaries_inner(&batches, input_buffer_size, collect_positions)
 }
 
+/// Prepare a contig for streaming annotation.
+///
+/// Composition of the two halves the preparation is split into:
+/// `prepare_contig_data` (reads data, builds read-only state, spawns nothing)
+/// and `activate_contig_lookups` (builds the lookup providers and spawns their
+/// workers). Callers see the same signature and the same result as before the
+/// split; the halves exist so the data half can later be run ahead of time.
 async fn prepare_contig_context(
+    session: Arc<SessionContext>,
+    cache: Arc<PartitionedAnnotationCache>,
+    chrom: String,
+    config: ContigAnnotationConfig,
+    full_schema: SchemaRef,
+) -> Result<Option<ContigReadyState>> {
+    match prepare_contig_data(Arc::clone(&session), cache, chrom, config, full_schema).await? {
+        None => Ok(None),
+        Some(data) => activate_contig_lookups(session, data).await,
+    }
+}
+
+/// Data half of contig preparation: validate identity, read schemas, load the
+/// contig context concurrently with the grid count pass, load SIFT, build the
+/// shared indexes and the shared annotation context, and plan the per-worker
+/// grid slices — but spawn no lookup worker and build no lookup provider.
+/// `activate_contig_lookups()` does that.
+async fn prepare_contig_data(
     session: Arc<SessionContext>,
     cache: Arc<PartitionedAnnotationCache>,
     chrom: String,
     mut config: ContigAnnotationConfig,
     full_schema: SchemaRef,
-) -> Result<Option<ContigReadyState>> {
+) -> Result<Option<ContigPreparedData>> {
     let t_contig = profile_start!();
+    // Dedicated span for this half. `t_contig` is carried through to
+    // `ContigReadyState` for the contig END timing, so it must not be used for
+    // the prepare accounting once the two halves can run apart.
+    let t_data = Instant::now();
     let pipeline_profile =
         profiling_enabled().then(|| Arc::new(Mutex::new(ContigPipelineProfile::default())));
     // Cloned handle so prepare_shared_ctx / prepare_total can still be recorded
     // after `pipeline_profile` is moved into the shared context below.
     let profile_handle = pipeline_profile.clone();
-    if profiling_enabled() {
-        eprintln!("[VEP_PROFILE] ------ contig {chrom} START ------");
-    }
+    // The `contig START` banner belongs to the half that actually starts the
+    // contig, so it lives in `activate_contig_lookups`.
+    pipeline_trace::emit(
+        "prefetch",
+        "data_start",
+        &[("chrom", TraceValue::Str(&chrom))],
+    );
 
     // Identity is a contig-local precondition: validate every participating
     // shard footer before opening variation or context data for this contig.
@@ -12770,8 +12849,7 @@ async fn prepare_contig_context(
     // transcript/exon/translation/regulatory/motif context via
     // `load_contig_transcripts`; no per-chrom parquet tables are registered.
 
-    // Lookup arm: build LookupProvider, create stream (cheap — build+probe
-    // happens on first poll, NOT here).
+    // Schemas for the lookup providers built during activation.
     let fallback_coloc_sink: ColocatedSink = Arc::new(Mutex::new(HashMap::new()));
     let vcf_schema = session
         .table(&config.vcf_table)
@@ -12794,15 +12872,348 @@ async fn prepare_contig_context(
     #[cfg(not(feature = "parquet-cache"))]
     let cache_schema: Schema = unreachable!("parquet-cache feature is required");
     // Stateful Merged/RefSeq at workers>1 runs N grid-aligned per-worker lookup
-    // scans (built after the context load below, once overlap_width is known),
-    // not the byte-budget partitioning. Keep schema clones for those providers.
+    // scans (planned below, once overlap_width is known), not the byte-budget
+    // partitioning.
     let stateful_parallel = cache_enabled
         && config.annotation_workers > 1
         && matches!(
             config.cache_source_type,
             CacheSourceType::Merged | CacheSourceType::RefSeq
         );
+
+    // Context arm: load transcripts, exons, translations, etc. (Parquet only).
+    // Everything up to here (identity validation, schema reads) is setup that
+    // runs before any context data is loaded. The lookup plan build and worker
+    // spawn are in `activate_contig_lookups` and are accounted for there.
+    record_contig_profile(&pipeline_profile, |profile| {
+        profile.prepare_setup += t_contig.elapsed();
+    });
+
+    let context_fut = async {
+        let t_ctx = profile_start!();
+        pipeline_trace::emit("context", "start", &[("chrom", TraceValue::Str(&chrom))]);
+        let _ = cache_enabled;
+        #[cfg(feature = "parquet-cache")]
+        {
+            let loaded =
+                load_contig_transcripts(cache.as_parquet(), &chrom, &config, &pipeline_profile)
+                    .await?;
+            let context_elapsed = t_ctx.elapsed();
+            pipeline_trace::emit(
+                "context",
+                "transcripts_done",
+                &[
+                    ("chrom", TraceValue::Str(&chrom)),
+                    ("transcripts", TraceValue::Usize(loaded.0.len())),
+                    ("elapsed", TraceValue::Duration(context_elapsed)),
+                ],
+            );
+            // context_load must cover ALL five entities. The transcripts are
+            // loaded here and the other four in load_contig_context_rest, and
+            // the two phases are strictly sequential (the grid plan needs the
+            // transcripts), so the total is their sum.
+            record_contig_profile(&pipeline_profile, |profile| {
+                profile.context_load += context_elapsed;
+            });
+            Ok(loaded)
+        }
+        #[cfg(not(feature = "parquet-cache"))]
+        {
+            unreachable!("parquet-cache feature is required")
+        }
+    };
+    // Cost-weighted grid split (opt-in). Resolved before the count pass because
+    // the weights need every row's position, which only that pass sees.
+    let grid_balance_enabled = stateful_parallel
+        && pipeline_trace::enabled_from_env_value(
+            std::env::var("VEP_GRID_BALANCE").ok().as_deref(),
+        );
+    // Run the grid count pass (VCF positions only) CONCURRENTLY with the context
+    // load (Parquet transcripts/exons) — independent IO, so the count is hidden
+    // behind context load instead of running as a serial prelude before workers.
+    let count_fut = async {
+        if stateful_parallel {
+            Some(
+                count_contig_buffer_boundaries(
+                    &session,
+                    &config.vcf_table,
+                    &chrom,
+                    config.input_buffer_size,
+                    grid_balance_enabled,
+                )
+                .await,
+            )
+        } else {
+            None
+        }
+    };
+    let context_result: Result<(Vec<TranscriptFeature>, HashMap<String, String>)>;
+    let grid_count;
+    (context_result, grid_count) = tokio::join!(context_fut, count_fut);
+    // No lookup worker has been spawned yet on this path, so a context failure
+    // has nothing to abort (the pre-split code aborted the byte-budget workers
+    // it had already started here).
+    let (tx_vec, translateable_seq) = context_result?;
+    log_phase_rss(&chrom, "after_context_load");
+
+    let tmp_provider = AnnotateProvider::new(
+        Arc::clone(&session),
+        config.vcf_table.clone(),
+        String::new(),
+        AnnotationBackend::Parquet,
+        config.cache_source_type,
+        config.options_json.clone(),
+        vcf_only_schema,
+    )?;
+    let engine = TranscriptConsequenceEngine::new_with_hgvs_shift_and_semantics(
+        config.upstream_distance,
+        config.downstream_distance,
+        config.hgvs_flags.shift_hgvs,
+        config.vep_semantics,
+    );
+
+    // SIFT source: a shared per-contig prediction store loaded from the Parquet
+    // translation_sift shard.
+    #[cfg(feature = "parquet-cache")]
+    let use_lookup_sift = config.cache_root.is_some();
+    #[cfg(not(feature = "parquet-cache"))]
+    let use_lookup_sift = false;
+
+    #[cfg(feature = "parquet-cache")]
+    let sift_prediction_store = if use_lookup_sift && config.flags.everything {
+        let sift_started = Instant::now();
+        let store =
+            load_parquet_sift_prediction_store_for_chrom(cache.as_parquet(), &chrom).await?;
+        record_contig_profile(&pipeline_profile, |profile| {
+            profile.sift_load += sift_started.elapsed();
+        });
+        store
+    } else {
+        None
+    };
+    log_phase_rss(&chrom, "after_sift_load");
+
+    let shared_ctx_started = Instant::now();
+    let base_transcripts = Arc::new(tx_vec);
+    let transcript_cache_regions = Arc::new(
+        base_transcripts
+            .iter()
+            .map(|tx| (tx.transcript_id.clone(), transcript_cache_regions(tx)))
+            .collect(),
+    );
+    let overlap_width_bp = compute_overlap_width_bp(&base_transcripts);
+    let tx_ids: HashSet<String> = base_transcripts
+        .iter()
+        .map(|tx| tx.transcript_id.clone())
+        .collect();
+    let t_rest = Instant::now();
+    let rest =
+        load_contig_context_rest(cache.as_parquet(), &chrom, &pipeline_profile, &tx_ids).await;
+    let rest_elapsed = t_rest.elapsed();
+    pipeline_trace::emit(
+        "context",
+        "done",
+        &[
+            ("chrom", TraceValue::Str(&chrom)),
+            ("elapsed", TraceValue::Duration(rest_elapsed)),
+        ],
+    );
+    record_contig_profile(&pipeline_profile, |profile| {
+        profile.context_load += rest_elapsed;
+    });
+    let (ex, tl, rg, mt) = rest?;
+
+    // Grid-aligned parallel lookup (stateful Merged/RefSeq, workers>1): a count
+    // pass finds the global 5000-unit buffer boundaries; each worker gets a
+    // whole-buffer rank range with a bounded-overlap warm-up start, and a lookup
+    // scan filtered to its `[scan_lo_pos, scan_hi_pos)` position window.
+    //
+    // Only the *planning* happens here. Building the providers and spawning the
+    // workers is `activate_contig_lookups`'s job, so this half never holds a set
+    // of lookup workers resident.
     let mut grid_slices: Vec<WorkerGridSlice> = Vec::new();
+    if stateful_parallel {
+        let (boundaries, _total_rows, grid_positions) =
+            grid_count.expect("stateful_parallel implies the count future ran")?;
+        // Cost-weighted grid split (opt-in via VEP_GRID_BALANCE). The default
+        // equal-buffer-count split equalises variants per worker, not work, so
+        // gene-dense slices straggle; weighting by transcript overlap equalises
+        // the thing that actually costs. Slice boundaries do not affect output
+        // (every worker count already yields byte-identical VCFs), so this is a
+        // scheduling change only.
+        let slices = if grid_balance_enabled {
+            let t_w = Instant::now();
+            let weights = buffer_transcript_weights(
+                &boundaries,
+                &grid_positions,
+                base_transcripts.iter().map(|tx| (tx.start, tx.end)),
+            );
+            let planned = plan_grid_partitions_balanced(
+                &boundaries,
+                config.annotation_workers,
+                overlap_width_bp,
+                &weights,
+            );
+            pipeline_trace::emit(
+                "grid_balance",
+                "done",
+                &[
+                    ("chrom", TraceValue::Str(&chrom)),
+                    ("buffers", TraceValue::Usize(weights.len())),
+                    ("slices", TraceValue::Usize(planned.len())),
+                    ("elapsed", TraceValue::Duration(t_w.elapsed())),
+                ],
+            );
+            for s in &planned {
+                let w: u64 = weights
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| {
+                        boundaries[*i].global_row >= s.emit_start_row
+                            && boundaries[*i].global_row < s.emit_end_row
+                    })
+                    .map(|(_, w)| *w)
+                    .sum();
+                pipeline_trace::emit(
+                    "grid_balance",
+                    "slice",
+                    &[
+                        ("worker_id", TraceValue::Usize(s.worker_id)),
+                        (
+                            "emit_rows",
+                            TraceValue::Usize(s.emit_end_row - s.emit_start_row),
+                        ),
+                        ("weight", TraceValue::Usize(w as usize)),
+                    ],
+                );
+            }
+            planned
+        } else {
+            plan_grid_partitions(&boundaries, config.annotation_workers, overlap_width_bp)
+        };
+        let _ = _total_rows;
+        grid_slices = slices;
+    }
+
+    let indexes = Arc::new(SharedContextIndexes::new(&ex, &tl));
+
+    // Open the per-contig custom-plugin registry when enabled and non-empty.
+    #[cfg(feature = "parquet-cache")]
+    let plugin_registry = match &config.plugin_cache_root {
+        Some(root) => {
+            let reg = crate::plugin_cache::registry::PluginRegistry::open(root, &chrom).await?;
+            if reg.is_empty() {
+                None
+            } else {
+                Some(Arc::new(reg))
+            }
+        }
+        None => None,
+    };
+
+    let shared_context = Arc::new(SharedContigAnnotationContext {
+        config: config.clone(),
+        profile: pipeline_profile.clone(),
+        base_transcripts,
+        overlap_width_bp,
+        base_translations: Arc::new(tl),
+        exons: Arc::new(ex),
+        indexes,
+        regulatory: Arc::new(rg),
+        motifs: Arc::new(mt),
+        // TODO: miRNA and structural features are not yet partitioned —
+        // these are rare and handled by the monolithic path only.
+        mirnas: Arc::new(Vec::new()),
+        structural: Arc::new(Vec::new()),
+        translateable_seq_by_tx: Arc::new(translateable_seq),
+        transcript_cache_regions,
+        tmp_provider: Arc::new(tmp_provider),
+        engine: Arc::new(engine),
+        #[cfg(feature = "parquet-cache")]
+        sift_prediction_store,
+        #[cfg(feature = "parquet-cache")]
+        plugin_registry,
+    });
+
+    // `pipeline_profile` is also held by the shared context now; use the cloned
+    // handle to record the shared-context build cost and this half's share of
+    // the prepare wall. The activation half records its own span.
+    let data_elapsed = t_data.elapsed();
+    record_contig_profile(&profile_handle, |profile| {
+        profile.prepare_shared_ctx += shared_ctx_started.elapsed();
+        profile.prepare_total += data_elapsed;
+    });
+    log_phase_rss(&chrom, "after_prepare_data");
+    pipeline_trace::emit(
+        "prefetch",
+        "data_done",
+        &[
+            ("chrom", TraceValue::Str(&chrom)),
+            ("elapsed", TraceValue::Duration(data_elapsed)),
+        ],
+    );
+
+    Ok(Some(ContigPreparedData {
+        chrom,
+        config,
+        cache,
+        pipeline_profile,
+        profile_handle,
+        ephemeral_tables,
+        shared_context,
+        grid_slices,
+        stateful_parallel,
+        var_table,
+        vcf_schema,
+        cache_schema,
+        fallback_coloc_sink,
+        t_contig,
+    }))
+}
+
+/// Activation half of contig preparation: build the `LookupProvider`s and spawn
+/// the lookup workers that feed the annotation workers.
+///
+/// Split out of `prepare_contig_data` because this is where the per-worker
+/// startup footprint is paid, and it must only be resident for the contig that
+/// is actually about to be annotated. Both the byte-budget/serial arms and the
+/// grid-aligned per-worker arm live here, so nothing is spawned by the data
+/// half. The consequence is that the byte-budget lookup build no longer
+/// overlaps the context load (the old `VEP_EARLY_WORKERS` interleave); that
+/// cost is paid back once the data half runs ahead of the contig.
+async fn activate_contig_lookups(
+    session: Arc<SessionContext>,
+    data: ContigPreparedData,
+) -> Result<Option<ContigReadyState>> {
+    let ContigPreparedData {
+        chrom,
+        config,
+        cache: _,
+        pipeline_profile,
+        profile_handle,
+        ephemeral_tables,
+        shared_context,
+        grid_slices,
+        stateful_parallel,
+        var_table,
+        vcf_schema,
+        cache_schema,
+        fallback_coloc_sink,
+        t_contig,
+    } = data;
+    let t_activate = Instant::now();
+    if profiling_enabled() {
+        eprintln!("[VEP_PROFILE] ------ contig {chrom} START ------");
+    }
+
+    #[cfg(feature = "parquet-cache")]
+    let cache_enabled = config.cache_root.is_some();
+    #[cfg(not(feature = "parquet-cache"))]
+    let cache_enabled = false;
+
+    // Lookup arm: build LookupProvider, create stream (cheap — build+probe
+    // happens on first poll, NOT here). Keep schema clones for the grid
+    // providers built further down.
     let grid_vcf_schema = vcf_schema.clone();
     let grid_cache_schema = cache_schema.clone();
     let mut provider = LookupProvider::new(
@@ -12826,9 +13237,9 @@ async fn prepare_contig_context(
     }
     let parallel_lookup = cache_enabled;
     let mut lookup_partitions = if stateful_parallel {
-        // Deferred: grid-aligned per-worker lookup scans are spawned after the
-        // context load below (once overlap_width_bp is known). The `provider`
-        // built above is unused on this path.
+        // The grid-aligned per-worker lookup scans are built below from the
+        // slices planned by the data half. The `provider` built above is unused
+        // on this path.
         VecDeque::new()
     } else if parallel_lookup {
         let session_state = session.state();
@@ -12891,400 +13302,126 @@ async fn prepare_contig_context(
         profile.lookup_partitions = lookup_partitions.len();
     });
 
-    // Context arm: load transcripts, exons, translations, etc. (Parquet only).
-    // Everything up to here (schema reads, lookup plan build, worker spawn) is
-    // setup that runs before any context data is loaded.
-    record_contig_profile(&pipeline_profile, |profile| {
-        profile.prepare_setup += t_contig.elapsed();
-    });
-
-    let context_fut = async {
-        let t_ctx = profile_start!();
-        pipeline_trace::emit("context", "start", &[("chrom", TraceValue::Str(&chrom))]);
-        let _ = cache_enabled;
+    if stateful_parallel {
+        let task_ctx = session.task_ctx();
+        // All workers of this contig probe the same variation shard, and the
+        // lookup is immutable once opened (its per-partition cursor is a
+        // stateless placeholder, and each probe opens its own file handle). Share
+        // one single-flight cell so the shard footer + page index are decoded
+        // once per contig rather than once per worker — the page index alone is
+        // ~0.5 GB for chr1, so per-worker loads dominated peak RSS. Scoped to
+        // this contig: it is rebuilt on the next activation.
         #[cfg(feature = "parquet-cache")]
-        {
-            let loaded =
-                load_contig_transcripts(cache.as_parquet(), &chrom, &config, &pipeline_profile)
-                    .await?;
-            let context_elapsed = t_ctx.elapsed();
-            pipeline_trace::emit(
-                "context",
-                "transcripts_done",
-                &[
-                    ("chrom", TraceValue::Str(&chrom)),
-                    ("transcripts", TraceValue::Usize(loaded.0.len())),
-                    ("elapsed", TraceValue::Duration(context_elapsed)),
-                ],
-            );
-            // context_load must cover ALL five entities. The transcripts are
-            // loaded here and the other four in load_contig_context_rest, and
-            // the two phases are strictly sequential (the grid plan needs the
-            // transcripts), so the total is their sum.
-            record_contig_profile(&pipeline_profile, |profile| {
-                profile.context_load += context_elapsed;
-            });
-            Ok(loaded)
-        }
-        #[cfg(not(feature = "parquet-cache"))]
-        {
-            unreachable!("parquet-cache feature is required")
-        }
-    };
-    // Cost-weighted grid split (opt-in). Resolved before the count pass because
-    // the weights need every row's position, which only that pass sees.
-    // Start the lookup workers as soon as the transcripts (the grid plan's only
-    // context dependency) are parsed, so they read VCF while the remaining four
-    // context entities still load. Opt out with VEP_EARLY_WORKERS=0.
-    let early_workers = stateful_parallel
-        && std::env::var("VEP_EARLY_WORKERS")
-            .ok()
-            .as_deref()
-            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-            .unwrap_or(true);
-    let grid_balance_enabled = stateful_parallel
-        && pipeline_trace::enabled_from_env_value(
-            std::env::var("VEP_GRID_BALANCE").ok().as_deref(),
-        );
-    // Run the grid count pass (VCF positions only) CONCURRENTLY with the context
-    // load (Parquet transcripts/exons) — independent IO, so the count is hidden
-    // behind context load instead of running as a serial prelude before workers.
-    let count_fut = async {
-        if stateful_parallel {
-            Some(
-                count_contig_buffer_boundaries(
-                    &session,
-                    &config.vcf_table,
-                    &chrom,
-                    config.input_buffer_size,
-                    grid_balance_enabled,
-                )
-                .await,
-            )
-        } else {
-            None
-        }
-    };
-    let context_result: Result<(Vec<TranscriptFeature>, HashMap<String, String>)>;
-    let grid_count;
-    (context_result, grid_count) = tokio::join!(context_fut, count_fut);
-    let (tx_vec, translateable_seq) = match context_result {
-        Ok(context) => context,
-        Err(e) => {
-            abort_lookup_partitions(&mut lookup_partitions);
-            return Err(e);
-        }
-    };
-    log_phase_rss(&chrom, "after_context_load");
-
-    let tmp_provider = AnnotateProvider::new(
-        Arc::clone(&session),
-        config.vcf_table.clone(),
-        String::new(),
-        AnnotationBackend::Parquet,
-        config.cache_source_type,
-        config.options_json.clone(),
-        vcf_only_schema,
-    )?;
-    let engine = TranscriptConsequenceEngine::new_with_hgvs_shift_and_semantics(
-        config.upstream_distance,
-        config.downstream_distance,
-        config.hgvs_flags.shift_hgvs,
-        config.vep_semantics,
-    );
-
-    // SIFT source: a shared per-contig prediction store loaded from the Parquet
-    // translation_sift shard.
-    #[cfg(feature = "parquet-cache")]
-    let use_lookup_sift = config.cache_root.is_some();
-    #[cfg(not(feature = "parquet-cache"))]
-    let use_lookup_sift = false;
-
-    #[cfg(feature = "parquet-cache")]
-    let sift_prediction_store = if use_lookup_sift && config.flags.everything {
-        let sift_started = Instant::now();
-        let store =
-            load_parquet_sift_prediction_store_for_chrom(cache.as_parquet(), &chrom).await?;
-        record_contig_profile(&pipeline_profile, |profile| {
-            profile.sift_load += sift_started.elapsed();
-        });
-        store
-    } else {
-        None
-    };
-    log_phase_rss(&chrom, "after_sift_load");
-
-    let shared_ctx_started = Instant::now();
-    let base_transcripts = Arc::new(tx_vec);
-    let transcript_cache_regions = Arc::new(
-        base_transcripts
-            .iter()
-            .map(|tx| (tx.transcript_id.clone(), transcript_cache_regions(tx)))
-            .collect(),
-    );
-    let overlap_width_bp = compute_overlap_width_bp(&base_transcripts);
-    let tx_ids: HashSet<String> = base_transcripts
-        .iter()
-        .map(|tx| tx.transcript_id.clone())
-        .collect();
-    let t_rest = Instant::now();
-    let rest_fut = async {
-        let rest =
-            load_contig_context_rest(cache.as_parquet(), &chrom, &pipeline_profile, &tx_ids).await;
-        let rest_elapsed = t_rest.elapsed();
-        pipeline_trace::emit(
-            "context",
-            "done",
-            &[
-                ("chrom", TraceValue::Str(&chrom)),
-                ("elapsed", TraceValue::Duration(rest_elapsed)),
-            ],
-        );
-        record_contig_profile(&pipeline_profile, |profile| {
-            profile.context_load += rest_elapsed;
-        });
-        rest
-    };
-
-    // Grid-aligned parallel lookup (stateful Merged/RefSeq, workers>1): a count
-    // pass finds the global 5000-unit buffer boundaries; each worker gets a
-    // whole-buffer rank range with a bounded-overlap warm-up start, and a lookup
-    // scan filtered to its `[scan_lo_pos, scan_hi_pos)` position window.
-    let grid_fut = async {
-        if stateful_parallel {
-            let (boundaries, _total_rows, grid_positions) =
-                grid_count.expect("stateful_parallel implies the count future ran")?;
-            // Cost-weighted grid split (opt-in via VEP_GRID_BALANCE). The default
-            // equal-buffer-count split equalises variants per worker, not work, so
-            // gene-dense slices straggle; weighting by transcript overlap equalises
-            // the thing that actually costs. Slice boundaries do not affect output
-            // (every worker count already yields byte-identical VCFs), so this is a
-            // scheduling change only.
-            let slices = if grid_balance_enabled {
-                let t_w = Instant::now();
-                let weights = buffer_transcript_weights(
-                    &boundaries,
-                    &grid_positions,
-                    base_transcripts.iter().map(|tx| (tx.start, tx.end)),
-                );
-                let planned = plan_grid_partitions_balanced(
-                    &boundaries,
-                    config.annotation_workers,
-                    overlap_width_bp,
-                    &weights,
-                );
-                pipeline_trace::emit(
-                    "grid_balance",
-                    "done",
-                    &[
-                        ("chrom", TraceValue::Str(&chrom)),
-                        ("buffers", TraceValue::Usize(weights.len())),
-                        ("slices", TraceValue::Usize(planned.len())),
-                        ("elapsed", TraceValue::Duration(t_w.elapsed())),
-                    ],
-                );
-                for s in &planned {
-                    let w: u64 = weights
-                        .iter()
-                        .enumerate()
-                        .filter(|(i, _)| {
-                            boundaries[*i].global_row >= s.emit_start_row
-                                && boundaries[*i].global_row < s.emit_end_row
-                        })
-                        .map(|(_, w)| *w)
-                        .sum();
-                    pipeline_trace::emit(
-                        "grid_balance",
-                        "slice",
-                        &[
-                            ("worker_id", TraceValue::Usize(s.worker_id)),
-                            (
-                                "emit_rows",
-                                TraceValue::Usize(s.emit_end_row - s.emit_start_row),
-                            ),
-                            ("weight", TraceValue::Usize(w as usize)),
-                        ],
-                    );
-                }
-                planned
-            } else {
-                plan_grid_partitions(&boundaries, config.annotation_workers, overlap_width_bp)
-            };
-            let _ = _total_rows;
-            let task_ctx = session.task_ctx();
-            // All workers of this contig probe the same variation shard, and the
-            // lookup is immutable once opened (its per-partition cursor is a
-            // stateless placeholder, and each probe opens its own file handle). Share
-            // one single-flight cell so the shard footer + page index are decoded
-            // once per contig rather than once per worker — the page index alone is
-            // ~0.5 GB for chr1, so per-worker loads dominated peak RSS. Scoped to
-            // this contig: it is rebuilt on the next `prepare_contig_context`.
-            #[cfg(feature = "parquet-cache")]
-            let shared_parquet_lookup_cell = Arc::new(tokio::sync::OnceCell::new());
-            // `session.state()` was cloned once per worker inside the loop.
-            let session_state = session.state();
-            let mut prepared: Vec<(usize, LookupProvider, ColocatedSink)> =
-                Vec::with_capacity(slices.len());
-            for (i, slice) in slices.iter().enumerate() {
-                let mut wprovider = LookupProvider::new(
-                    Arc::clone(&session),
-                    config.vcf_table.clone(),
-                    var_table.clone(),
-                    grid_vcf_schema.clone(),
-                    grid_cache_schema.clone(),
-                    config.cache_columns.clone(),
-                    config.extended_probes,
-                    config.allowed_failed,
-                )?;
-                // Restrict each worker to its [scan_lo_pos, scan_hi_pos) window so it
-                // reads ONLY its range's lookup (warm-up + emit) — no over-read. The
-                // full-contig worker below reads ALL partitions of this filtered plan
-                // (the earlier truncation was reading only partition 0, not a broken
-                // filter). The last worker has no upper bound (reads to contig end).
-                let mut filter = col("chrom")
-                    .eq(lit(&*chrom))
-                    .and(col("start").gt_eq(lit(slice.scan_lo_pos)));
-                if slice.scan_hi_pos != i64::MAX {
-                    filter = filter.and(col("start").lt(lit(slice.scan_hi_pos)));
-                }
-                wprovider.set_vcf_filter(Some(filter));
-                wprovider.set_target_partitions(config.target_partitions);
-                // Warm-up rows (strictly before this worker's seam) are read only to
-                // replay buffer state and are then discarded, so skip their variation
-                // probe. Worker 0 has no warm-up. Opt out with VEP_SKIP_WARMUP_LOOKUP=0.
-                let skip_warm_up_lookup = std::env::var("VEP_SKIP_WARMUP_LOOKUP")
-                    .ok()
-                    .as_deref()
-                    .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
-                    .unwrap_or(true);
-                if skip_warm_up_lookup && slice.scan_lo_pos < slice.emit_start_pos {
-                    wprovider.set_probe_floor_pos(Some(slice.emit_start_pos));
-                }
-                #[cfg(feature = "parquet-cache")]
-                if let Some(root) = &config.cache_root {
-                    wprovider.set_cache_root(root.clone());
-                    if config.parquet_backend {
-                        wprovider.set_parquet_backend(true);
-                    }
-                    wprovider.set_parquet_lookup_cell(Arc::clone(&shared_parquet_lookup_cell));
-                }
-                let sink: ColocatedSink = Arc::new(Mutex::new(HashMap::new()));
-                if config.flags.check_existing {
-                    wprovider.set_colocated_sink(Arc::clone(&sink));
-                }
-                prepared.push((i, wprovider, sink));
+        let shared_parquet_lookup_cell = Arc::new(tokio::sync::OnceCell::new());
+        // `session.state()` was cloned once per worker inside the loop.
+        let session_state = session.state();
+        let mut prepared: Vec<(usize, LookupProvider, ColocatedSink)> =
+            Vec::with_capacity(grid_slices.len());
+        for (i, slice) in grid_slices.iter().enumerate() {
+            let mut wprovider = LookupProvider::new(
+                Arc::clone(&session),
+                config.vcf_table.clone(),
+                var_table.clone(),
+                grid_vcf_schema.clone(),
+                grid_cache_schema.clone(),
+                config.cache_columns.clone(),
+                config.extended_probes,
+                config.allowed_failed,
+            )?;
+            // Restrict each worker to its [scan_lo_pos, scan_hi_pos) window so it
+            // reads ONLY its range's lookup (warm-up + emit) — no over-read. The
+            // full-contig worker below reads ALL partitions of this filtered plan
+            // (the earlier truncation was reading only partition 0, not a broken
+            // filter). The last worker has no upper bound (reads to contig end).
+            let mut filter = col("chrom")
+                .eq(lit(&*chrom))
+                .and(col("start").gt_eq(lit(slice.scan_lo_pos)));
+            if slice.scan_hi_pos != i64::MAX {
+                filter = filter.and(col("start").lt(lit(slice.scan_hi_pos)));
             }
-            // Each worker's physical plan is independent of the others, but they
-            // were built one after another, so this grew linearly with worker
-            // count and sat directly on the prelude's critical path.
-            let t_plans = Instant::now();
-            let concurrent_plans = std::env::var("VEP_CONCURRENT_PLANS")
+            wprovider.set_vcf_filter(Some(filter));
+            wprovider.set_target_partitions(config.target_partitions);
+            // Warm-up rows (strictly before this worker's seam) are read only to
+            // replay buffer state and are then discarded, so skip their variation
+            // probe. Worker 0 has no warm-up. Opt out with VEP_SKIP_WARMUP_LOOKUP=0.
+            let skip_warm_up_lookup = std::env::var("VEP_SKIP_WARMUP_LOOKUP")
                 .ok()
                 .as_deref()
                 .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
                 .unwrap_or(true);
-            let built: Vec<(usize, Arc<dyn ExecutionPlan>, ColocatedSink)> = if concurrent_plans {
-                futures::future::try_join_all(prepared.into_iter().map(|(i, wp, sink)| {
-                    let session_state = &session_state;
-                    async move {
-                        let plan = wp.scan(session_state, None, &[], None).await?;
-                        Ok::<_, DataFusionError>((i, plan, sink))
-                    }
-                }))
-                .await?
-            } else {
-                let mut out = Vec::with_capacity(prepared.len());
-                for (i, wp, sink) in prepared {
-                    let plan = wp.scan(&session_state, None, &[], None).await?;
-                    out.push((i, plan, sink));
+            if skip_warm_up_lookup && slice.scan_lo_pos < slice.emit_start_pos {
+                wprovider.set_probe_floor_pos(Some(slice.emit_start_pos));
+            }
+            #[cfg(feature = "parquet-cache")]
+            if let Some(root) = &config.cache_root {
+                wprovider.set_cache_root(root.clone());
+                if config.parquet_backend {
+                    wprovider.set_parquet_backend(true);
                 }
-                out
-            };
-            pipeline_trace::emit(
-                "grid_plans",
-                "done",
-                &[
-                    ("chrom", TraceValue::Str(&chrom)),
-                    ("workers", TraceValue::Usize(built.len())),
-                    ("elapsed", TraceValue::Duration(t_plans.elapsed())),
-                ],
-            );
-            for (i, plan, sink) in built {
-                lookup_partitions.push_back(spawn_lookup_full_contig_worker(
-                    Arc::clone(&plan),
-                    Arc::clone(&task_ctx),
-                    i, // logical id = shard / output order
-                    chrom.to_string(),
-                    sink,
-                    LOOKUP_PARTITION_QUEUE_BATCHES,
-                    pipeline_profile.clone(),
-                ));
+                wprovider.set_parquet_lookup_cell(Arc::clone(&shared_parquet_lookup_cell));
             }
-            grid_slices = slices;
-            record_contig_profile(&pipeline_profile, |profile| {
-                profile.lookup_partitions = lookup_partitions.len();
-            });
-        }
-        Ok::<(), DataFusionError>(())
-    };
-
-    // Either start the workers while the rest of the context loads (default), or
-    // reproduce the original ordering where nothing is spawned until the whole
-    // context is resident.
-    let (rest_result, grid_result) = if early_workers {
-        tokio::join!(rest_fut, grid_fut)
-    } else {
-        let rest = rest_fut.await;
-        let grid = grid_fut.await;
-        (rest, grid)
-    };
-    grid_result?;
-    let (ex, tl, rg, mt) = rest_result?;
-    let indexes = Arc::new(SharedContextIndexes::new(&ex, &tl));
-
-    // Open the per-contig custom-plugin registry when enabled and non-empty.
-    #[cfg(feature = "parquet-cache")]
-    let plugin_registry = match &config.plugin_cache_root {
-        Some(root) => {
-            let reg = crate::plugin_cache::registry::PluginRegistry::open(root, &chrom).await?;
-            if reg.is_empty() {
-                None
-            } else {
-                Some(Arc::new(reg))
+            let sink: ColocatedSink = Arc::new(Mutex::new(HashMap::new()));
+            if config.flags.check_existing {
+                wprovider.set_colocated_sink(Arc::clone(&sink));
             }
+            prepared.push((i, wprovider, sink));
         }
-        None => None,
-    };
+        // Each worker's physical plan is independent of the others, but they
+        // were built one after another, so this grew linearly with worker
+        // count and sat directly on the prelude's critical path.
+        let t_plans = Instant::now();
+        let concurrent_plans = std::env::var("VEP_CONCURRENT_PLANS")
+            .ok()
+            .as_deref()
+            .map(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+            .unwrap_or(true);
+        let built: Vec<(usize, Arc<dyn ExecutionPlan>, ColocatedSink)> = if concurrent_plans {
+            futures::future::try_join_all(prepared.into_iter().map(|(i, wp, sink)| {
+                let session_state = &session_state;
+                async move {
+                    let plan = wp.scan(session_state, None, &[], None).await?;
+                    Ok::<_, DataFusionError>((i, plan, sink))
+                }
+            }))
+            .await?
+        } else {
+            let mut out = Vec::with_capacity(prepared.len());
+            for (i, wp, sink) in prepared {
+                let plan = wp.scan(&session_state, None, &[], None).await?;
+                out.push((i, plan, sink));
+            }
+            out
+        };
+        pipeline_trace::emit(
+            "grid_plans",
+            "done",
+            &[
+                ("chrom", TraceValue::Str(&chrom)),
+                ("workers", TraceValue::Usize(built.len())),
+                ("elapsed", TraceValue::Duration(t_plans.elapsed())),
+            ],
+        );
+        for (i, plan, sink) in built {
+            lookup_partitions.push_back(spawn_lookup_full_contig_worker(
+                Arc::clone(&plan),
+                Arc::clone(&task_ctx),
+                i, // logical id = shard / output order
+                chrom.to_string(),
+                sink,
+                LOOKUP_PARTITION_QUEUE_BATCHES,
+                pipeline_profile.clone(),
+            ));
+        }
+        record_contig_profile(&pipeline_profile, |profile| {
+            profile.lookup_partitions = lookup_partitions.len();
+        });
+    }
 
-    let shared_context = Arc::new(SharedContigAnnotationContext {
-        config: config.clone(),
-        profile: pipeline_profile,
-        base_transcripts,
-        overlap_width_bp,
-        base_translations: Arc::new(tl),
-        exons: Arc::new(ex),
-        indexes,
-        regulatory: Arc::new(rg),
-        motifs: Arc::new(mt),
-        // TODO: miRNA and structural features are not yet partitioned —
-        // these are rare and handled by the monolithic path only.
-        mirnas: Arc::new(Vec::new()),
-        structural: Arc::new(Vec::new()),
-        translateable_seq_by_tx: Arc::new(translateable_seq),
-        transcript_cache_regions,
-        tmp_provider: Arc::new(tmp_provider),
-        engine: Arc::new(engine),
-        #[cfg(feature = "parquet-cache")]
-        sift_prediction_store,
-        #[cfg(feature = "parquet-cache")]
-        plugin_registry,
-    });
-
-    // `pipeline_profile` was moved into the shared context above; use the cloned
-    // handle to record the shared-context build cost and the total prepare wall.
+    // Second half of the prepare wall. Deliberately NOT `t_contig.elapsed()`:
+    // once the data half can run ahead, that span also covers the previous
+    // contig's annotation.
     record_contig_profile(&profile_handle, |profile| {
-        profile.prepare_shared_ctx += shared_ctx_started.elapsed();
-        profile.prepare_total += t_contig.elapsed();
+        profile.prepare_total += t_activate.elapsed();
     });
     log_phase_rss(&chrom, "after_prepare");
 

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -13579,6 +13579,18 @@ impl TableProvider for AnnotateProvider {
     }
 }
 
+/// VEP_CONTIG_PREFETCH gate: prefetch the next contig's data phase during the
+/// current contig's annotation. Default ON for parallel annotation (workers>1),
+/// where the idle prelude is on the critical path; "1"/"true" forces it on for
+/// workers=1 experiments, "0"/"false" disables it everywhere.
+fn contig_prefetch_enabled(annotation_workers: usize, env: Option<&str>) -> bool {
+    match env {
+        Some(v) if v == "0" || v.eq_ignore_ascii_case("false") => false,
+        Some(v) if v == "1" || v.eq_ignore_ascii_case("true") => true,
+        _ => annotation_workers > 1,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -13625,6 +13637,20 @@ mod tests {
             select_cache_backed_contigs(&["chr2".to_string()], &cache_chroms, Path::new("/cache"))
                 .unwrap_err();
         assert!(error.to_string().contains("none of the VCF"));
+    }
+
+    #[test]
+    fn contig_prefetch_gate_decision_table() {
+        // unset: on only for workers>1
+        assert!(!contig_prefetch_enabled(1, None));
+        assert!(contig_prefetch_enabled(2, None));
+        assert!(contig_prefetch_enabled(16, None));
+        // "0"/"false": always off
+        assert!(!contig_prefetch_enabled(8, Some("0")));
+        assert!(!contig_prefetch_enabled(8, Some("false")));
+        // "1"/"true": on even for workers=1 (experiment override)
+        assert!(contig_prefetch_enabled(1, Some("1")));
+        assert!(contig_prefetch_enabled(1, Some("true")));
     }
 
     /// `colocated::AF_COL_NAMES` is maintained by hand alongside `AF_COLUMNS`

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -12886,7 +12886,7 @@ async fn prepare_contig_data(
     // runs before any context data is loaded. The lookup plan build and worker
     // spawn are in `activate_contig_lookups` and are accounted for there.
     record_contig_profile(&pipeline_profile, |profile| {
-        profile.prepare_setup += t_contig.elapsed();
+        profile.prepare_setup += t_data.elapsed();
     });
 
     let context_fut = async {
@@ -13179,8 +13179,8 @@ async fn prepare_contig_data(
 /// is actually about to be annotated. Both the byte-budget/serial arms and the
 /// grid-aligned per-worker arm live here, so nothing is spawned by the data
 /// half. The consequence is that the byte-budget lookup build no longer
-/// overlaps the context load (the old `VEP_EARLY_WORKERS` interleave); that
-/// cost is paid back once the data half runs ahead of the contig.
+/// overlaps the context load (the removed early-worker interleave); that cost
+/// is paid back once the data half runs ahead of the contig.
 async fn activate_contig_lookups(
     session: Arc<SessionContext>,
     data: ContigPreparedData,

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -10773,21 +10773,56 @@ struct ContigAnnotationStream {
     next_global_shard_id: usize,
     /// In-flight prefetch of the NEXT contig's data phase (spawned when the
     /// current contig enters annotation; depth is always <= 1). The contig name
-    /// rides along so cleanup can log what was discarded. The task spawns no
-    /// lookup workers (data phase only), so aborting it leaks nothing.
+    /// rides along so cleanup can log what was discarded.
     ///
     /// The contig is popped off `contigs` at spawn time, so `StartContig` must
     /// consume this BEFORE it treats an empty queue as end-of-stream.
+    ///
+    /// Held through [`AbortOnDrop`] so the task cannot outlive the stream on
+    /// ANY path — including the window where the handle has been moved into the
+    /// `PreparingContig` future and the stream no longer owns it (dropping a
+    /// bare `JoinHandle` detaches the task instead of cancelling it).
+    ///
+    /// Cancellation caveats — abort is not synchronous and not total:
+    /// - `abort()` only lands at the task's next await point. The data phase
+    ///   does long inline CPU work between awaits (e.g. `parse_transcript_batches`
+    ///   inside `load_contig_transcripts`), so a cancelled prefetch can keep
+    ///   burning CPU until it reaches one.
+    /// - With `VEP_CTX_PARALLEL` enabled, `load_contig_context_rest` hands four
+    ///   parses to `spawn_blocking`; tokio cannot cancel blocking tasks, so
+    ///   those run to completion holding their `RecordBatch`es. That path is
+    ///   OFF by default (`enabled_from_env_value(None) == false`).
+    ///
+    /// The data phase registers no ephemeral session tables and spawns no
+    /// lookup workers, so an aborted prefetch leaves no dangling registration
+    /// or orphaned worker — only the transient work described above.
     ///
     /// Error semantics: a failed prefetch is not observed until its contig
     /// STARTS — the future built in `StartContig` awaits the handle and yields
     /// the error there. That preserves today's user-visible failure ordering:
     /// the current contig's annotation is never interrupted by a bad next
     /// contig.
-    prefetched_data: Option<(
-        String,
-        tokio::task::JoinHandle<Result<Option<ContigPreparedData>>>,
-    )>,
+    prefetched_data: Option<(String, AbortOnDrop)>,
+}
+
+/// Owns a spawned contig-prefetch task and aborts it when dropped.
+///
+/// A bare `tokio::task::JoinHandle` DETACHES its task on drop, which is the
+/// wrong default here: the prefetch holds an `Arc<SessionContext>` and an
+/// `Arc<PartitionedAnnotationCache>` and loads a whole contig context, so a
+/// detached one would keep running (GB-scale for chr1) after the query has been
+/// torn down. Teardown is routine — `LimitExec` drops its input once the LIMIT
+/// is satisfied, and any downstream/sibling error drops the plan.
+///
+/// Wrapping the handle makes cancellation follow ownership, so the guard also
+/// covers the window where the handle has been moved out of the stream and into
+/// the in-flight `PreparingContig` future: dropping that future drops the guard.
+struct AbortOnDrop(tokio::task::JoinHandle<Result<Option<ContigPreparedData>>>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 impl ContigAnnotationStream {
@@ -10841,19 +10876,22 @@ impl ContigAnnotationStream {
         let config = self.config.clone();
         let full_schema = self.full_schema.clone();
         let prefetch_chrom = chrom.clone();
+        // Emitted BEFORE the spawn so the trace order holds on a multi-thread
+        // runtime: the task's own `data_start` must never precede `spawned`.
+        pipeline_trace::emit("prefetch", "spawned", &[("chrom", TraceValue::Str(&chrom))]);
         let handle = tokio::spawn(async move {
             prepare_contig_data(session, cache, prefetch_chrom, config, full_schema).await
         });
-        pipeline_trace::emit("prefetch", "spawned", &[("chrom", TraceValue::Str(&chrom))]);
-        self.prefetched_data = Some((chrom, handle));
+        self.prefetched_data = Some((chrom, AbortOnDrop(handle)));
     }
 
     /// Drop an in-flight prefetch. Used by every path that abandons the stream
     /// (drop, error teardown, `Done`) so the spawned data phase cannot outlive
     /// the stream. Idempotent.
     fn abort_prefetch(&mut self) {
-        if let Some((chrom, handle)) = self.prefetched_data.take() {
-            handle.abort();
+        if let Some((chrom, guard)) = self.prefetched_data.take() {
+            // `AbortOnDrop::drop` does the abort; explicit for readability.
+            drop(guard);
             pipeline_trace::emit("prefetch", "aborted", &[("chrom", TraceValue::Str(&chrom))]);
         }
     }
@@ -12271,7 +12309,7 @@ impl Stream for ContigAnnotationStream {
                     // the LAST contig is prefetched the queue is empty while
                     // the work is still pending, and treating that as
                     // end-of-stream would silently drop a contig.
-                    let fut: PrepareFuture = if let Some((chrom, handle)) =
+                    let fut: PrepareFuture = if let Some((chrom, mut guard)) =
                         self.prefetched_data.take()
                     {
                         pipeline_trace::emit(
@@ -12280,8 +12318,12 @@ impl Stream for ContigAnnotationStream {
                             &[("chrom", TraceValue::Str(&chrom))],
                         );
                         let session = Arc::clone(&self.session);
+                        // `guard` is moved into the future, so cancellation
+                        // keeps following ownership: dropping this future
+                        // (stream torn down while PreparingContig) aborts the
+                        // task instead of detaching it.
                         Box::pin(async move {
-                            let data = handle.await.map_err(|e| {
+                            let data = Pin::new(&mut guard.0).await.map_err(|e| {
                                 DataFusionError::Execution(format!(
                                     "contig prefetch task failed: {e}"
                                 ))
@@ -13764,6 +13806,52 @@ mod tests {
         // "1"/"true": on even for workers=1 (experiment override)
         assert!(contig_prefetch_enabled(1, Some("1")));
         assert!(contig_prefetch_enabled(1, Some("true")));
+    }
+
+    /// The prefetch guard must CANCEL its task on drop, not detach it. A bare
+    /// `JoinHandle` detaches, which would let a contig data phase keep loading
+    /// GBs after the query was torn down (`LimitExec` dropping its input, or a
+    /// sibling-partition error). The task body below only sets the flag after
+    /// several await points, so a still-running task would set it.
+    #[tokio::test]
+    async fn abort_on_drop_cancels_the_prefetch_task() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let ran_to_completion = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&ran_to_completion);
+        let guard = AbortOnDrop(tokio::spawn(async move {
+            for _ in 0..64 {
+                tokio::task::yield_now().await;
+            }
+            flag.store(true, Ordering::SeqCst);
+            Ok(None)
+        }));
+
+        drop(guard);
+        // Give the runtime ample opportunity to schedule the task; an aborted
+        // task is never polled again, a detached one would finish here.
+        for _ in 0..256 {
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            !ran_to_completion.load(Ordering::SeqCst),
+            "dropping AbortOnDrop must cancel the spawned prefetch, not detach it"
+        );
+    }
+
+    /// The guard must not interfere with the normal path: when the future
+    /// awaits the handle to completion, the prefetch result comes through.
+    #[tokio::test]
+    async fn abort_on_drop_still_yields_the_result_when_awaited() {
+        let mut guard = AbortOnDrop(tokio::spawn(async {
+            tokio::task::yield_now().await;
+            Ok(None)
+        }));
+        let joined = Pin::new(&mut guard.0)
+            .await
+            .expect("task must not be aborted");
+        assert!(joined.expect("prefetch must succeed").is_none());
     }
 
     /// `colocated::AF_COL_NAMES` is maintained by hand alongside `AF_COLUMNS`

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -10093,8 +10093,9 @@ struct ContigPreparedData {
     /// Profile handle passed to the spawned lookup workers. Same `Arc` as
     /// `profile_handle`; kept separate so activation mirrors the pre-split code.
     pipeline_profile: Option<SharedContigPipelineProfile>,
-    /// Clone of the pipeline profile handle; the original was moved into
-    /// `shared_context`, and activation still records into it.
+    /// Second handle on the same `Arc` as `pipeline_profile` (the shared
+    /// context holds a clone of it too); activation records the prepare wall
+    /// into this one.
     profile_handle: Option<SharedContigPipelineProfile>,
     ephemeral_tables: Vec<String>,
     shared_context: Arc<SharedContigAnnotationContext>,
@@ -12349,7 +12350,7 @@ impl Stream for ContigAnnotationStream {
                         // (stream torn down while PreparingContig) aborts the
                         // task instead of detaching it.
                         Box::pin(async move {
-                            let data = Pin::new(&mut guard.0).await.map_err(|e| {
+                            let data = (&mut guard.0).await.map_err(|e| {
                                 DataFusionError::Execution(format!(
                                     "contig prefetch task failed: {e}"
                                 ))
@@ -12988,8 +12989,11 @@ async fn prepare_contig_data(
     let t_data = profile_start!();
     let pipeline_profile =
         profiling_enabled().then(|| Arc::new(Mutex::new(ContigPipelineProfile::default())));
-    // Cloned handle so prepare_shared_ctx / prepare_total can still be recorded
-    // after `pipeline_profile` is moved into the shared context below.
+    // Second handle on the same profile `Arc`. `pipeline_profile` is cloned --
+    // not moved -- into the shared context below and stays live for the rest of
+    // this half; the separate binding keeps the pre-split shape, where
+    // prepare_shared_ctx / prepare_total are recorded through `profile_handle`
+    // and it is what `activate_contig_lookups` records into.
     let profile_handle = pipeline_profile.clone();
     // The `contig START` banner belongs to the half that actually starts the
     // contig, so it lives in `activate_contig_lookups`.
@@ -13893,9 +13897,7 @@ mod tests {
             tokio::task::yield_now().await;
             Ok(None)
         }));
-        let joined = Pin::new(&mut guard.0)
-            .await
-            .expect("task must not be aborted");
+        let joined = (&mut guard.0).await.expect("task must not be aborted");
         assert!(joined.expect("prefetch must succeed").is_none());
     }
 

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -10111,9 +10111,6 @@ struct ContigPreparedData {
     cache_schema: Schema,
     /// Colocated sink used by the serial (single-partition) lookup arm.
     fallback_coloc_sink: ColocatedSink,
-    /// Contig wall-clock start, carried through to `ContigReadyState` for the
-    /// downstream contig END timing.
-    t_contig: Instant,
 }
 
 /// Everything needed to start streaming annotation for a contig.
@@ -10127,7 +10124,13 @@ struct ContigReadyState {
     shared_context: Arc<SharedContigAnnotationContext>,
     ephemeral_tables: Vec<String>,
     chrom: String,
-    t_contig: Instant,
+    /// Origin of this contig's OWN wall clock, started in
+    /// `activate_contig_lookups`. Deliberately not started in
+    /// `prepare_contig_data`: under `VEP_CONTIG_PREFETCH` the data half runs
+    /// during the PREVIOUS contig's annotation, so a data-phase instant would
+    /// fold that window into this contig's `TOTAL` / `variation_lookup` spans
+    /// and make per-contig totals sum to far more than the run's wall time.
+    t_contig_active: Instant,
 }
 
 /// Mutable annotation state for window-based streaming within a single contig.
@@ -10139,7 +10142,9 @@ struct ContigAnnotationState {
     chrom: String,
     config: ContigAnnotationConfig,
     session: Arc<SessionContext>,
-    t_contig: Instant,
+    /// See `ContigReadyState::t_contig_active`: activation-origin instant, so
+    /// the `TOTAL` / `variation_lookup` spans exclude the prefetch overlap.
+    t_contig_active: Instant,
     contig_rows: usize,
     lookup_wait_started: Option<Instant>,
     ordered_lookup_wait_started: Option<Instant>,
@@ -10178,7 +10183,9 @@ struct ParallelContigState {
     chrom: String,
     config: ContigAnnotationConfig,
     session: Arc<SessionContext>,
-    t_contig: Instant,
+    /// See `ContigReadyState::t_contig_active`: activation-origin instant, so
+    /// the `TOTAL` span excludes the prefetch overlap.
+    t_contig_active: Instant,
     shared: Arc<SharedContigAnnotationContext>,
 }
 
@@ -10801,7 +10808,16 @@ struct ContigAnnotationStream {
     /// STARTS — the future built in `StartContig` awaits the handle and yields
     /// the error there. That preserves today's user-visible failure ordering:
     /// the current contig's annotation is never interrupted by a bad next
-    /// contig.
+    /// contig. Failure ORDERING is preserved; failure KIND is not: a panic
+    /// inside a prefetched data phase comes back as a `JoinError` and is
+    /// reported as `DataFusionError::Execution("contig prefetch task failed:
+    /// …")`, whereas on the gate-OFF path the same panic unwinds through the
+    /// caller as a panic.
+    ///
+    /// `VEP_CONTIG_PREFETCH=0` is a kill switch for the prefetch, NOT a
+    /// rollback to master: the data/activate split also removed the
+    /// `VEP_EARLY_WORKERS` interleave, and turning the gate off does not
+    /// reinstate it (see `contig_prefetch_enabled`).
     prefetched_data: Option<(String, AbortOnDrop)>,
 }
 
@@ -10859,6 +10875,15 @@ impl ContigAnnotationStream {
     fn start_prefetch_next_contig(&mut self) {
         if self.prefetched_data.is_some() {
             // Depth stays at one.
+            return;
+        }
+        if self.config.fetch_limit.is_some() {
+            // LIMIT queries usually finish inside the current contig, and
+            // `StartContig` throws an un-consumed prefetch away once the limit
+            // is satisfied. Loading a whole next-contig context speculatively
+            // would just burn IO against the query it is meant to accelerate.
+            // Deliberately not a remaining-rows estimate: rows-per-contig is
+            // unknown here, so `is_some()` is the honest test.
             return;
         }
         if !contig_prefetch_enabled(
@@ -12272,7 +12297,7 @@ fn poll_lookup_partitions(
                 ann.worker.lookup_done = true;
                 profile_end!(
                     &format!("{}: 1. variation_lookup", ann.chrom),
-                    ann.t_contig,
+                    ann.t_contig_active,
                     format!("{} rows", ann.contig_rows)
                 );
                 return Poll::Ready(Ok(()));
@@ -12354,6 +12379,13 @@ impl Stream for ContigAnnotationStream {
                 StreamState::PreparingContig(fut) => match fut.as_mut().poll(cx) {
                     Poll::Pending => return Poll::Pending,
                     Poll::Ready(Err(e)) => {
+                        // No prefetch can be in flight anywhere in this state:
+                        // `StartContig` moved any pending one into `fut`, and
+                        // the next spawn only happens once this contig reaches
+                        // annotation. The `abort_prefetch()` calls in this arm
+                        // and in the activation arms below are therefore
+                        // defensive no-ops — kept because they are idempotent
+                        // and make every teardown path uniformly safe.
                         self.abort_prefetch();
                         self.state = StreamState::Done;
                         return Poll::Ready(Some(Err(e)));
@@ -12477,7 +12509,7 @@ impl Stream for ContigAnnotationStream {
                                 chrom: ready.chrom,
                                 config,
                                 session,
-                                t_contig: ready.t_contig,
+                                t_contig_active: ready.t_contig_active,
                                 shared,
                             };
                             self.state = StreamState::AnnotatingParallel(state);
@@ -12506,7 +12538,7 @@ impl Stream for ContigAnnotationStream {
                                 chrom: ready.chrom,
                                 config,
                                 session,
-                                t_contig: ready.t_contig,
+                                t_contig_active: ready.t_contig_active,
                                 contig_rows: 0,
                                 lookup_wait_started: None,
                                 ordered_lookup_wait_started: None,
@@ -12556,7 +12588,7 @@ impl Stream for ContigAnnotationStream {
                             }
                             profile_end!(
                                 &format!("{}: TOTAL", state.chrom),
-                                state.t_contig,
+                                state.t_contig_active,
                                 format!("{contig_rows} rows")
                             );
                             emit_contig_pipeline_profile(&state.shared.profile, &state.chrom);
@@ -12706,7 +12738,7 @@ impl Stream for ContigAnnotationStream {
                     // Drop heavy state eagerly before the async cleanup future runs.
                     profile_end!(
                         &format!("{}: TOTAL", ann.chrom),
-                        ann.t_contig,
+                        ann.t_contig_active,
                         format!("{} rows", ann.contig_rows)
                     );
                     emit_contig_pipeline_profile(&ann.worker.shared.profile, &ann.chrom);
@@ -12947,11 +12979,12 @@ async fn prepare_contig_data(
     mut config: ContigAnnotationConfig,
     full_schema: SchemaRef,
 ) -> Result<Option<ContigPreparedData>> {
-    let t_contig = profile_start!();
-    // Dedicated span for this half. `t_contig` is carried through to
-    // `ContigReadyState` for the contig END timing, so it must not be used for
-    // the prepare accounting once the two halves can run apart.
-    let t_data = Instant::now();
+    // Span for this half ONLY. No contig-wide instant is started here: under
+    // `VEP_CONTIG_PREFETCH` this function runs during the PREVIOUS contig's
+    // annotation, so anything anchored here would fold that window into this
+    // contig's timings. The contig's own wall clock (`t_contig_active`) starts
+    // in `activate_contig_lookups`, where the contig genuinely begins.
+    let t_data = profile_start!();
     let pipeline_profile =
         profiling_enabled().then(|| Arc::new(Mutex::new(ContigPipelineProfile::default())));
     // Cloned handle so prepare_shared_ctx / prepare_total can still be recorded
@@ -13323,7 +13356,6 @@ async fn prepare_contig_data(
         vcf_schema,
         cache_schema,
         fallback_coloc_sink,
-        t_contig,
     }))
 }
 
@@ -13354,9 +13386,13 @@ async fn activate_contig_lookups(
         vcf_schema,
         cache_schema,
         fallback_coloc_sink,
-        t_contig,
     } = data;
+    // Two instants, one origin. Activation is the point where the contig
+    // genuinely begins, so it anchors BOTH the second-half prepare span and the
+    // contig's own wall clock. The data half cannot anchor either one: under
+    // `VEP_CONTIG_PREFETCH` it ran during the previous contig's annotation.
     let t_activate = Instant::now();
+    let t_contig_active = t_activate;
     if profiling_enabled() {
         eprintln!("[VEP_PROFILE] ------ contig {chrom} START ------");
     }
@@ -13572,9 +13608,9 @@ async fn activate_contig_lookups(
         });
     }
 
-    // Second half of the prepare wall. Deliberately NOT `t_contig.elapsed()`:
-    // once the data half can run ahead, that span also covers the previous
-    // contig's annotation.
+    // Second half of the prepare wall. Deliberately anchored at activation, not
+    // at the data phase: once the data half can run ahead, a data-phase span
+    // also covers the previous contig's annotation.
     record_contig_profile(&profile_handle, |profile| {
         profile.prepare_total += t_activate.elapsed();
     });
@@ -13586,7 +13622,7 @@ async fn activate_contig_lookups(
         shared_context,
         ephemeral_tables,
         chrom,
-        t_contig,
+        t_contig_active,
     }))
 }
 
@@ -13738,6 +13774,14 @@ impl TableProvider for AnnotateProvider {
 /// current contig's annotation. Default ON for parallel annotation (workers>1),
 /// where the idle prelude is on the critical path; "1"/"true" forces it on for
 /// workers=1 experiments, "0"/"false" disables it everywhere.
+///
+/// Turning the gate OFF is not a like-for-like master baseline. Splitting
+/// prepare into data/activate also deleted the `VEP_EARLY_WORKERS` interleave
+/// (`tokio::join!(rest_fut, grid_fut)`), which on master overlapped the grid
+/// provider/plan build and worker spawn with `load_contig_context_rest` for
+/// workers>1 on Merged/RefSeq caches; `activate_contig_lookups` is strictly
+/// serial. The gate disables prefetching only — gate-OFF is master MINUS that
+/// removed overlap, so A/B numbers against it are not master numbers.
 fn contig_prefetch_enabled(annotation_workers: usize, env: Option<&str>) -> bool {
     match env {
         Some(v) if v == "0" || v.eq_ignore_ascii_case("false") => false,
@@ -14273,7 +14317,7 @@ mod tests {
             chrom: "chr1".to_string(),
             config,
             session: Arc::new(SessionContext::new()),
-            t_contig: Instant::now(),
+            t_contig_active: Instant::now(),
             contig_rows: 0,
             lookup_wait_started: None,
             ordered_lookup_wait_started: None,

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -10089,7 +10089,6 @@ struct ContigPreparedData {
     /// Post identity-validation config (`vep_semantics` resolved from the
     /// contig's cache shards).
     config: ContigAnnotationConfig,
-    cache: Arc<PartitionedAnnotationCache>,
     /// Profile handle passed to the spawned lookup workers. Same `Arc` as
     /// `profile_handle`; kept separate so activation mirrors the pre-split code.
     pipeline_profile: Option<SharedContigPipelineProfile>,
@@ -10772,6 +10771,23 @@ struct ContigAnnotationStream {
     /// worker-minor) for the `threads>1` sharded-output path. Monotonic across
     /// contigs so `vcf_sink` concatenates shards in ascending = position order.
     next_global_shard_id: usize,
+    /// In-flight prefetch of the NEXT contig's data phase (spawned when the
+    /// current contig enters annotation; depth is always <= 1). The contig name
+    /// rides along so cleanup can log what was discarded. The task spawns no
+    /// lookup workers (data phase only), so aborting it leaks nothing.
+    ///
+    /// The contig is popped off `contigs` at spawn time, so `StartContig` must
+    /// consume this BEFORE it treats an empty queue as end-of-stream.
+    ///
+    /// Error semantics: a failed prefetch is not observed until its contig
+    /// STARTS — the future built in `StartContig` awaits the handle and yields
+    /// the error there. That preserves today's user-visible failure ordering:
+    /// the current contig's annotation is never interrupted by a bad next
+    /// contig.
+    prefetched_data: Option<(
+        String,
+        tokio::task::JoinHandle<Result<Option<ContigPreparedData>>>,
+    )>,
 }
 
 impl ContigAnnotationStream {
@@ -10793,10 +10809,57 @@ impl ContigAnnotationStream {
             state: StreamState::StartContig,
             rows_emitted: 0,
             next_global_shard_id: 0,
+            prefetched_data: None,
+        }
+    }
+
+    /// Spawn the NEXT contig's data phase so it overlaps the current contig's
+    /// annotation. Called immediately after the stream commits to annotating a
+    /// contig (serial and sharded paths alike).
+    ///
+    /// The task is `tokio::spawn`ed rather than stored as a bare future on
+    /// purpose: the stream only makes progress when the consumer polls it, so
+    /// an unspawned future would not run until `StartContig` awaited it — i.e.
+    /// no prefetch at all.
+    fn start_prefetch_next_contig(&mut self) {
+        if self.prefetched_data.is_some() {
+            // Depth stays at one.
+            return;
+        }
+        if !contig_prefetch_enabled(
+            self.config.annotation_workers,
+            std::env::var("VEP_CONTIG_PREFETCH").ok().as_deref(),
+        ) {
+            return;
+        }
+        // Pop the contig NOW so `StartContig` cannot double-prepare it.
+        let Some(chrom) = self.contigs.pop_front() else {
+            return;
+        };
+        let session = Arc::clone(&self.session);
+        let cache = Arc::clone(&self.cache);
+        let config = self.config.clone();
+        let full_schema = self.full_schema.clone();
+        let prefetch_chrom = chrom.clone();
+        let handle = tokio::spawn(async move {
+            prepare_contig_data(session, cache, prefetch_chrom, config, full_schema).await
+        });
+        pipeline_trace::emit("prefetch", "spawned", &[("chrom", TraceValue::Str(&chrom))]);
+        self.prefetched_data = Some((chrom, handle));
+    }
+
+    /// Drop an in-flight prefetch. Used by every path that abandons the stream
+    /// (drop, error teardown, `Done`) so the spawned data phase cannot outlive
+    /// the stream. Idempotent.
+    fn abort_prefetch(&mut self) {
+        if let Some((chrom, handle)) = self.prefetched_data.take() {
+            handle.abort();
+            pipeline_trace::emit("prefetch", "aborted", &[("chrom", TraceValue::Str(&chrom))]);
         }
     }
 
     fn cleanup_registered_tables_on_drop(&mut self) {
+        self.abort_prefetch();
         match &mut self.state {
             StreamState::AnnotatingContig(ann) => {
                 abort_annotation_lookup_partitions(ann);
@@ -12195,29 +12258,61 @@ impl Stream for ContigAnnotationStream {
 
                 StreamState::StartContig => {
                     // LIMIT pushdown: stop processing contigs if limit reached.
+                    // Checked BEFORE the prefetch is consumed so a satisfied
+                    // LIMIT throws the prefetched contig away instead of paying
+                    // for its activation.
                     if fetch_limit.is_some_and(|limit| rows_emitted >= limit) {
+                        self.abort_prefetch();
                         self.state = StreamState::Done;
                         return Poll::Ready(None);
                     }
-                    let Some(chrom) = self.contigs.pop_front() else {
-                        // All contigs processed.
-                        self.state = StreamState::Done;
-                        return Poll::Ready(None);
-                    };
-                    let session = Arc::clone(&self.session);
-                    let cache = Arc::clone(&self.cache);
-                    let config = self.config.clone();
-                    let full_schema = self.full_schema.clone();
+                    // The prefetch already popped its contig off `contigs`, so
+                    // it must be consumed BEFORE the queue-empty check: after
+                    // the LAST contig is prefetched the queue is empty while
+                    // the work is still pending, and treating that as
+                    // end-of-stream would silently drop a contig.
+                    let fut: PrepareFuture = if let Some((chrom, handle)) =
+                        self.prefetched_data.take()
+                    {
+                        pipeline_trace::emit(
+                            "prefetch",
+                            "consumed",
+                            &[("chrom", TraceValue::Str(&chrom))],
+                        );
+                        let session = Arc::clone(&self.session);
+                        Box::pin(async move {
+                            let data = handle.await.map_err(|e| {
+                                DataFusionError::Execution(format!(
+                                    "contig prefetch task failed: {e}"
+                                ))
+                            })??;
+                            match data {
+                                None => Ok(None),
+                                Some(data) => activate_contig_lookups(session, data).await,
+                            }
+                        })
+                    } else {
+                        let Some(chrom) = self.contigs.pop_front() else {
+                            // All contigs processed.
+                            self.state = StreamState::Done;
+                            return Poll::Ready(None);
+                        };
+                        let session = Arc::clone(&self.session);
+                        let cache = Arc::clone(&self.cache);
+                        let config = self.config.clone();
+                        let full_schema = self.full_schema.clone();
 
-                    let fut: PrepareFuture = Box::pin(async move {
-                        prepare_contig_context(session, cache, chrom, config, full_schema).await
-                    });
+                        Box::pin(async move {
+                            prepare_contig_context(session, cache, chrom, config, full_schema).await
+                        })
+                    };
                     self.state = StreamState::PreparingContig(fut);
                 }
 
                 StreamState::PreparingContig(fut) => match fut.as_mut().poll(cx) {
                     Poll::Pending => return Poll::Pending,
                     Poll::Ready(Err(e)) => {
+                        self.abort_prefetch();
                         self.state = StreamState::Done;
                         return Poll::Ready(Some(Err(e)));
                     }
@@ -12238,6 +12333,7 @@ impl Stream for ContigAnnotationStream {
                             // producer of the "threads" option), which sets
                             // vcf_shard_ctx.
                             let Some(shard_ctx) = config.vcf_shard_ctx.clone() else {
+                                self.abort_prefetch();
                                 self.state = StreamState::Done;
                                 return Poll::Ready(Some(Err(DataFusionError::Internal(
                                     "parallel annotation (threads>1) requires a VCF shard \
@@ -12298,6 +12394,7 @@ impl Stream for ContigAnnotationStream {
                                 for h in &lookup_join {
                                     h.abort();
                                 }
+                                self.abort_prefetch();
                                 self.state = StreamState::Done;
                                 return Poll::Ready(Some(Err(DataFusionError::Internal(
                                     "parallel annotation (threads>1) requires spawned lookup \
@@ -12342,6 +12439,9 @@ impl Stream for ContigAnnotationStream {
                                 shared,
                             };
                             self.state = StreamState::AnnotatingParallel(state);
+                            // Committed to annotating this contig: overlap the
+                            // NEXT contig's data phase with it.
+                            self.start_prefetch_next_contig();
                         } else {
                             let worker =
                                 match AnnotationWorkerState::new(Arc::clone(&ready.shared_context))
@@ -12349,6 +12449,7 @@ impl Stream for ContigAnnotationStream {
                                     Ok(worker) => worker,
                                     Err(e) => {
                                         abort_lookup_partitions(&mut ready.lookup_partitions);
+                                        self.abort_prefetch();
                                         self.state = StreamState::Done;
                                         return Poll::Ready(Some(Err(e)));
                                     }
@@ -12370,6 +12471,9 @@ impl Stream for ContigAnnotationStream {
                                 inflight: VecDeque::new(),
                             };
                             self.state = StreamState::AnnotatingContig(ann);
+                            // Committed to annotating this contig: overlap the
+                            // NEXT contig's data phase with it.
+                            self.start_prefetch_next_contig();
                         }
                     }
                 },
@@ -12428,6 +12532,9 @@ impl Stream for ContigAnnotationStream {
                                 std::mem::take(&mut state.ephemeral_tables),
                             );
                             self.state = StreamState::ErrorCleaningUp(fut, e);
+                            // The run ends with this error; the next contig
+                            // will never start, so drop its prefetch.
+                            self.abort_prefetch();
                             continue;
                         }
                     }
@@ -12483,6 +12590,7 @@ impl Stream for ContigAnnotationStream {
                                     make_cleanup_future(session, tables),
                                     e,
                                 );
+                                self.abort_prefetch();
                                 continue;
                             }
                         }
@@ -12609,6 +12717,7 @@ impl Stream for ContigAnnotationStream {
                                 std::mem::take(&mut ann.ephemeral_tables),
                             );
                             self.state = StreamState::ErrorCleaningUp(fut, e);
+                            self.abort_prefetch();
                             continue;
                         }
                         Poll::Ready(Err(join_err)) => {
@@ -12621,6 +12730,7 @@ impl Stream for ContigAnnotationStream {
                                 fut,
                                 DataFusionError::External(Box::new(join_err)),
                             );
+                            self.abort_prefetch();
                             continue;
                         }
                     }
@@ -12673,10 +12783,13 @@ impl Stream for ContigAnnotationStream {
                 StreamState::CleaningUp(fut) => match fut.as_mut().poll(cx) {
                     Poll::Pending => return Poll::Pending,
                     Poll::Ready(Err(e)) => {
+                        // Terminal: the prefetched contig will never start.
+                        self.abort_prefetch();
                         self.state = StreamState::Done;
                         return Poll::Ready(Some(Err(e)));
                     }
                     Poll::Ready(Ok(())) => {
+                        // The prefetch (if any) is consumed by `StartContig`.
                         self.state = StreamState::StartContig;
                     }
                 },
@@ -12690,6 +12803,7 @@ impl Stream for ContigAnnotationStream {
                         else {
                             unreachable!()
                         };
+                        self.abort_prefetch();
                         return Poll::Ready(Some(Err(original_err)));
                     }
                 },
@@ -12697,6 +12811,7 @@ impl Stream for ContigAnnotationStream {
                 StreamState::FinalCleanup(fut) => match fut.as_mut().poll(cx) {
                     Poll::Pending => return Poll::Pending,
                     Poll::Ready(_) => {
+                        self.abort_prefetch();
                         self.state = StreamState::Done;
                         return Poll::Ready(None);
                     }
@@ -13156,7 +13271,6 @@ async fn prepare_contig_data(
     Ok(Some(ContigPreparedData {
         chrom,
         config,
-        cache,
         pipeline_profile,
         profile_handle,
         ephemeral_tables,
@@ -13188,7 +13302,6 @@ async fn activate_contig_lookups(
     let ContigPreparedData {
         chrom,
         config,
-        cache: _,
         pipeline_profile,
         profile_handle,
         ephemeral_tables,

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -9210,9 +9210,10 @@ async fn load_contig_context_rest(
     tx_ids: &HashSet<String>,
 ) -> Result<ContigContextRest> {
     // The four scans are mutually independent and the parses are CPU-bound, so
-    // by default they run concurrently. VEP_CTX_PARALLEL=0 forces the original
-    // strictly serial order, which keeps the A/B honest and gives an opt-out
-    // when the extra concurrency would contend with something else.
+    // they CAN run concurrently — but the default is the original strictly
+    // serial order: `enabled_from_env_value(None)` is false, so concurrency is
+    // opt-in via VEP_CTX_PARALLEL=1. Serial-by-default keeps the A/B honest and
+    // avoids contending with the rest of the pipeline unless asked.
     let concurrent =
         pipeline_trace::enabled_from_env_value(std::env::var("VEP_CTX_PARALLEL").ok().as_deref());
 


### PR DESCRIPTION
## What

Contigs were processed strictly serially: each contig's `prepare_contig_context` — the parquet transcript/exon/translation scans, the grid count pass, SIFT, shared-index build — ran with **every annotation worker idle**, and only then did annotation start. At `workers=8` that idle prelude was ~24% of WGS wall time, and it got *worse* with more workers (~31% at `workers=16`), because the contig's N lookup readers spin up concurrently with those scans.

This PR splits `prepare_contig_context` into a **data phase** (everything up to and including grid-slice planning) and an **activation phase** (lookup provider build + plan scan + worker spawn), then `tokio::spawn`s the *next* contig's data phase the moment the current contig enters annotation. The prepare cost is overlapped instead of stalled on.

Gate: `VEP_CONTIG_PREFETCH` — default ON for `workers>1`, `"1"`/`"true"` forces it on at any worker count, `"0"`/`"false"` disables it.

This is a port of the #206/#208 lineage onto post-#209 master. Those PRs were merged into each other as a stacked pair and never reached `master`, and #209 rewrote the same region of `annotate_provider.rs`, so a rebase was not viable — this is a re-implementation against the current structure.

## Mechanism evidence (the primary result)

Per-contig **activation gap** — dead time between one contig finishing and the next activating, which is exactly what this change targets:

| run | median gap | max gap | contigs ≥0.5 s | summed |
|---|---|---|---|---|
| `workers=8`, gate OFF | 0.612 s | 1.084 s | **14 / 21** | 12.72 s |
| `workers=8`, gate ON | **0.016 s** | **0.029 s** | **0 / 21** | 0.32 s |
| `workers=16`, gate OFF | 0.776 s | 1.222 s | **19 / 21** | 16.26 s |
| `workers=16`, gate ON | **0.016 s** | **0.027 s** | **0 / 21** | 0.33 s |

A ~40× collapse, uniform across every contig — not an average hiding outliers.

## Wall time and scaling vs actual `origin/master`

Full 1→16 sweep against `origin/master` (ce5c64a), HG002 WGS / 4,096,123 variants / merged 116 cache / plain output, 12P+4E Apple M-series. Medians over every run of 2026-08-12 (38 WGS runs total), with the observed min–max:

| workers | n | master | this branch | delta |
|---|---|---|---|---|
| 1 (control, gate off) | 1 | 275.1 s | 282.6 s | +2.7% |
| 2 | 1 | 154.0 s | 151.5 s | −1.6% |
| 4 | 3 | 106.2 s | 98.0 s | **−7.7%** |
| 8 | 4 | 84.2 s (76.6–101.6) | 79.1 s (74.4–81.0) | **−6.1%** |
| 12 | 4 | 78.0 s (77.1–82.9) | **68.5 s** (67.0–68.9) | **−12.1%** |
| 16 | 4 | 85.6 s (82.3–87.4) | 81.4 s (72.4–93.4) | **−4.9%** |

**Both arms peak at 12 workers.** At that peak the branch is 12% faster in wall time (78.0 → 68.5 s) and reaches **4.12x vs 3.53x** self-relative speedup. The branch is faster at every worker count from 4 up; `workers=1` is a control (the gate is off there) and its +2.7% marks the noise floor.

### Decomposition: the two changes pull in opposite directions

The branch does two separable things. Running the same binary with the gate forced off isolates them:

| workers | master → gate OFF (cost of the removed `VEP_EARLY_WORKERS` interleave) | gate OFF → gate ON (the prefetch itself) | net |
|---|---|---|---|
| 4 | +1.5% | −9.1% | −7.7% |
| 8 | +1.2% | −7.2% | −6.1% |
| 12 | +5.6% | −16.8% | −12.1% |
| 16 | +5.1% | −9.6% | −4.9% |

The prefetch is worth 7–17%; removing the interleave gives 1–6% back, and that cost **grows with worker count** (more per-worker lookup plans to build serially). **Restoring an interleave inside `activate_contig_lookups` is the obvious follow-up** — it looks worth ~5% at 12–16 workers.

Why the win grows with worker count at all is just Amdahl: the serial prepare is 15.6% of wall at 4 workers, 24% at 8, and 31% at 16, which bounds what overlapping it can return.

### Variance — read the ranges, not the point estimates

The prefetch also makes runtime **more predictable**, which may matter more than the mean. Master's `workers=8` timing spans 76.6–101.6 s across four runs (**33% spread**); the branch spans 74.4–81.0 s (8.9%). That follows from the mechanism: on master the serial prepare is a single-threaded bottleneck with every worker parked, so ambient load stretches the critical path directly; hiding it behind annotation absorbs that.

That variance is also why two earlier revisions of this description carried wrong numbers — one claimed −11% at `workers=8`, the next "corrected" it to +5.6% (a regression). Both were n=2 reads of a point whose spread is 33%. The table above supersedes both. On this shared machine, **treat any single ±5% point estimate as noise; the reproducible facts are the direction at every worker count ≥4, the 12-worker peak, and the variance reduction.**

## Cost

Peak RSS rises **~1.3–1.7 GB** across the sweep (8.11→8.99 GB at `workers=8`; 9.11→10.78 GB at `workers=16`; identical 3.98 GB at `workers=1`, where the gate is off) — one extra contig's context is resident during the overlap. This is inherent to prefetching and matches the predicted ~1.7 GB. Not optional when the gate is on.

## Correctness

Output is **byte-identical**. Same SHA-256 (`f0de05c1…be7edb2`) and same byte count (29,410,585,470) across all four of: `origin/master`, the refactor commit alone, gate-OFF, and gate-ON, on the full 29.4 GB / 4.1 M-variant WGS output.

- 896 Rust unit tests; `clippy --all-targets` zero warnings (verified on forced recompile); `cargo fmt --check` clean.
- vepyr's Python suite: 156 tests pass both by default and with `VEP_CONTIG_PREFETCH=1` forced on (which is what exercises the prefetch path at `workers=1`).
- Two `#[tokio::test]`s cover the abort-on-drop guard; the cancel test was mutation-checked (neutering the `Drop` impl makes it fail), so it distinguishes abort from detach rather than merely compiling.

## Caveats reviewers should know

1. **The gate is not a rollback to master.** `613a4fc` removed the `VEP_EARLY_WORKERS` interleave (`tokio::join!(rest_fut, grid_fut)`), which on master let the grid plan build overlap `load_contig_context_rest`. So `VEP_CONTIG_PREFETCH=0` is *master minus that overlap*, not master. Documented at both the gate and the field. This is also why the wall-time numbers above are measured against `origin/master` rather than against gate-OFF — an earlier gate-ON/OFF comparison flattered the feature. A commit restoring the interleave (`7b66c18`) was carried on this branch for a while and has been **dropped** — it never demonstrated a win in six traced runs and cost ~1% CPU plus a 4x distortion of the `context_load` profile metric. See the measurement comment below; re-propose separately if a quiet machine ever shows the ~9% gate-ON ceiling materialising.
2. **Per-contig `TOTAL` is now anchored at activation, in both modes.** Master anchored it at the top of prepare. So `chrN: TOTAL` and `chrN: 1. variation_lookup` from this build are systematically smaller than master's by roughly one data phase, and per-contig totals no longer sum to run wall time. Do not compare per-contig `TOTAL` across this boundary. Known follow-up: emit the data-half duration as its own profile field.
3. **Cancellation is not instant.** `abort()` lands at the next await point, and the data phase does long inline CPU work (`parse_transcript_batches`). With `VEP_CTX_PARALLEL` enabled (off by default) its four `spawn_blocking` parses cannot be cancelled at all and run to completion detached. Documented on the field.
4. A panic inside a prefetched prepare surfaces as `DataFusionError::Execution("contig prefetch task failed: …")` rather than unwinding as it would gate-OFF. Failure *ordering* is preserved (errors surface when the prefetched contig starts); failure *kind* changes.
5. No prefetch is started when a `fetch_limit` is set, so a `LIMIT` query never pays for an aborted context load.

## Commits

| commit | |
|---|---|
| `613a4fc` | split `prepare_contig_context` into data and activate phases (pure refactor, byte-identical) |
| `8cfbfc4` | use the data-phase span for `prepare_setup` |
| `04f7f6d` | `VEP_CONTIG_PREFETCH` gate decision + decision-table test |
| `ca9233d` | prefetch the next contig's data phase while the current one annotates |
| `387e10b` | abort the prefetch on drop instead of detaching it |
| `c45f193` | time each contig from activation, not from its prefetched data phase |
| `1807a25` | correct the `VEP_CTX_PARALLEL` default in a stale comment (pre-existing) |
| `2dc4ba6` | review nits: stale `profile_handle` comment, redundant `Pin::new` on an `Unpin` `JoinHandle` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)




