### PR TITLE
feat(vep): optionally reproduce the input's INFO and FORMAT key order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=d9f616642dd8ca606de7085d3cb8a934de04ec8a#d9f616642dd8ca606de7085d3cb8a934de04ec8a"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7a50b988a9c91243bcecb6c4c3851566d335cce8#7a50b988a9c91243bcecb6c4c3851566d335cce8"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=d9f616642dd8ca606de7085d3cb8a934de04ec8a#d9f616642dd8ca606de7085d3cb8a934de04ec8a"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7a50b988a9c91243bcecb6c4c3851566d335cce8#7a50b988a9c91243bcecb6c4c3851566d335cce8"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=d9f616642dd8ca606de7085d3cb8a934de04ec8a#d9f616642dd8ca606de7085d3cb8a934de04ec8a"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7a50b988a9c91243bcecb6c4c3851566d335cce8#7a50b988a9c91243bcecb6c4c3851566d335cce8"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,8 +1280,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1303,12 +1303,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-trait",
  "datafusion",
- "datafusion-bio-format-core 1.10.0",
+ "datafusion-bio-format-core 1.11.0",
  "datafusion-execution",
  "flate2",
  "log",
@@ -1321,15 +1321,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
  "datafusion",
- "datafusion-bio-format-core 1.10.0",
+ "datafusion-bio-format-core 1.11.0",
  "datafusion-execution",
  "env_logger",
  "flate2",
@@ -1402,7 +1402,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
- "datafusion-bio-format-core 1.10.0",
+ "datafusion-bio-format-core 1.11.0",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
  "datafusion-bio-function-ranges",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7a50b988a9c91243bcecb6c4c3851566d335cce8#7a50b988a9c91243bcecb6c4c3851566d335cce8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7a50b988a9c91243bcecb6c4c3851566d335cce8#7a50b988a9c91243bcecb6c4c3851566d335cce8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7a50b988a9c91243bcecb6c4c3851566d335cce8#7a50b988a9c91243bcecb6c4c3851566d335cce8"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c62910c7e2850c622ededf2fae8d3f0beb6acb02#c62910c7e2850c622ededf2fae8d3f0beb6acb02"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c62910c7e2850c622ededf2fae8d3f0beb6acb02#c62910c7e2850c622ededf2fae8d3f0beb6acb02"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c62910c7e2850c622ededf2fae8d3f0beb6acb02#c62910c7e2850c622ededf2fae8d3f0beb6acb02"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c62910c7e2850c622ededf2fae8d3f0beb6acb02#c62910c7e2850c622ededf2fae8d3f0beb6acb02"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=e87d753158d447dc4172fa90654024a3d99aa7e4#e87d753158d447dc4172fa90654024a3d99aa7e4"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c62910c7e2850c622ededf2fae8d3f0beb6acb02#c62910c7e2850c622ededf2fae8d3f0beb6acb02"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=e87d753158d447dc4172fa90654024a3d99aa7e4#e87d753158d447dc4172fa90654024a3d99aa7e4"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c62910c7e2850c622ededf2fae8d3f0beb6acb02#c62910c7e2850c622ededf2fae8d3f0beb6acb02"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=e87d753158d447dc4172fa90654024a3d99aa7e4#e87d753158d447dc4172fa90654024a3d99aa7e4"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=e87d753158d447dc4172fa90654024a3d99aa7e4#e87d753158d447dc4172fa90654024a3d99aa7e4"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=d9f616642dd8ca606de7085d3cb8a934de04ec8a#d9f616642dd8ca606de7085d3cb8a934de04ec8a"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1304,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=e87d753158d447dc4172fa90654024a3d99aa7e4#e87d753158d447dc4172fa90654024a3d99aa7e4"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=d9f616642dd8ca606de7085d3cb8a934de04ec8a#d9f616642dd8ca606de7085d3cb8a934de04ec8a"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=e87d753158d447dc4172fa90654024a3d99aa7e4#e87d753158d447dc4172fa90654024a3d99aa7e4"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=d9f616642dd8ca606de7085d3cb8a934de04ec8a#d9f616642dd8ca606de7085d3cb8a934de04ec8a"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c62910c7e2850c622ededf2fae8d3f0beb6acb02" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c62910c7e2850c622ededf2fae8d3f0beb6acb02" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c62910c7e2850c622ededf2fae8d3f0beb6acb02", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e87d753158d447dc4172fa90654024a3d99aa7e4" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e87d753158d447dc4172fa90654024a3d99aa7e4" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e87d753158d447dc4172fa90654024a3d99aa7e4", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7a50b988a9c91243bcecb6c4c3851566d335cce8" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7a50b988a9c91243bcecb6c4c3851566d335cce8" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7a50b988a9c91243bcecb6c4c3851566d335cce8", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e87d753158d447dc4172fa90654024a3d99aa7e4" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e87d753158d447dc4172fa90654024a3d99aa7e4" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "e87d753158d447dc4172fa90654024a3d99aa7e4", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "d9f616642dd8ca606de7085d3cb8a934de04ec8a" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "d9f616642dd8ca606de7085d3cb8a934de04ec8a" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "d9f616642dd8ca606de7085d3cb8a934de04ec8a", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "d9f616642dd8ca606de7085d3cb8a934de04ec8a" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "d9f616642dd8ca606de7085d3cb8a934de04ec8a" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "d9f616642dd8ca606de7085d3cb8a934de04ec8a", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7a50b988a9c91243bcecb6c4c3851566d335cce8" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7a50b988a9c91243bcecb6c4c3851566d335cce8" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7a50b988a9c91243bcecb6c4c3851566d335cce8", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c62910c7e2850c622ededf2fae8d3f0beb6acb02" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c62910c7e2850c622ededf2fae8d3f0beb6acb02" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c62910c7e2850c622ededf2fae8d3f0beb6acb02", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -30,9 +30,9 @@ tempfile = "3"
 noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
-datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9", optional = true }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
+datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272", optional = true }
 indicatif = "0.18.4"
 
 # `libc` is only used by `peak_rss_mb()` (getrusage) on UNIX; scoping it here

--- a/datafusion/bio-function-vep/README.md
+++ b/datafusion/bio-function-vep/README.md
@@ -120,19 +120,24 @@ The `annotate_to_vcf()` function wraps the annotation pipeline to produce a stan
 ```rust
 use datafusion_bio_function_vep::vcf_sink::{annotate_to_vcf, AnnotateVcfConfig};
 
+// `AnnotateVcfConfig` is `#[non_exhaustive]`: build it by assignment, so a
+// field added here later defaults in your build instead of breaking it.
+let mut config = AnnotateVcfConfig::default();
+config.everything = true;
+config.extended_probes = true;
+config.reference_fasta_path = Some("/path/to/reference.fa".into());
+config.compression = VcfCompressionType::Gzip;
+config.show_progress = true;
+// Reproduce each input record's own INFO and FORMAT key order in the output,
+// which is what byte-level agreement with Ensembl VEP requires.
+config.preserve_record_layout = true;
+
 let rows = annotate_to_vcf(
     "input.vcf.gz",
     "/path/to/cache",
     "parquet",
     "output.vcf",
-    &AnnotateVcfConfig {
-        everything: true,
-        extended_probes: true,
-        reference_fasta_path: Some("/path/to/reference.fa".into()),
-        compression: VcfCompressionType::Gzip,
-        show_progress: true,
-        ..Default::default()
-    },
+    &config,
 ).await?;
 ```
 

--- a/datafusion/bio-function-vep/examples/annotate_vcf.rs
+++ b/datafusion/bio-function-vep/examples/annotate_vcf.rs
@@ -4,7 +4,8 @@
 //! ```text
 //! cargo run --release -p datafusion-bio-function-vep --example annotate_vcf -- \
 //!   --input <in.vcf> --cache <parquet cache root> --out <out.vcf> \
-//!   --fasta <ref.fa> [--plugin-cache <plugin cache root>] [--everything] [--hgvs]
+//!   --fasta <ref.fa> [--plugin-cache <plugin cache root>] [--everything] [--hgvs] \\
+//!   [--preserve-record-layout]
 //! ```
 
 use datafusion::common::{DataFusionError, Result};
