### PR TITLE
fix(vep): record the real cache format, not the vestigial backend token

### DIFF
--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -749,11 +749,11 @@ fn provenance_header_lines(
     cache_source_type: CacheSourceType,
 ) -> Vec<String> {
     let mut identity = format!(
-        "##{PROVENANCE_KEY}=\"{}\" cache=\"{}\" cache_type=\"{}\" backend=\"{}\"",
+        "##{PROVENANCE_KEY}=\"{}\" cache=\"{}\" cache_type=\"{}\" cache_format=\"{}\"",
         env!("CARGO_PKG_VERSION"),
         escape_header_attribute(cache_source),
         cache_source_type.as_str(),
-        escape_header_attribute(backend),
+        escape_header_attribute(cache_format_for_backend(backend)),
     );
 
     // The caller's product name, recorded but not load-bearing.
@@ -800,10 +800,10 @@ fn provenance_header_lines(
     let invocation = serde_json::json!({
         "engine": env!("CARGO_PKG_NAME"),
         "compression": compression,
+        "cache_format": cache_format_for_backend(backend),
         "input": input_vcf,
         "output": output_vcf,
         "cache": cache_source,
-        "backend": backend,
         "reference_fasta": config.reference_fasta_path,
         "plugin_cache_root": config.plugin_cache_root
             .as_ref()
@@ -2182,7 +2182,11 @@ mod tests {
             lines[0]
         );
         assert!(lines[0].contains("cache_type=\"merged\""), "{}", lines[0]);
-        assert!(lines[0].contains("backend=\"parquet\""), "{}", lines[0]);
+        assert!(
+            lines[0].contains("cache_format=\"parquet\""),
+            "{}",
+            lines[0]
+        );
         assert!(
             lines[1].starts_with(&format!("##{key}-command-line='")),
             "{}",
@@ -2199,6 +2203,33 @@ mod tests {
             "{identity}"
         );
         assert!(!identity.contains("unknown"), "{identity}");
+    }
+
+    #[test]
+    fn provenance_records_the_real_cache_format_not_the_backend_token() {
+        // `backend` is a vestigial identifier — callers pass "lance" while the
+        // storage is Parquet — so recording it would state something false in an
+        // audit trail. Record the resolved cache format instead.
+        let lines = provenance_header_lines(
+            "/in.vcf",
+            "/cache",
+            "lance",
+            "/out.vcf",
+            &AnnotateVcfConfig::default(),
+            CacheSourceType::Merged,
+        );
+        assert!(
+            lines[0].contains("cache_format=\"parquet\""),
+            "{}",
+            lines[0]
+        );
+        for line in &lines {
+            assert!(
+                !line.contains("lance"),
+                "vestigial backend token leaked: {line}"
+            );
+            assert!(!line.contains("backend"), "{line}");
+        }
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -800,7 +800,6 @@ fn provenance_header_lines(
     let invocation = serde_json::json!({
         "engine": env!("CARGO_PKG_NAME"),
         "compression": compression,
-        "cache_format": cache_format_for_backend(backend),
         "input": input_vcf,
         "output": output_vcf,
         "cache": cache_source,
@@ -2230,6 +2229,14 @@ mod tests {
             );
             assert!(!line.contains("backend"), "{line}");
         }
+        // `to_options_json_with_backend` already resolves cache_format into the
+        // nested options object, so the invocation must not repeat it.
+        assert_eq!(
+            lines[1].matches("\"cache_format\"").count(),
+            1,
+            "cache_format duplicated in {}",
+            lines[1]
+        );
     }
 
     #[test]


### PR DESCRIPTION
The provenance line added in #214 recorded `backend="lance"`. That is false.

`backend` is a dead identifier. Callers pass `"lance"` while the storage is Parquet, and `cache_format_for_backend` ignores the argument entirely:

```rust
fn cache_format_for_backend(_backend: &str) -> &str {
    // Parquet is the only supported cache format.
    "parquet"
}
```

vepyr's call site documents the same thing:

```rust
// The annotation store uses the engine's fixed backend token, which upstream
// still names "lance" (a vestigial identifier — the actual storage is Parquet).
let backend = "lance";
```

Verified on a real run: annotating chr21 against a Parquet cache produced

```
##datafusion-bio-function-vep="0.15.0" cache="…/116_GRCh38_merged" cache_type="merged" backend="lance" …
```

A reader would conclude the cache was Lance-backed. Wrong provenance is worse than none, because the line exists specifically to state how a run can be reproduced.

## Fix

Record the resolved cache format in both the identity line and the invocation JSON, and drop the backend token from both.

```
cache_format="parquet"
```

## Test

A call passing `"lance"` records `cache_format="parquet"`, and the token appears nowhere in the output — so the vestigial identifier cannot leak back in.

912 lib tests green, `cargo fmt --check` and `clippy -D warnings` clean.

## Note for release

Separately worth flagging: `AnnotateVcfConfig` is `pub` with `pub` fields and no `#[non_exhaustive]`, so #214's two new fields were a breaking change for any downstream constructing it exhaustively. vepyr failed to compile against it; bio-functions' own tests all use `..Default::default()`, so CI stayed green. The next tag should be a minor bump, and `#[non_exhaustive]` would make future field additions non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)