@@ -32,17 +33,19 @@ async fn main() -> Result<()> {
     let fasta = arg(&args, "--fasta");
     let plugin_cache = arg(&args, "--plugin-cache");
 
-    let config = AnnotateVcfConfig {
-        everything: flag(&args, "--everything"),
-        hgvs: flag(&args, "--hgvs"),
-        reference_fasta_path: fasta,
-        workers: arg(&args, "--workers")
-            .and_then(|w| w.parse().ok())
-            .unwrap_or(1),
-        target_partitions: 1,
-        plugin_cache_root: plugin_cache.map(std::path::PathBuf::from),
-        ..AnnotateVcfConfig::default()
-    };
+    // `AnnotateVcfConfig` is `#[non_exhaustive]`, so it is built by assignment
+    // rather than a struct literal: a field this crate adds then defaults here
+    // instead of breaking every caller's build.
+    let mut config = AnnotateVcfConfig::default();
+    config.everything = flag(&args, "--everything");
+    config.hgvs = flag(&args, "--hgvs");
+    config.reference_fasta_path = fasta;
+    config.workers = arg(&args, "--workers")
+        .and_then(|w| w.parse().ok())
+        .unwrap_or(1);
+    config.target_partitions = 1;
+    config.plugin_cache_root = plugin_cache.map(std::path::PathBuf::from);
+    config.preserve_record_layout = flag(&args, "--preserve-record-layout");
 
     eprintln!(
         "annotate: input={input} cache={cache} plugin_cache={:?} everything={} hgvs={}",

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -3414,16 +3414,20 @@ impl AnnotateProvider {
         let include_pick_output = pick_flags.include_pick_output();
         let annotation_column_defs =
             annotation_column_defs_for_selection(transcript_selection, include_pick_output);
-        // Output schema starts with all VCF columns and appends annotation fields.
+        // Output schema starts with all VCF columns and appends annotation
+        // fields. The input fields keep their metadata: it carries the VCF
+        // typing the writer needs (`bio.vcf.field.*`) and the marker that
+        // identifies a carried record-layout column, and rebuilding the fields
+        // bare made the sink reconstruct the first by name and lose the second
+        // entirely.
         let mut fields: Vec<Arc<Field>> = vcf_schema
             .fields()
             .iter()
             .map(|field| {
-                Arc::new(Field::new(
-                    field.name(),
-                    field.data_type().clone(),
-                    field.is_nullable(),
-                ))
+                Arc::new(
+                    Field::new(field.name(), field.data_type().clone(), field.is_nullable())
+                        .with_metadata(field.metadata().clone()),
+                )
             })
             .collect();
 

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -13,7 +13,9 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::TableProvider;
 use datafusion::prelude::SessionContext;
-use datafusion_bio_format_core::metadata::VCF_HEADER_RAW_LINES_KEY;
+use datafusion_bio_format_core::metadata::{
+    VCF_FORMAT_KEYS_COLUMN, VCF_HEADER_RAW_LINES_KEY, VCF_INFO_KEYS_COLUMN,
+};
 use datafusion_bio_format_vcf::serializer::{VcfRecordLine, batch_to_vcf_lines};
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 use datafusion_bio_format_vcf::{VcfCompressionType, VcfLocalWriter};
@@ -379,6 +381,7 @@ impl VcfBodyShardWriter {
 }
 
 /// Configuration for VCF annotation output.
+#[non_exhaustive]
 pub struct AnnotateVcfConfig {
     /// Enable all annotation features (80-field CSQ, SIFT, PolyPhen, etc.).
     pub everything: bool,
@@ -461,6 +464,16 @@ pub struct AnnotateVcfConfig {
     /// Version recorded next to [`Self::provenance_tool_name`]. `None` records
     /// this engine's crate version.
     pub provenance_tool_version: Option<String>,
+    /// Reproduce each input record's own INFO key order and FORMAT key list in
+    /// the output, instead of the schema's.
+    ///
+    /// Both are per record and neither survives the typed columns, so without
+    /// this the output reorders INFO and drops any FORMAT key whose value is
+    /// missing in every sample. Ensembl VEP preserves both by copying the input
+    /// line and only appending to INFO, so byte-level agreement with it needs
+    /// this on. Costs two dictionary-encoded string columns through the
+    /// pipeline.
+    pub preserve_record_layout: bool,
 }
 
 impl Default for AnnotateVcfConfig {
@@ -502,6 +515,7 @@ impl Default for AnnotateVcfConfig {
             plugin_cache_root: None,
             provenance_tool_name: None,
             provenance_tool_version: None,
+            preserve_record_layout: false,
         }
     }
 }
@@ -1047,6 +1061,51 @@ fn run_assembler_thread_bgzf(
 }
 
 /// Drive the `threads>1` sharded-VCF-output path: build the annotation plan
+/// The columns the annotation output carries, in output order: the core VCF
+/// columns, the input's INFO fields, `CSQ`, the per-sample FORMAT columns, and
+/// — when the record layout is preserved — the two carried key-order columns.
+///
+/// Those two go last, matching where the VCF reader puts them, and they are not
+/// INFO fields: the writer reads them to order INFO and FORMAT, and never emits
+/// them on a line.
+fn annotation_output_columns(
+    core_vcf: &[&str],
+    info_fields: &[String],
+    format_fields: &[String],
+    preserve_record_layout: bool,
+) -> Vec<String> {
+    let layout: &[&str] = if preserve_record_layout {
+        &[VCF_INFO_KEYS_COLUMN, VCF_FORMAT_KEYS_COLUMN]
+    } else {
+        &[]
+    };
+    core_vcf
+        .iter()
+        .map(|name| (*name).to_string())
+        .chain(info_fields.iter().cloned())
+        .chain(std::iter::once("CSQ".to_string()))
+        .chain(format_fields.iter().cloned())
+        .chain(layout.iter().map(|name| (*name).to_string()))
+        .collect()
+}
+
+/// Renders [`annotation_output_columns`] as a SQL select list.
+fn annotation_select_list(names: &[String]) -> String {
+    names
+        .iter()
+        .map(|name| {
+            // CSQ is the annotation function's own output column, not one of
+            // the input table's, and is quoted the way the function names it.
+            if name == "CSQ" {
+                format!("\"{name}\"")
+            } else {
+                format!("`{name}`")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// directly (bypassing SQL) with a [`VcfShardContext`] so each fused worker
 /// streams its own position-ordered VCF body shard into `shard_ctx.tempdir`,
 /// then concatenate the shards in ascending id (= position) order into `writer`.
@@ -1233,14 +1292,21 @@ pub async fn annotate_to_vcf(
     crate::register_vep_functions(&ctx);
 
     let vcf_path = input_vcf.to_string();
+    let carry_layout = config.preserve_record_layout;
+    let open_provider = move |path: String| -> Result<VcfTableProvider> {
+        let provider = VcfTableProvider::new(path, None, None, None, false)?;
+        if carry_layout {
+            provider.with_record_layout()
+        } else {
+            Ok(provider)
+        }
+    };
     let vcf_provider = if concurrency_plan.spawn_vcf_provider_open {
-        tokio::task::spawn_blocking(move || {
-            VcfTableProvider::new(vcf_path, None, None, None, false)
-        })
-        .await
-        .map_err(|e| datafusion::common::DataFusionError::External(Box::new(e)))??
+        tokio::task::spawn_blocking(move || open_provider(vcf_path))
+            .await
+            .map_err(|e| datafusion::common::DataFusionError::External(Box::new(e)))??
     } else {
-        VcfTableProvider::new(vcf_path, None, None, None, false)?
+        open_provider(vcf_path)?
     };
 
     let vcf_schema = vcf_provider.schema();
@@ -1341,18 +1407,17 @@ pub async fn annotate_to_vcf(
     };
 
     // 4. Build annotation SQL — only VCF-relevant columns + csq.
-    let mut select_cols: Vec<String> = Vec::new();
-    for name in &core_vcf {
-        select_cols.push(format!("`{name}`"));
-    }
-    for name in &info_fields {
-        select_cols.push(format!("`{name}`"));
-    }
-    select_cols.push("\"CSQ\"".to_string());
-    for name in &format_fields {
-        select_cols.push(format!("`{name}`"));
-    }
-    let select_list = select_cols.join(", ");
+    //
+    // The serial path SELECTs these columns and the sharded path projects the
+    // annotation plan by them. They must name the same columns in the same
+    // order, so both come from one list.
+    let projection_names = annotation_output_columns(
+        &core_vcf,
+        &info_fields,
+        &format_fields,
+        config.preserve_record_layout,
+    );
+    let select_list = annotation_select_list(&projection_names);
 
     let options_json = config.to_options_json_with_backend(backend);
     let opts_clause = format!(", '{}'", options_json.replace('\'', "''"));
@@ -1361,17 +1426,6 @@ pub async fn annotate_to_vcf(
         cache_source.replace('\'', "''"),
         backend.replace('\'', "''"),
     );
-
-    // Column set the formatter consumes (same as the serial SELECT list): core
-    // VCF columns + INFO fields + CSQ + per-sample FORMAT columns. Used by the
-    // threads>1 sharded path to project the annotation plan identically.
-    let projection_names: Vec<String> = core_vcf
-        .iter()
-        .map(|name| (*name).to_string())
-        .chain(info_fields.iter().cloned())
-        .chain(std::iter::once("CSQ".to_string()))
-        .chain(format_fields.iter().cloned())
-        .collect();
 
     let mut vcf_info_fields = info_fields;
     vcf_info_fields.push("CSQ".to_string());
@@ -2459,5 +2513,41 @@ mod tests {
             chunk,
             b"chr1\t1\t.\tA\tC\t.\t.\t.\nchr1\t2\t.\tG\tT\t.\t.\t.\n"
         );
+    }
+
+    /// The serial path SELECTs these columns and the sharded path projects the
+    /// annotation plan by them. Two lists that must agree, so they are one list.
+    #[test]
+    fn the_select_list_names_exactly_the_projected_columns() {
+        let names = annotation_output_columns(
+            &["chrom", "start"],
+            &["DP".to_string()],
+            &["SAMPLE1_GT".to_string()],
+            false,
+        );
+        assert_eq!(names, ["chrom", "start", "DP", "CSQ", "SAMPLE1_GT"]);
+        assert_eq!(
+            annotation_select_list(&names),
+            "`chrom`, `start`, `DP`, \"CSQ\", `SAMPLE1_GT`"
+        );
+    }
+
+    #[test]
+    fn preserving_the_record_layout_carries_its_two_columns() {
+        let names = annotation_output_columns(&["chrom"], &[], &[], true);
+        assert_eq!(
+            names,
+            ["chrom", "CSQ", VCF_INFO_KEYS_COLUMN, VCF_FORMAT_KEYS_COLUMN]
+        );
+        // Last, matching the reader's schema, and quoted like any other column.
+        assert!(annotation_select_list(&names).ends_with(&format!(
+            "`{VCF_INFO_KEYS_COLUMN}`, `{VCF_FORMAT_KEYS_COLUMN}`"
+        )));
+    }
+
+    #[test]
+    fn not_preserving_the_record_layout_carries_neither_column() {
+        let names = annotation_output_columns(&["chrom"], &[], &[], false);
+        assert_eq!(names, ["chrom", "CSQ"]);
     }
 }

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -1060,7 +1060,6 @@ fn run_assembler_thread_bgzf(
     })
 }
 
-/// Drive the `threads>1` sharded-VCF-output path: build the annotation plan
 /// The columns the annotation output carries, in output order: the core VCF
 /// columns, the input's INFO fields, `CSQ`, the per-sample FORMAT columns, and
 /// — when the record layout is preserved — the two carried key-order columns.
@@ -1106,6 +1105,7 @@ fn annotation_select_list(names: &[String]) -> String {
         .join(", ")
 }
 
+/// Drive the `threads>1` sharded-VCF-output path: build the annotation plan
 /// directly (bypassing SQL) with a [`VcfShardContext`] so each fused worker
 /// streams its own position-ordered VCF body shard into `shard_ctx.tempdir`,
 /// then concatenate the shards in ascending id (= position) order into `writer`.


### PR DESCRIPTION
> **Stacked on #215** (`fix/provenance-records-cache-format`), which carries the `provenance_tool_name`/`provenance_tool_version` fields this branch's config sits next to. Retarget to `master` once that merges.
>
> **Depends on** biodatageeks/datafusion-bio-formats#243 — pinned here by rev.

## What

`AnnotateVcfConfig::preserve_record_layout` opens the input VCF with the reader's new record-layout carry and forwards the two key-order columns (`_vcf_info_keys`, `_vcf_format_keys`) to the sink. The writer emits INFO in the source's order and the record's own FORMAT keys — including one whose value is missing in every sample.

Neither survives the typed columns otherwise: both are per record, and a FORMAT key missing everywhere is null exactly like a key the record never had. Ensembl VEP keeps both by copying the input line and only appending to INFO, so byte agreement with it needs this.

Off by default. A run that does not need byte agreement pays nothing.

## Two lists became one

The serial path built a SQL `SELECT` list and the sharded path built a `projection_names` list — the same columns, in the same order, maintained by hand in two places. If they drift, the sharded path silently emits different output from the serial one. They are now one list, rendered to SQL where a select list is needed.

Both paths were verified to produce the same body digest on chr21 (`a42bbf6468779da3c6ad0102c5bfd8e2`, serial and `workers=4`).

## `#[non_exhaustive]`

`AnnotateVcfConfig` is `pub` with `pub` fields, so every field added to it has been a breaking change for callers that name them all. The last two additions broke vepyr's build while this crate's tests stayed green, because they all use `..Default::default()`.

It is now `#[non_exhaustive]`, which makes future additions non-breaking. The cost: callers build it by assignment rather than a struct literal — functional update is disallowed too, as this repo's own example demonstrated. The example shows the shape. **The next release should be a minor version bump.**

## Verification

- 915 lib tests, clippy clean.
- New unit tests pin that the select list names exactly the projected columns, and that the layout columns appear only when asked for.
- End to end through vepyr: output is **byte-identical to Ensembl VEP 116.0 on all 22 autosomes of HG002 — 4,096,123 records**, every strict-mode body digest matching. The only header line that still differs is a `##bcftools_normCommand` harness artifact from the reference run's different normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NifnHcLFdXTnLepZtnAxsB