### PR TITLE
Plugin-cache: streaming shard write, assume_unique, VCF/BED providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-bio-format-bed"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
+dependencies = [
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "datafusion",
+ "datafusion-bio-format-core 1.11.0",
+ "datafusion-execution",
+ "env_logger",
+ "futures",
+ "futures-util",
+ "log",
+ "noodles-bed",
+ "noodles-bgzf 0.49.0",
+ "opendal",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "datafusion-bio-format-core"
 version = "1.8.0"
 source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.8.0#7f7fdcd6e4c3f818d08fa42a60866f57a76daa08"
@@ -1402,6 +1425,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
+ "datafusion-bio-format-bed",
  "datafusion-bio-format-core 1.11.0",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
@@ -3462,6 +3486,20 @@ dependencies = [
  "noodles-vcf 0.90.0",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "noodles-bed"
+version = "0.36.0"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=42a3c0165617b7b8f9f5c5905287968eef92e31e#42a3c0165617b7b8f9f5c5905287968eef92e31e"
+dependencies = [
+ "bstr",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf 0.49.0",
+ "noodles-core 0.20.0",
+ "noodles-csi 0.58.0",
+ "noodles-tabix 0.64.0",
 ]
 
 [[package]]

--- a/datafusion/bio-function-vep/Cargo.toml
+++ b/datafusion/bio-function-vep/Cargo.toml
@@ -31,6 +31,7 @@ noodles-core = "0.16"
 noodles-fasta = "0.49"
 parquet = { version = "=58.0.0", features = ["arrow", "async", "zstd"] }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
+datafusion-bio-format-bed = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
 datafusion-bio-format-core = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272", optional = true }
 indicatif = "0.18.4"

--- a/datafusion/bio-function-vep/examples/build_plugin.rs
+++ b/datafusion/bio-function-vep/examples/build_plugin.rs
@@ -6,6 +6,8 @@
 //!   --source-path /tmp/AlphaMissense_hg38.tsv.gz \
 //!   --variation-cache-dir <cache root containing variation/> \
 //!   --out /tmp/plugin_cache [--chrom 22]
+//!
+//! Multi-source manifests use one `--source-part <name>=<path>` per part.
 //! ```
 
 use std::path::PathBuf;
@@ -21,8 +23,17 @@ fn arg(args: &[String], key: &str) -> Option<String> {
         .cloned()
 }
 
+fn arg_values(args: &[String], key: &str) -> Vec<String> {
+    args.iter()
+        .enumerate()
+        .filter(|(_, value)| value.as_str() == key)
+        .filter_map(|(index, _)| args.get(index + 1).cloned())
+        .collect()
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
+    let _ = env_logger::try_init();
     let args: Vec<String> = std::env::args().collect();
     let manifest_path = arg(&args, "--manifest")
         .ok_or_else(|| DataFusionError::Execution("--manifest required".into()))?;
@@ -40,14 +51,34 @@ async fn main() -> Result<()> {
     {
         first.path = source_path;
     }
+    for source_part in arg_values(&args, "--source-part") {
+        let (part, path) = source_part.split_once('=').ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "--source-part expects <name>=<path>, got '{source_part}'"
+            ))
+        })?;
+        let source = manifest
+            .sources
+            .iter_mut()
+            .find(|source| source.part.as_deref() == Some(part))
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("manifest has no [[source]] with part='{part}'"))
+            })?;
+        source.path = path.to_string();
+    }
     let manifest_file = PathBuf::from(&manifest_path)
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| manifest_path.clone());
 
     println!(
-        "Building plugin '{}' from '{}'",
-        manifest.plugin_name, manifest.sources[0].path
+        "Building plugin '{}' from {:?}",
+        manifest.plugin_name,
+        manifest
+            .sources
+            .iter()
+            .map(|source| (&source.part, &source.path))
+            .collect::<Vec<_>>()
     );
     let mut builder =
         PluginCacheBuilder::new(&manifest, &manifest_file, &variation_cache_dir, &out);

--- a/datafusion/bio-function-vep/src/allele.rs
+++ b/datafusion/bio-function-vep/src/allele.rs
@@ -381,6 +381,54 @@ pub fn vcf_to_vep_input_allele(
     (ref_allele.to_string(), alt_allele.to_string(), pos)
 }
 
+/// Reduce an allele pair to the minimal representation Ensembl probes a plugin
+/// data file with.
+///
+/// Replays `trim_sequences()` in its **left-first** order — shared prefix first,
+/// advancing the start, then shared suffix — which is the order Ensembl's VCF
+/// parser applies when building the `VariationFeature`, and therefore the
+/// `(ref, alt, pos)` that `get_matched_variant_alleles()` compares.
+///
+/// The direction is not a detail; it decides which row is found. `bcftools norm
+/// -m -both` splits multi-allelic records without re-trimming, so non-minimal
+/// pairs are routine, and the two orders disagree on where the variant sits:
+///
+/// | VCF (chr21) | left-first (Ensembl) | right-first |
+/// |---|---|---|
+/// | `CGTGTGT/CGTGT` | `GT/-` at 13836153 — no row, as VEP reports | `GT/-` at 13836149 — another variant's score |
+/// | `AAC/ACAC` | `-/C` at 26062231 — the row VEP reports | same |
+///
+/// Verified against Ensembl VEP 116.0 on chr21: left-first reproduces VEP's CADD
+/// output on every disputed variant, in both directions — found where VEP finds,
+/// empty where VEP is empty. Right-first invents matches VEP does not report.
+///
+/// Only consulted for plugins whose Ensembl implementation minimises at all; see
+/// [`crate::plugin_cache::cache_manifest::AlleleMatch`].
+pub fn plugin_probe_allele(pos: i64, ref_allele: &str, alt_allele: &str) -> (String, String, i64) {
+    let mut r = ref_allele.as_bytes();
+    let mut a = alt_allele.as_bytes();
+    let mut start = pos;
+
+    while !r.is_empty() && !a.is_empty() && r[0] == a[0] {
+        r = &r[1..];
+        a = &a[1..];
+        start += 1;
+    }
+    while !r.is_empty() && !a.is_empty() && r[r.len() - 1] == a[a.len() - 1] {
+        r = &r[..r.len() - 1];
+        a = &a[..a.len() - 1];
+    }
+
+    let to_allele = |b: &[u8]| {
+        if b.is_empty() {
+            "-".to_string()
+        } else {
+            String::from_utf8_lossy(b).into_owned()
+        }
+    };
+    (to_allele(r), to_allele(a), start)
+}
+
 /// Traceability:
 /// - Ensembl VEP `compare_existing()`
 ///   <https://github.com/Ensembl/ensembl-vep/blob/2beada0d57ca6234f467b14a6c60280f4a082717/modules/Bio/EnsEMBL/VEP/AnnotationType/Variation.pm#L146-L206>
@@ -1197,5 +1245,105 @@ mod tests {
         // No suffix since alt_remaining=0. So: start=101, end=103
         assert_eq!(vep_norm_start(100, "TCAC", "T"), 101);
         assert_eq!(vep_norm_end(100, "TCAC", "T"), 103);
+    }
+
+    /// Equal-length MNVs left behind by `bcftools norm -m -both`. Each pair is a
+    /// real chr21 HG002 variant whose CADD score was present in the shard under
+    /// the minimal key but missed by an unreduced probe.
+    #[test]
+    fn plugin_probe_allele_reduces_untrimmed_mnvs() {
+        // chr21:13973877, 12 shared trailing bases -> a plain T>G substitution.
+        assert_eq!(
+            plugin_probe_allele(13973877, "TTGTGTGTGTGTG", "GTGTGTGTGTGTG"),
+            ("T".into(), "G".into(), 13973877)
+        );
+        assert_eq!(
+            plugin_probe_allele(26032805, "AAT", "TAT"),
+            ("A".into(), "T".into(), 26032805)
+        );
+        assert_eq!(
+            plugin_probe_allele(28149937, "CGT", "TGT"),
+            ("C".into(), "T".into(), 28149937)
+        );
+        assert_eq!(
+            plugin_probe_allele(39327921, "AAATG", "GAATG"),
+            ("A".into(), "G".into(), 39327921)
+        );
+        assert_eq!(
+            plugin_probe_allele(27136796, "CA", "AA"),
+            ("C".into(), "A".into(), 27136796)
+        );
+        assert_eq!(
+            plugin_probe_allele(18829623, "AATAT", "TATAT"),
+            ("A".into(), "T".into(), 18829623)
+        );
+    }
+
+    /// Indels reduce too, but the trim *order* decides which row is reached.
+    /// Every expectation below was checked against Ensembl VEP 116.0 + CADD on
+    /// chr21: left-first lands where VEP lands, in both directions.
+    #[test]
+    fn plugin_probe_allele_reduces_indels_left_first() {
+        // chr21:26062230 AAC>ACAC — left-first gives -/C at 26062231, the row
+        // VEP reports (raw -0.121737). Right-first would land elsewhere.
+        assert_eq!(
+            plugin_probe_allele(26062231, "AC", "CAC"),
+            ("-".into(), "C".into(), 26062231)
+        );
+        // chr21:13836148 CGTGTGT>CGTGT — left-first gives GT/- at 13836153,
+        // where no row exists, so we stay empty exactly as VEP does. Right-first
+        // would give 13836149 and steal the unrelated CGT>C score (-0.057515).
+        assert_eq!(
+            plugin_probe_allele(13836149, "GTGTGT", "GTGT"),
+            ("GT".into(), "-".into(), 13836153)
+        );
+        // chr21:14031159 TTG>TTGTGTGTG (insertion); VEP reports no CADD.
+        assert_eq!(
+            plugin_probe_allele(14031160, "TG", "TGTGTGTG"),
+            ("-".into(), "TGTGTG".into(), 14031162)
+        );
+        // chr21:26139879 AAAACAAAC>AAAAC; right-first regressed ClinVar here.
+        assert_eq!(
+            plugin_probe_allele(26139880, "AAACAAAC", "AAAC"),
+            ("AAAC".into(), "-".into(), 26139884)
+        );
+        // Pure deletion already in minimal form stays put (raw -0.076825).
+        assert_eq!(
+            plugin_probe_allele(13836149, "GTGTGT", "-"),
+            ("GTGTGT".into(), "-".into(), 13836149)
+        );
+    }
+
+    #[test]
+    fn plugin_probe_allele_leaves_minimal_pairs_alone() {
+        // Already-minimal SNV and MNV: untouched, start unshifted.
+        assert_eq!(
+            plugin_probe_allele(100, "A", "G"),
+            ("A".into(), "G".into(), 100)
+        );
+        assert_eq!(
+            plugin_probe_allele(100, "AC", "GT"),
+            ("AC".into(), "GT".into(), 100)
+        );
+        // Anchor-trimmed indels from vcf_to_vep_input_allele carry the `-`
+        // sentinel and must pass through untouched, or working insertion
+        // lookups (chr21:33549184 -/TTGT) would regress.
+        assert_eq!(
+            plugin_probe_allele(33549184, "-", "TTGT"),
+            ("-".into(), "TTGT".into(), 33549184)
+        );
+        assert_eq!(
+            plugin_probe_allele(100, "CGT", "-"),
+            ("CGT".into(), "-".into(), 100)
+        );
+    }
+
+    #[test]
+    fn plugin_probe_allele_trims_prefix_with_start_shift() {
+        // Shared prefix costs a start shift; shared suffix does not.
+        assert_eq!(
+            plugin_probe_allele(100, "ATCG", "AGCG"),
+            ("T".into(), "G".into(), 101)
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -178,8 +178,8 @@ use std::borrow::Cow;
 use std::fmt::Write;
 
 use crate::allele::{
-    MatchedVariantAllele, reverse_complement_allele, vcf_to_vep_allele, vcf_to_vep_input_allele,
-    vep_norm_end, vep_norm_start,
+    MatchedVariantAllele, plugin_probe_allele, reverse_complement_allele, vcf_to_vep_allele,
+    vcf_to_vep_input_allele, vep_norm_end, vep_norm_start,
 };
 use crate::annotation_store::AnnotationBackend;
 use crate::cache_source::{CACHE_SOURCE_METADATA_KEY, CacheSourceType};
@@ -5468,14 +5468,24 @@ impl AnnotateProvider {
             // `vcf_to_vep_input_allele` shifts it, so the take must use the same
             // normalized start the probe uses or indel plugins would miss.
             let mut starts: Vec<u32> = (0..batch.num_rows())
-                .filter_map(|row| {
+                .flat_map(|row| {
                     let start_val = int64_at(batch.column(start_idx).as_ref(), row).unwrap_or(0);
                     let ref_al = string_at(batch.column(ref_idx).as_ref(), row).unwrap_or_default();
                     let alt_al = string_at(batch.column(alt_idx).as_ref(), row).unwrap_or_default();
-                    let (_ir, _ia, input_start) =
+                    let (input_ref, input_alt, input_start) =
                         vcf_to_vep_input_allele(start_val, &ref_al, &alt_al);
-                    u32::try_from(input_start).ok()
+                    // Both spellings the probe may ask for: the primary key and the
+                    // fully minimal fallback, whose start shifts when a shared
+                    // prefix is trimmed. Taking only the primary would leave the
+                    // fallback row outside the page range and defeat the retry.
+                    let (_mr, _ma, min_start) =
+                        plugin_probe_allele(input_start, &input_ref, &input_alt);
+                    [
+                        u32::try_from(input_start).ok(),
+                        u32::try_from(min_start).ok(),
+                    ]
                 })
+                .flatten()
                 .collect();
             starts.sort_unstable();
             starts.dedup();
@@ -6423,6 +6433,17 @@ impl AnnotateProvider {
                                 input_alt.as_str(),
                             );
                             let plugin_allele = format!("{input_ref}/{input_alt}");
+                            // Fully minimal spelling, used only when the primary
+                            // key misses (see `probe_all`).
+                            let (min_ref, min_alt, min_start) =
+                                plugin_probe_allele(input_start, &input_ref, &input_alt);
+                            let minimal_allele = format!("{min_ref}/{min_alt}");
+                            let fallback_key = (minimal_allele != plugin_allele).then(|| {
+                                (
+                                    u32::try_from(min_start).unwrap_or(0),
+                                    minimal_allele.as_str(),
+                                )
+                            });
                             let scalars = plugin_slices
                                 .as_ref()
                                 .map(|s| {
@@ -6431,6 +6452,7 @@ impl AnnotateProvider {
                                     s.probe_all(
                                         u32::try_from(input_start).unwrap_or(0),
                                         &plugin_allele,
+                                        fallback_key,
                                         &ns,
                                     )
                                 })
@@ -6471,12 +6493,22 @@ impl AnnotateProvider {
                             // `input_allele_string` was moved upstream; rebuild the
                             // `ref/alt` allele exactly as the transcript path does.
                             let plugin_allele = format!("{input_ref}/{input_alt}");
+                            let (min_ref, min_alt, min_start) =
+                                plugin_probe_allele(input_start, &input_ref, &input_alt);
+                            let minimal_allele = format!("{min_ref}/{min_alt}");
+                            let fallback_key = (minimal_allele != plugin_allele).then(|| {
+                                (
+                                    u32::try_from(min_start).unwrap_or(0),
+                                    minimal_allele.as_str(),
+                                )
+                            });
                             let scalars = plugin_slices
                                 .as_ref()
                                 .map(|s| {
                                     s.probe_all(
                                         u32::try_from(input_start).unwrap_or(0),
                                         &plugin_allele,
+                                        fallback_key,
                                         &[],
                                     )
                                 })

--- a/datafusion/bio-function-vep/src/annotate_provider.rs
+++ b/datafusion/bio-function-vep/src/annotate_provider.rs
@@ -6408,6 +6408,7 @@ impl AnnotateProvider {
                             let ns = crate::plugin_cache::template::build_attr_namespace(
                                 terms_str,
                                 gene,
+                                symbol,
                                 feature_type,
                                 feature,
                                 biotype,

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -126,10 +126,18 @@ fn is_order_violation(e: &DataFusionError) -> bool {
 /// spill threshold. Only the sort can actually honour it by spilling.
 ///
 /// The previous 2 GiB default was too small for that reality: measured on
-/// chr21 (the smallest autosome, on a 64 GB machine), the join alone reserved
-/// 1557 MB for dbNSFP and 2034 MB for CADD, exhausting the pool before the
-/// sort reserved anything and failing both builds outright. 8 GiB clears both
-/// with room to spare while still bounding a runaway plan.
+/// chr21 (the smallest autosome, 64 GB machine), the join alone reserved
+/// 1557 MB for dbNSFP, exhausting the pool before the sort reserved anything
+/// and failing the build outright. 8 GiB clears it with room to spare (peak
+/// RSS 1.7 GB, builds in 0.2 min) while still bounding a runaway plan.
+///
+/// This does NOT fix CADD, and no pool size does. Its reservation grows to
+/// consume whatever budget it is given -- 2.03 GB at a 2 GiB pool, 6.4 GB at
+/// 8 GiB, 22.6 GB at 24 GiB -- and fails each time asking for the same
+/// 592.7 MB increment, while peak RSS plateaus around 17 GB. So the
+/// accounting outruns what is actually materialized, and raising the ceiling
+/// only moves the failure. See the tier-join analysis on PR #217; the fix
+/// there is structural, not a bigger number.
 const DEFAULT_RETRY_SORT_MEMORY_MIB: usize = 8 * 1024;
 
 /// Env override for [`DEFAULT_RETRY_SORT_MEMORY_MIB`], in MiB.
@@ -818,14 +826,16 @@ type = "Float32"
     }
 
     #[test]
-    fn retry_memory_default_clears_the_measured_chr21_join_reservations() {
-        // chr21, the smallest autosome: the join alone reserved 1557 MB
-        // (dbNSFP) and 2034 MB (CADD) before the sort reserved anything, which
-        // the old 2 GiB default could not cover. Guard the regression.
+    fn retry_memory_default_clears_the_measured_dbnsfp_join_reservation() {
+        // chr21, smallest autosome: the join alone reserved 1557 MB for dbNSFP
+        // before the sort reserved anything, which the old 2 GiB default could
+        // not cover once the rest of the plan is counted. Guard that
+        // regression. CADD is deliberately NOT covered -- its reservation
+        // scales with whatever pool it is given, so no constant satisfies it.
         let limit = DEFAULT_RETRY_SORT_MEMORY_MIB * 1024 * 1024;
         assert!(
-            limit > 2034 * 1024 * 1024,
-            "must clear the measured CADD join"
+            limit > 2 * 1557 * 1024 * 1024,
+            "must clear the measured dbNSFP join with headroom"
         );
     }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -1,5 +1,5 @@
 //! End-to-end per-chrom plugin cache build: register sources → ingest view →
-//! normalization wrapper → variation-frequency join/tier → two-pass tiered
+//! normalization wrapper → variation-frequency join/tier → direct tiered
 //! shard write → cache-manifest chrom entry.
 //!
 //! Both joins run in a bounded, parallel DataFusion context. For each join we
@@ -7,14 +7,16 @@
 //! statistics to decide whether the estimated reservation fits the active
 //! pool. If it does not, or the statistics are incomplete, only
 //! `prefer_hash_join` is changed and DataFusion plans its built-in
-//! SortMergeJoin. The final query always has an explicit `ORDER BY start`, so
-//! correctness does not depend on execution-partition or hash-table order.
+//! SortMergeJoin. The final query always has an explicit
+//! `ORDER BY tier, start`, so correctness does not depend on execution-
+//! partition or hash-table order and the result can be written directly in
+//! the point-lookup shard's physical order.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, Int8Array, UInt32Array};
-use datafusion::arrow::compute::{cast, filter_record_batch};
+use datafusion::arrow::array::{Array, Int8Array, UInt32Array};
+use datafusion::arrow::compute::cast;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
@@ -59,49 +61,77 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
         .map_err(|e| DataFusionError::Execution(format!("reproject: {e}")))
 }
 
-/// Verify `start` is non-decreasing within `batch` and against `last_seen` (the
-/// previous batch's final `start` for this tier), returning the batch's own
-/// final `start` on success.
+#[derive(Debug, PartialEq, Eq)]
+struct TierOrderSummary {
+    last_key: Option<(i8, u32)>,
+    warm: usize,
+    cold: usize,
+}
+
+/// Verify `(tier, start)` is lexicographically non-decreasing within `batch`
+/// and against the previous batch's final key. Return the batch's final key
+/// and its warm/cold row counts.
 ///
-/// The streaming shard write below relies on the tiered join emitting rows in
-/// position-ascending order per tier; that holds whenever the plugin's own
-/// input already arrives globally sorted (see the module doc for why), but a
-/// source that isn't -- multiple files concatenated without a merge sort,
-/// say -- can surface a genuine regression here. Rather than trust the
-/// assumption silently, check it: a real violation aborts the fast write
-/// immediately (no shard is written) instead of producing a page directory
-/// whose binary-search lookup can silently miss rows that are actually
-/// present (`PageDir::resolve_ranges` assumes a genuinely sorted run);
-/// `build_plugin_chrom` catches this and retries with an explicit sort.
-fn assert_start_monotonic(
+/// The query's explicit `ORDER BY tier, start` provides this contract. Check
+/// it at the storage boundary anyway: a planner/executor regression must abort
+/// the write instead of producing a page directory whose binary-search lookup
+/// can silently miss rows (`PageDir::resolve_ranges` assumes a sorted run).
+fn inspect_tier_start_order(
     batch: &RecordBatch,
     start_idx: usize,
-    tier: i8,
+    tier_idx: usize,
     chrom: &str,
-    last_seen: Option<u32>,
-) -> Result<Option<u32>> {
+    plugin_name: &str,
+    last_seen: Option<(i8, u32)>,
+) -> Result<TierOrderSummary> {
     let starts = batch
         .column(start_idx)
         .as_any()
         .downcast_ref::<UInt32Array>()
         .ok_or_else(|| DataFusionError::Execution("start column not UInt32".into()))?;
+    let tiers = batch
+        .column(tier_idx)
+        .as_any()
+        .downcast_ref::<Int8Array>()
+        .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?;
     let mut prev = last_seen;
+    let (mut warm, mut cold) = (0usize, 0usize);
     for i in 0..starts.len() {
-        let v = starts.value(i);
-        if let Some(p) = prev
-            && v < p
-        {
+        if starts.is_null(i) || tiers.is_null(i) {
             return Err(DataFusionError::Execution(format!(
-                "plugin_cache[{chrom}]: tier {tier} shard write is not position-ascending \
-                 (start {v} follows {p}) -- the tier join did not preserve row order; the \
-                 on-disk point-lookup directory requires a sorted shard, so refusing to \
-                 write a corrupt one. The adaptive plan's explicit ORDER BY contract was \
-                 violated."
+                "plugin_cache[{plugin_name}/{chrom}]: NULL tier/start in final shard row"
             )));
         }
-        prev = Some(v);
+        let key = (tiers.value(i), starts.value(i));
+        match key.0 {
+            0 => warm += 1,
+            1 => cold += 1,
+            tier => {
+                return Err(DataFusionError::Execution(format!(
+                    "plugin_cache[{plugin_name}/{chrom}]: invalid tier {tier}; expected 0 or 1"
+                )));
+            }
+        }
+        if let Some(previous) = prev
+            && key < previous
+        {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{plugin_name}/{chrom}]: final shard write is not ordered by \
+                 (tier, start): ({}, {}) follows ({}, {}) -- the tier join did not preserve \
+                 row order; the \
+                 on-disk point-lookup directory requires a sorted shard, so refusing to \
+                 write a corrupt one. The adaptive plan's explicit ORDER BY contract was \
+                 violated.",
+                key.0, key.1, previous.0, previous.1
+            )));
+        }
+        prev = Some(key);
     }
-    Ok(prev)
+    Ok(TierOrderSummary {
+        last_key: prev,
+        warm,
+        cold,
+    })
 }
 
 /// Default memory budget for the adaptive tier plan's `FairSpillPool`, in MiB.
@@ -253,10 +283,6 @@ impl ScratchGuard {
         Self(paths.into_iter().collect())
     }
 
-    fn watch(&mut self, path: PathBuf) {
-        self.0.push(path);
-    }
-
     /// Stop watching: the scratch files have been consumed into the final
     /// shard (or deliberately removed), so dropping must not delete anything.
     fn disarm(mut self) {
@@ -272,25 +298,24 @@ impl Drop for ScratchGuard {
     }
 }
 
-/// Consume `stream`, split rows by `tier` into warm (0) / cold (1), and write
-/// each run through its own `PluginShardWriter`. The monotonicity check is a
-/// final assertion of the adaptive plan's explicit sorted-output contract.
+/// Consume the globally `(tier, start)`-sorted stream and write it directly to
+/// the final temporary shard. The monotonicity check is a final assertion of
+/// the adaptive plan's explicit sorted-output contract.
 ///
 /// `PluginShardWriter::create` truncates its target path, so a runtime
 /// Hash-to-SMJ fallback safely overwrites any partial first attempt.
 async fn write_tiered_shard(
     mut stream: SendableRecordBatchStream,
     out_schema: &SchemaRef,
-    warm_path: &Path,
-    cold_path: &Path,
+    path: &Path,
     chrom: &str,
     plugin_name: &str,
-) -> Result<(usize, usize)> {
-    let mut warm_writer = PluginShardWriter::create(warm_path, Arc::clone(out_schema))?;
-    let mut cold_writer = PluginShardWriter::create(cold_path, Arc::clone(out_schema))?;
+) -> Result<(usize, usize, usize)> {
+    let mut writer = PluginShardWriter::create(path, Arc::clone(out_schema))?;
     let (mut warm, mut cold) = (0usize, 0usize);
     let start_idx = out_schema.index_of("start")?;
-    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
+    let tier_idx = out_schema.index_of("tier")?;
+    let mut last_key: Option<(i8, u32)> = None;
 
     while let Some(b) = stream.next().await {
         let batch = b?;
@@ -298,51 +323,22 @@ async fn write_tiered_shard(
             continue;
         }
         let reordered = reproject_cast(&batch, out_schema)?;
-        let tier_col = reordered
-            .column(out_schema.index_of("tier")?)
-            .as_any()
-            .downcast_ref::<Int8Array>()
-            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
-            .clone();
-        let mut kept_this_batch = 0usize;
-        for keep in [0i8, 1i8] {
-            let mask: BooleanArray = (0..reordered.num_rows())
-                .map(|i| Some(tier_col.value(i) == keep))
-                .collect();
-            let filtered = filter_record_batch(&reordered, &mask)
-                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
-            if filtered.num_rows() == 0 {
-                continue;
-            }
-            kept_this_batch += filtered.num_rows();
-            if keep == 0 {
-                warm_last_start =
-                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
-                warm += filtered.num_rows();
-                warm_writer.write(&filtered)?;
-            } else {
-                cold_last_start =
-                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
-                cold += filtered.num_rows();
-                cold_writer.write(&filtered)?;
-            }
-        }
-        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
-        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
-        // would silently drop a row with any other value rather than error,
-        // so check explicitly instead of trusting that invariant blindly.
-        if kept_this_batch != reordered.num_rows() {
-            return Err(DataFusionError::Execution(format!(
-                "plugin_cache[{plugin_name}/{chrom}]: {} row(s) had a tier value outside {{0,1}} \
-                 and were dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
-                 impossible; investigate before trusting this shard",
-                reordered.num_rows() - kept_this_batch
-            )));
-        }
+        let summary = inspect_tier_start_order(
+            &reordered,
+            start_idx,
+            tier_idx,
+            chrom,
+            plugin_name,
+            last_key,
+        )?;
+        last_key = summary.last_key;
+        warm += summary.warm;
+        cold += summary.cold;
+        writer.write(&reordered)?;
     }
-    warm_writer.finish()?;
-    cold_writer.finish()?;
-    Ok((warm, cold))
+    let rows = writer.finish()?;
+    debug_assert_eq!(rows, warm + cold);
+    Ok((rows, warm, cold))
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -456,12 +452,30 @@ pub async fn build_plugin_chrom(
         .with_memory_pool(Arc::clone(&pool))
         .build_arc()
         .map_err(|e| DataFusionError::Execution(format!("tier runtime env: {e}")))?;
+    // The variation-filter semi join needs only these two columns. Register a
+    // narrow zero-copy projection as its own MemTable so DataFusion sees exact
+    // key-only statistics and never considers the plugin's wide value columns
+    // when choosing the probe-filter join's build side.
+    let key_indices = [
+        norm_schema.index_of("start")?,
+        norm_schema.index_of("allele_string")?,
+    ];
+    let key_schema = Arc::new(norm_schema.project(&key_indices)?);
+    let key_batches = deduped
+        .iter()
+        .map(|batch| batch.project(&key_indices))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
     let deduped = partition_batches(deduped, build_config.target_partitions());
+    let key_batches = partition_batches(key_batches, build_config.target_partitions());
     let build_ctx = SessionContext::new_with_config_rt(build_config, build_runtime);
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
+    let key_view = format!("plugin_{}_variation_keys", src.plugin_name);
     let mem = MemTable::try_new(norm_schema.clone(), deduped)
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
     build_ctx.register_table(&dedup_view, Arc::new(mem))?;
+    let key_mem = MemTable::try_new(key_schema, key_batches)
+        .map_err(|e| DataFusionError::Execution(format!("variation-key memtable: {e}")))?;
+    build_ctx.register_table(&key_view, Arc::new(key_mem))?;
 
     let out_schema = plugin_output_schema(&src.match_columns, &src.value_columns);
     let plugin_dir = output_cache_root.join("plugin").join(&src.plugin_name);
@@ -469,17 +483,20 @@ pub async fn build_plugin_chrom(
         .map_err(|e| DataFusionError::Execution(format!("mkdir {}: {e}", plugin_dir.display())))?;
     let file_name = format!("{}.parquet", canonical_chrom_label(chrom));
     let shard_path = plugin_dir.join(&file_name);
-    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
-    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
-    let mut scratch = ScratchGuard::new([warm_tmp.clone(), cold_tmp.clone()]);
+    // Write to a sibling temporary path and atomically rename only after the
+    // Parquet footer is flushed. A failed/retried hash plan can safely
+    // truncate this same path without exposing a partial runtime shard.
+    let build_tmp = plugin_dir.join(format!("{file_name}.build.tmp"));
+    let scratch = ScratchGuard::new([build_tmp.clone()]);
 
-    // Execute the explicitly sorted parallel plan and stream it into two
-    // per-tier temp shards. If a HashJoin estimate was optimistic, retry only
+    // Execute the explicitly sorted parallel plan and stream it directly into
+    // one final-order temp shard. If a HashJoin estimate was optimistic, retry only
     // when the root error is ResourcesExhausted and the pool attributes the
     // rejected reservation to HashJoinInput. Other failures propagate as-is.
     let adaptive = match tiered_stream_sorted_adaptive(
         &build_ctx,
         &dedup_view,
+        &key_view,
         variation_shard,
         pool.as_ref(),
         tracer.as_ref(),
@@ -496,8 +513,7 @@ pub async fn build_plugin_chrom(
     let written = write_tiered_shard(
         adaptive.stream,
         &out_schema,
-        &warm_tmp,
-        &cold_tmp,
+        &build_tmp,
         chrom,
         &src.plugin_name,
     )
@@ -514,8 +530,7 @@ pub async fn build_plugin_chrom(
             write_tiered_shard(
                 merge_stream,
                 &out_schema,
-                &warm_tmp,
-                &cold_tmp,
+                &build_tmp,
                 chrom,
                 &src.plugin_name,
             )
@@ -525,7 +540,7 @@ pub async fn build_plugin_chrom(
     };
     // Report before propagating: the peak table is most useful on failure.
     tracer.report();
-    let (warm, cold) = written?;
+    let (rows, warm, cold) = written?;
     info!(
         "plugin_cache[{}/{chrom}]: tier-join+write done, warm={warm} cold={cold}, {:.1}s elapsed",
         src.plugin_name,
@@ -536,6 +551,7 @@ pub async fn build_plugin_chrom(
     // stale shard from a previous build so the manifest (rows: 0) matches disk
     // and the runtime never opens a leftover file for an empty chrom.
     if warm + cold == 0 {
+        let _ = std::fs::remove_file(&build_tmp);
         let _ = std::fs::remove_file(&shard_path);
         return Ok(ChromEntry {
             chrom: canonical_chrom_label(chrom),
@@ -546,48 +562,13 @@ pub async fn build_plugin_chrom(
         });
     }
 
-    // Merge: final shard = warm run then cold run. Both temps are already
-    // start-sorted by construction (see above), so this is a plain streaming
-    // batch-by-batch copy into the final writer (which carries the point-lookup
-    // page-index properties) — no sort, O(one batch) memory.
-    //
-    // Written to a `.merge.tmp` path and renamed into place only once fully
-    // flushed, rather than directly to `shard_path`: a crash mid-merge already
-    // fails loudly on next open (a parquet file with no footer, not a silent
-    // half-written one), but writing in place still leaves a corrupt file
-    // *at the path the runtime looks up* until the next successful rebuild
-    // overwrites it -- a rename is atomic on the same filesystem, so a crash
-    // here instead leaves either the previous good shard (if any) or nothing.
-    let merge_tmp = plugin_dir.join(format!("{file_name}.merge.tmp"));
-    scratch.watch(merge_tmp.clone());
-    let mut writer = PluginShardWriter::create(&merge_tmp, Arc::clone(&out_schema))?;
-    for tmp in [&warm_tmp, &cold_tmp] {
-        let file = std::fs::File::open(tmp)
-            .map_err(|e| DataFusionError::Execution(format!("open temp {}: {e}", tmp.display())))?;
-        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
-            .map_err(|e| DataFusionError::Execution(format!("open temp reader: {e}")))?
-            .build()
-            .map_err(|e| DataFusionError::Execution(format!("build temp reader: {e}")))?;
-        for batch in reader {
-            let batch =
-                batch.map_err(|e| DataFusionError::Execution(format!("read temp batch: {e}")))?;
-            writer.write(&batch)?;
-        }
-        let _ = std::fs::remove_file(tmp);
-    }
-    let rows = writer.finish()?;
-    if rows == 0 {
-        let _ = std::fs::remove_file(&merge_tmp);
-        let _ = std::fs::remove_file(&shard_path);
-    } else {
-        std::fs::rename(&merge_tmp, &shard_path).map_err(|e| {
-            DataFusionError::Execution(format!(
-                "rename {} -> {}: {e}",
-                merge_tmp.display(),
-                shard_path.display()
-            ))
-        })?;
-    }
+    std::fs::rename(&build_tmp, &shard_path).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "rename {} -> {}: {e}",
+            build_tmp.display(),
+            shard_path.display()
+        ))
+    })?;
     scratch.disarm();
     info!(
         "plugin_cache[{}/{chrom}]: done, rows={rows}, {:.1}s total",
@@ -800,66 +781,50 @@ type = "Float32"
         }
     }
 
-    // C1 regression: a tiered join that does NOT preserve row order (e.g. the
-    // planner puts the plugin on the hash-build side for a small-plugin/
-    // large-probe query shape) must fail the build loudly rather than write a
-    // shard whose on-disk (tier, start) sort claim is false.
-    #[test]
-    fn assert_start_monotonic_catches_within_batch_disorder() {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "start",
-            DataType::UInt32,
-            false,
-        )]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![Arc::new(UInt32Array::from(vec![10u32, 20, 15]))],
+    fn tier_start_batch(tiers: Vec<i8>, starts: Vec<u32>) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("start", DataType::UInt32, false),
+                Field::new("tier", DataType::Int8, false),
+            ])),
+            vec![
+                Arc::new(UInt32Array::from(starts)),
+                Arc::new(Int8Array::from(tiers)),
+            ],
         )
-        .unwrap();
-        let err = assert_start_monotonic(&batch, 0, 1, "1", None).unwrap_err();
-        assert!(err.to_string().contains("not position-ascending"));
+        .unwrap()
     }
 
     #[test]
-    fn assert_start_monotonic_catches_cross_batch_regression() {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "start",
-            DataType::UInt32,
-            false,
-        )]));
-        let first = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(UInt32Array::from(vec![100u32]))],
-        )
-        .unwrap();
-        let last_seen = assert_start_monotonic(&first, 0, 0, "1", None).unwrap();
-        assert_eq!(last_seen, Some(100));
-        let second =
-            RecordBatch::try_new(schema, vec![Arc::new(UInt32Array::from(vec![50u32]))]).unwrap();
-        let err = assert_start_monotonic(&second, 0, 0, "1", last_seen).unwrap_err();
-        assert!(err.to_string().contains("not position-ascending"));
+    fn tier_start_order_catches_within_tier_disorder() {
+        let batch = tier_start_batch(vec![0, 0, 0], vec![10, 20, 15]);
+        let err = inspect_tier_start_order(&batch, 0, 1, "1", "demo", None).unwrap_err();
+        assert!(err.to_string().contains("not ordered by (tier, start)"));
     }
 
     #[test]
-    fn assert_start_monotonic_accepts_sorted_input() {
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "start",
-            DataType::UInt32,
-            false,
-        )]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![Arc::new(UInt32Array::from(vec![10u32, 10, 20, 30]))],
-        )
-        .unwrap();
-        let last_seen = assert_start_monotonic(&batch, 0, 0, "1", None).unwrap();
-        assert_eq!(last_seen, Some(30));
+    fn tier_start_order_catches_cross_batch_tier_regression() {
+        let first = tier_start_batch(vec![1], vec![100]);
+        let summary = inspect_tier_start_order(&first, 0, 1, "1", "demo", None).unwrap();
+        let last_seen = summary.last_key;
+        assert_eq!(last_seen, Some((1, 100)));
+        let second = tier_start_batch(vec![0], vec![500]);
+        let err = inspect_tier_start_order(&second, 0, 1, "1", "demo", last_seen).unwrap_err();
+        assert!(err.to_string().contains("not ordered by (tier, start)"));
     }
 
-    // `write_tiered_shard` must surface a genuine reorder as the same
-    // "not position-ascending" error `assert_start_monotonic` raises directly
-    // The writer must still reject a broken sorted-output contract rather than
-    // silently creating a page directory whose lookups can miss rows.
+    #[test]
+    fn tier_start_order_accepts_start_reset_at_warm_to_cold_boundary() {
+        let batch = tier_start_batch(vec![0, 0, 1, 1], vec![10, 30, 5, 20]);
+        let summary = inspect_tier_start_order(&batch, 0, 1, "1", "demo", None).unwrap();
+        assert_eq!(summary.last_key, Some((1, 20)));
+        assert_eq!((summary.warm, summary.cold), (2, 2));
+    }
+
+    // `write_tiered_shard` must surface a genuine reorder as the same error
+    // `inspect_tier_start_order` raises directly. The writer must still reject
+    // a broken sorted-output contract rather than silently creating a page
+    // directory whose lookups can miss rows.
     #[test]
     fn retry_memory_limit_defaults_and_honours_the_env_override() {
         // Serial within one test: these mutate process-wide env.
@@ -993,7 +958,7 @@ type = "Float32"
     }
 
     #[test]
-    fn scratch_guard_tolerates_files_the_merge_already_consumed() {
+    fn scratch_guard_tolerates_files_already_consumed() {
         let dir = tempfile::tempdir().unwrap();
         let gone = dir.path().join("already-removed.tmp");
         drop(ScratchGuard::new([gone.clone()]));
@@ -1036,15 +1001,79 @@ type = "Float32"
             futures::stream::iter(batches),
         ));
         let dir = tempfile::tempdir().unwrap();
-        let warm = dir.path().join("warm.tmp");
-        let cold = dir.path().join("cold.tmp");
-        let err = write_tiered_shard(stream, &schema, &warm, &cold, "1", "demo")
+        let path = dir.path().join("build.tmp");
+        let err = write_tiered_shard(stream, &schema, &path, "1", "demo")
             .await
             .unwrap_err();
         assert!(
-            err.to_string().contains("is not position-ascending"),
+            err.to_string().contains("not ordered by (tier, start)"),
             "unexpected error: {err}"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_tiered_shard_writes_final_order_directly() {
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("end", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        let make_batch = |tiers: Vec<i8>, starts: Vec<u32>| {
+            let n = starts.len();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(vec!["1"; n])),
+                    Arc::new(UInt32Array::from(starts.clone())),
+                    Arc::new(UInt32Array::from(starts)),
+                    Arc::new(StringArray::from(vec!["A/G"; n])),
+                    Arc::new(Int8Array::from(tiers)),
+                ],
+            )
+            .unwrap()
+        };
+        let batches: Vec<Result<RecordBatch>> = vec![
+            Ok(make_batch(vec![0, 0], vec![100, 300])),
+            Ok(make_batch(vec![1, 1], vec![50, 200])),
+        ];
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            futures::stream::iter(batches),
+        ));
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("build.tmp");
+        assert_eq!(
+            write_tiered_shard(stream, &schema, &path, "1", "demo")
+                .await
+                .unwrap(),
+            (4, 2, 2)
+        );
+
+        let file = std::fs::File::open(path).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut keys = Vec::new();
+        for batch in reader {
+            let batch = batch.unwrap();
+            let starts = batch
+                .column(batch.schema().index_of("start").unwrap())
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap();
+            let tiers = batch
+                .column(batch.schema().index_of("tier").unwrap())
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .unwrap();
+            keys.extend((0..batch.num_rows()).map(|i| (tiers.value(i), starts.value(i))));
+        }
+        assert_eq!(keys, vec![(0, 100), (0, 300), (1, 50), (1, 200)]);
     }
 
     // C1 regression, end-to-end: `HashJoinExec`'s `CollectLeft` mode collects

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -258,6 +258,7 @@ pub async fn build_plugin_chrom(
             .downcast_ref::<Int8Array>()
             .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
             .clone();
+        let mut kept_this_batch = 0usize;
         for keep in [0i8, 1i8] {
             let mask: BooleanArray = (0..reordered.num_rows())
                 .map(|i| Some(tier_col.value(i) == keep))
@@ -267,6 +268,7 @@ pub async fn build_plugin_chrom(
             if filtered.num_rows() == 0 {
                 continue;
             }
+            kept_this_batch += filtered.num_rows();
             if keep == 0 {
                 warm_last_start =
                     assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
@@ -278,6 +280,19 @@ pub async fn build_plugin_chrom(
                 cold += filtered.num_rows();
                 cold_writer.write(&filtered)?;
             }
+        }
+        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
+        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
+        // would silently drop a row with any other value rather than error,
+        // so check explicitly instead of trusting that invariant blindly.
+        if kept_this_batch != reordered.num_rows() {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{}/{chrom}]: {} row(s) had a tier value outside {{0,1}} and were \
+                 dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
+                 impossible; investigate before trusting this shard",
+                src.plugin_name,
+                reordered.num_rows() - kept_this_batch
+            )));
         }
     }
     warm_writer.finish()?;
@@ -308,7 +323,16 @@ pub async fn build_plugin_chrom(
     // start-sorted by construction (see above), so this is a plain streaming
     // batch-by-batch copy into the final writer (which carries the point-lookup
     // page-index properties) — no sort, O(one batch) memory.
-    let mut writer = PluginShardWriter::create(&shard_path, Arc::clone(&out_schema))?;
+    //
+    // Written to a `.merge.tmp` path and renamed into place only once fully
+    // flushed, rather than directly to `shard_path`: a crash mid-merge already
+    // fails loudly on next open (a parquet file with no footer, not a silent
+    // half-written one), but writing in place still leaves a corrupt file
+    // *at the path the runtime looks up* until the next successful rebuild
+    // overwrites it -- a rename is atomic on the same filesystem, so a crash
+    // here instead leaves either the previous good shard (if any) or nothing.
+    let merge_tmp = plugin_dir.join(format!("{file_name}.merge.tmp"));
+    let mut writer = PluginShardWriter::create(&merge_tmp, Arc::clone(&out_schema))?;
     for tmp in [&warm_tmp, &cold_tmp] {
         let file = std::fs::File::open(tmp)
             .map_err(|e| DataFusionError::Execution(format!("open temp {}: {e}", tmp.display())))?;
@@ -325,7 +349,16 @@ pub async fn build_plugin_chrom(
     }
     let rows = writer.finish()?;
     if rows == 0 {
+        let _ = std::fs::remove_file(&merge_tmp);
         let _ = std::fs::remove_file(&shard_path);
+    } else {
+        std::fs::rename(&merge_tmp, &shard_path).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "rename {} -> {}: {e}",
+                merge_tmp.display(),
+                shard_path.display()
+            ))
+        })?;
     }
     info!(
         "plugin_cache[{}/{chrom}]: done, rows={rows}, {:.1}s total",

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -13,6 +13,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::{StreamExt, TryStreamExt};
+use log::info;
+use std::time::Instant;
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
@@ -49,6 +51,11 @@ pub async fn build_plugin_chrom(
     output_cache_root: &Path,
     chrom: &str,
 ) -> Result<ChromEntry> {
+    // Coarse-grained stage timing at `info` level — cheap (a handful of
+    // `Instant::now()` calls) and the only thing that would have turned CADD
+    // chr6's multi-hour "is it stuck?" investigation (no visibility into
+    // which stage was running) into a 30-second log check.
+    let t_start = Instant::now();
     // Read context: single partition ONLY for the source scan → normalize →
     // dedup leg, so the CSV scan yields rows in source-file order (a
     // multi-partition scan reads byte ranges concurrently and coalescing does not
@@ -126,6 +133,12 @@ pub async fn build_plugin_chrom(
     };
     // The source scan is done — drop the decompressed temp before the join leg.
     drop(src_temps);
+    let read_rows: usize = deduped.iter().map(|b| b.num_rows()).sum();
+    info!(
+        "plugin_cache[{}/{chrom}]: read+normalize+dedup done, {read_rows} rows, {:.1}s elapsed",
+        src.plugin_name,
+        t_start.elapsed().as_secs_f64()
+    );
 
     // Build context: single partition, same reasoning as `read_ctx` above — the
     // streaming write below (see `tiered_stream` consumption) relies on the join
@@ -210,6 +223,11 @@ pub async fn build_plugin_chrom(
     }
     warm_writer.finish()?;
     cold_writer.finish()?;
+    info!(
+        "plugin_cache[{}/{chrom}]: tier-join+streaming-write done, warm={warm} cold={cold}, {:.1}s elapsed",
+        src.plugin_name,
+        t_start.elapsed().as_secs_f64()
+    );
 
     // Empty chrom → no shard (matches variation builder cleanup). Remove any
     // stale shard from a previous build so the manifest (rows: 0) matches disk
@@ -250,6 +268,11 @@ pub async fn build_plugin_chrom(
     if rows == 0 {
         let _ = std::fs::remove_file(&shard_path);
     }
+    info!(
+        "plugin_cache[{}/{chrom}]: done, rows={rows}, {:.1}s total",
+        src.plugin_name,
+        t_start.elapsed().as_secs_f64()
+    );
     Ok(ChromEntry {
         chrom: canonical_chrom_label(chrom),
         file: file_name,

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -118,12 +118,36 @@ fn is_order_violation(e: &DataFusionError) -> bool {
     e.to_string().contains("is not position-ascending")
 }
 
-/// Memory budget for the sorted retry's `FairSpillPool`: generous for the
-/// sparse plugins this path exists for (ClinVar-scale, low hundreds of
-/// thousands of rows per chromosome), but bounded so a plugin that turns out
-/// far larger than expected spills to disk instead of raising the OOM risk
-/// the streaming write (the common/fast path) exists to avoid.
-const RETRY_SORT_MEMORY_LIMIT_BYTES: usize = 2 * 1024 * 1024 * 1024;
+/// Default memory budget for the sorted retry's `FairSpillPool`, in MiB.
+///
+/// The pool bounds the retry's WHOLE plan, not just its sort -- and the plan's
+/// `HashJoinExec` cannot spill (DataFusion has no spill path for a hash join's
+/// build side), so for the join this budget is a hard ceiling rather than a
+/// spill threshold. Only the sort can actually honour it by spilling.
+///
+/// The previous 2 GiB default was too small for that reality: measured on
+/// chr21 (the smallest autosome, on a 64 GB machine), the join alone reserved
+/// 1557 MB for dbNSFP and 2034 MB for CADD, exhausting the pool before the
+/// sort reserved anything and failing both builds outright. 8 GiB clears both
+/// with room to spare while still bounding a runaway plan.
+const DEFAULT_RETRY_SORT_MEMORY_MIB: usize = 8 * 1024;
+
+/// Env override for [`DEFAULT_RETRY_SORT_MEMORY_MIB`], in MiB.
+///
+/// A fixed default cannot suit both a 16 GB laptop and a 512 GB node, and the
+/// right value depends on the plugin's row width as much as its row count --
+/// so make it tunable rather than guessing. Invalid or zero values fall back
+/// to the default rather than failing a long build on a typo'd env var.
+const RETRY_SORT_MEMORY_ENV: &str = "VEPYR_PLUGIN_RETRY_MEMORY_MIB";
+
+fn retry_sort_memory_limit_bytes() -> usize {
+    let mib = std::env::var(RETRY_SORT_MEMORY_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<usize>().ok())
+        .filter(|mib| *mib > 0)
+        .unwrap_or(DEFAULT_RETRY_SORT_MEMORY_MIB);
+    mib * 1024 * 1024
+}
 
 /// Consume `stream`, split rows by `tier` into warm (0) / cold (1), and write
 /// each run through its own `PluginShardWriter`. Checks `start` is
@@ -407,7 +431,9 @@ pub async fn build_plugin_chrom(
                 src.plugin_name
             );
             let sort_runtime = RuntimeEnvBuilder::new()
-                .with_memory_pool(Arc::new(FairSpillPool::new(RETRY_SORT_MEMORY_LIMIT_BYTES)))
+                .with_memory_pool(Arc::new(
+                    FairSpillPool::new(retry_sort_memory_limit_bytes()),
+                ))
                 .build_arc()
                 .map_err(|e| DataFusionError::Execution(format!("retry runtime env: {e}")))?;
             let sort_ctx = SessionContext::new_with_config_rt(
@@ -766,6 +792,43 @@ type = "Float32"
     // (this is what `build_plugin_chrom` pattern-matches on via
     // `is_order_violation` to decide whether to retry with a sort), and it
     // must do so without finishing the writers on the failing tier.
+    #[test]
+    fn retry_memory_limit_defaults_and_honours_the_env_override() {
+        // Serial within one test: these mutate process-wide env.
+        unsafe { std::env::remove_var(RETRY_SORT_MEMORY_ENV) };
+        assert_eq!(
+            retry_sort_memory_limit_bytes(),
+            DEFAULT_RETRY_SORT_MEMORY_MIB * 1024 * 1024
+        );
+
+        unsafe { std::env::set_var(RETRY_SORT_MEMORY_ENV, "16384") };
+        assert_eq!(retry_sort_memory_limit_bytes(), 16384 * 1024 * 1024);
+
+        // A typo must not fail a multi-hour build, and 0 must not create a
+        // pool that rejects every allocation.
+        for bad in ["", "0", "lots", "-1", "8GiB"] {
+            unsafe { std::env::set_var(RETRY_SORT_MEMORY_ENV, bad) };
+            assert_eq!(
+                retry_sort_memory_limit_bytes(),
+                DEFAULT_RETRY_SORT_MEMORY_MIB * 1024 * 1024,
+                "{bad:?} should fall back to the default"
+            );
+        }
+        unsafe { std::env::remove_var(RETRY_SORT_MEMORY_ENV) };
+    }
+
+    #[test]
+    fn retry_memory_default_clears_the_measured_chr21_join_reservations() {
+        // chr21, the smallest autosome: the join alone reserved 1557 MB
+        // (dbNSFP) and 2034 MB (CADD) before the sort reserved anything, which
+        // the old 2 GiB default could not cover. Guard the regression.
+        let limit = DEFAULT_RETRY_SORT_MEMORY_MIB * 1024 * 1024;
+        assert!(
+            limit > 2034 * 1024 * 1024,
+            "must clear the measured CADD join"
+        );
+    }
+
     #[test]
     fn scratch_guard_removes_watched_files_unless_disarmed() {
         let dir = tempfile::tempdir().unwrap();

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -12,13 +12,13 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use log::info;
 use std::time::Instant;
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
-use crate::plugin_cache::dedup::dedup_keep_first;
+use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
 use crate::plugin_cache::join::tiered_stream;
 use crate::plugin_cache::normalize::{
     canonical_contig_str, canonical_contig_udf, wrap_normalization,
@@ -167,12 +167,15 @@ pub async fn build_plugin_chrom(
         .execute_stream()
         .await?;
     let norm_schema = norm_stream.schema();
-    // `assume_unique` sources are structurally guaranteed to never repeat a
-    // probe key, so the keep-first pass (a HashSet<String> with one entry per
-    // row — the dominant memory cost on the largest chromosomes) is skipped;
-    // batches are collected as-is.
+    // `assume_unique` sources are claimed to never repeat a probe key, so the
+    // exhaustive keep-first pass (a HashSet<String> with one entry per row —
+    // the dominant memory cost on the largest chromosomes) is skipped in
+    // favor of a bounded-memory sampled check that still catches a violated
+    // claim instead of trusting it blindly (see `check_assume_unique_sample`
+    // docs for why this can't be exhaustive without reintroducing the same
+    // memory cost the flag exists to avoid).
     let deduped = if src.assume_unique {
-        norm_stream.try_collect::<Vec<_>>().await?
+        check_assume_unique_sample(norm_stream, &match_cols).await?
     } else {
         dedup_keep_first(norm_stream, &match_cols).await?
     };

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -34,7 +34,7 @@ use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
 use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
 use crate::plugin_cache::join::{
-    partition_batches, should_retry_hash_join, tiered_stream_sorted_adaptive,
+    partition_batches, should_retry_final_hash_plan, tiered_stream_sorted_adaptive,
     tiered_stream_sorted_sort_merge,
 };
 use crate::plugin_cache::mem_trace;
@@ -491,9 +491,10 @@ pub async fn build_plugin_chrom(
     let scratch = ScratchGuard::new([build_tmp.clone()]);
 
     // Execute the explicitly sorted parallel plan and stream it directly into
-    // one final-order temp shard. If a HashJoin estimate was optimistic, retry only
-    // when the root error is ResourcesExhausted and the pool attributes the
-    // rejected reservation to HashJoinInput. Other failures propagate as-is.
+    // one final-order temp shard. If a HashJoin estimate was optimistic, or it
+    // fit but starved the downstream external sorter, retry only when the root
+    // error and pool trace attribute exhaustion to that hash plan. Other
+    // failures propagate as-is.
     let adaptive = match tiered_stream_sorted_adaptive(
         &build_ctx,
         &dedup_view,
@@ -520,9 +521,9 @@ pub async fn build_plugin_chrom(
     )
     .await;
     let written = match written {
-        Err(error) if should_retry_hash_join(&error, algorithm, tracer.as_ref()) => {
+        Err(error) if should_retry_final_hash_plan(&error, algorithm, tracer.as_ref()) => {
             info!(
-                "plugin_cache[{}/{chrom}]: tier HashJoin exhausted its reservation \
+                "plugin_cache[{}/{chrom}]: final HashJoin plan exhausted the pool \
                  ({read_rows} plugin rows this chrom) -- retrying with DataFusion SortMergeJoin",
                 src.plugin_name
             );

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -2,22 +2,13 @@
 //! normalization wrapper → variation-frequency join/tier → two-pass tiered
 //! shard write → cache-manifest chrom entry.
 //!
-//! The tiered join (`p LEFT JOIN v`) plans as `HashJoinExec` in `CollectLeft`
-//! mode: the plugin (`p`, the LEFT side) is collected into a hash table, and
-//! the variation probe (`v`) streams as the probe side. A row that MATCHES
-//! comes out in the probe's own scan order, which is fine -- a real variation
-//! shard is itself position-sorted. A row that MISSES gets appended
-//! afterward by iterating the plugin's own original row order. So this holds
-//! in position-ascending order for any plugin whose input already arrives
-//! globally sorted (true whenever the source is a single position-sorted
-//! file, or a `bcftools`/`tabix` query over one) -- but a source built by
-//! concatenating multiple files without a merge sort (the original CADD
-//! SNV+indel bug) surfaces here as soon as any of its rows miss the variation
-//! probe. `assert_start_monotonic` catches a real violation as it writes;
-//! `build_plugin_chrom` responds by re-running the join once with an explicit
-//! `ORDER BY` (see `join::tiered_stream_sorted`) rather than hard-failing the
-//! build. The sort only runs on the retry, so a normally-sorted source (every
-//! plugin shipped so far) pays nothing extra.
+//! Both joins run in a bounded, parallel DataFusion context. For each join we
+//! first inspect DataFusion's optimized HashJoin build side and use its actual
+//! statistics to decide whether the estimated reservation fits the active
+//! pool. If it does not, or the statistics are incomplete, only
+//! `prefer_hash_join` is changed and DataFusion plans its built-in
+//! SortMergeJoin. The final query always has an explicit `ORDER BY start`, so
+//! correctness does not depend on execution-partition or hash-table order.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -27,10 +18,11 @@ use datafusion::arrow::compute::{cast, filter_record_batch};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
+use datafusion::dataframe::DataFrame;
 use datafusion::datasource::MemTable;
 use datafusion::execution::memory_pool::{FairSpillPool, MemoryPool};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::physical_plan::{SendableRecordBatchStream, stream::RecordBatchStreamAdapter};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::StreamExt;
 use log::info;
@@ -39,7 +31,10 @@ use std::time::Instant;
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
 use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
-use crate::plugin_cache::join::{tiered_stream, tiered_stream_sorted};
+use crate::plugin_cache::join::{
+    partition_batches, should_retry_hash_join, tiered_stream_sorted_adaptive,
+    tiered_stream_sorted_sort_merge,
+};
 use crate::plugin_cache::mem_trace;
 use crate::plugin_cache::normalize::{
     canonical_contig_str, canonical_contig_udf, wrap_normalization,
@@ -100,8 +95,8 @@ fn assert_start_monotonic(
                 "plugin_cache[{chrom}]: tier {tier} shard write is not position-ascending \
                  (start {v} follows {p}) -- the tier join did not preserve row order; the \
                  on-disk point-lookup directory requires a sorted shard, so refusing to \
-                 write a corrupt one from the fast path. The caller retries with an \
-                 explicit sort instead of trusting this shard."
+                 write a corrupt one. The adaptive plan's explicit ORDER BY contract was \
+                 violated."
             )));
         }
         prev = Some(v);
@@ -109,19 +104,9 @@ fn assert_start_monotonic(
     Ok(prev)
 }
 
-/// `assert_start_monotonic` reports a genuine reorder with this exact phrase;
-/// matching on it (rather than introducing a dedicated error variant threaded
-/// through every `Result<_, DataFusionError>` in this module) is enough to
-/// distinguish "the join lost row order, retry with a sort" from any other
-/// failure in the write pass (I/O, cast errors, tier-value corruption), which
-/// must still propagate as-is rather than trigger a pointless retry.
-fn is_order_violation(e: &DataFusionError) -> bool {
-    e.to_string().contains("is not position-ascending")
-}
-
-/// Default memory budget for the sorted retry's `FairSpillPool`, in MiB.
+/// Default memory budget for the adaptive tier plan's `FairSpillPool`, in MiB.
 ///
-/// The pool bounds the retry's WHOLE plan, not just its sort -- and the plan's
+/// The pool bounds the WHOLE plan, not just its sort -- and a selected
 /// `HashJoinExec` cannot spill (DataFusion has no spill path for a hash join's
 /// build side), so for the join this budget is a hard ceiling rather than a
 /// spill threshold. Only the sort can actually honour it by spilling.
@@ -138,13 +123,16 @@ fn is_order_violation(e: &DataFusionError) -> bool {
 /// ceiling while RSS stayed flat; raising this default only moved the failure.
 const DEFAULT_RETRY_SORT_MEMORY_MIB: usize = 8 * 1024;
 
-/// Env override for [`DEFAULT_RETRY_SORT_MEMORY_MIB`], in MiB.
+/// Env override for [`DEFAULT_RETRY_SORT_MEMORY_MIB`], in MiB. The existing
+/// variable name is retained for compatibility even though the bounded pool
+/// now covers every tier plan rather than only an order-recovery retry.
 ///
 /// A fixed default cannot suit both a 16 GB laptop and a 512 GB node, and the
 /// right value depends on the plugin's row width as much as its row count --
 /// so make it tunable rather than guessing. Invalid or zero values fall back
 /// to the default rather than failing a long build on a typo'd env var.
 const RETRY_SORT_MEMORY_ENV: &str = "VEPYR_PLUGIN_RETRY_MEMORY_MIB";
+const TARGET_PARTITIONS_ENV: &str = "VEPYR_PLUGIN_TARGET_PARTITIONS";
 
 fn retry_sort_memory_limit_bytes() -> usize {
     let mib = std::env::var(RETRY_SORT_MEMORY_ENV)
@@ -155,15 +143,12 @@ fn retry_sort_memory_limit_bytes() -> usize {
     mib * 1024 * 1024
 }
 
-/// Consume `stream`, split rows by `tier` into warm (0) / cold (1), and write
-/// each run through its own `PluginShardWriter`. Checks `start` is
-/// position-ascending within each tier as it writes (`assert_start_monotonic`)
-/// and returns that error immediately without finishing the writers -- the
-/// caller decides whether to retry with a sorted stream or propagate.
-///
-/// `PluginShardWriter::create` truncates its target path, so calling this
-/// twice at the same `warm_path`/`cold_path` (fast attempt, then sorted retry)
-/// is safe -- the first attempt's partial output is simply overwritten.
+fn target_partitions_from(raw: Option<&str>, runtime_default: usize) -> usize {
+    raw.and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|partitions| *partitions > 0)
+        .unwrap_or_else(|| runtime_default.max(2))
+}
+
 /// Session config for the tier-join passes.
 ///
 /// `schema_force_view_types` is DataFusion's default-on parquet behaviour of
@@ -180,10 +165,76 @@ fn retry_sort_memory_limit_bytes() -> usize {
 /// It also drops the `CAST(... AS Utf8View)` nodes the mismatch forced into
 /// the join keys.
 fn tier_join_config() -> SessionConfig {
-    SessionConfig::new().with_target_partitions(1).set_bool(
-        "datafusion.execution.parquet.schema_force_view_types",
-        false,
-    )
+    let config = SessionConfig::new();
+    // Production follows DataFusion's runtime default with a two-worker
+    // minimum. The override exists for controlled scaling measurements and
+    // operator debugging; invalid/zero values preserve the automatic default.
+    let target_partitions = target_partitions_from(
+        std::env::var(TARGET_PARTITIONS_ENV).ok().as_deref(),
+        config.target_partitions(),
+    );
+    config
+        .with_target_partitions(target_partitions)
+        .set_bool(
+            "datafusion.execution.parquet.schema_force_view_types",
+            false,
+        )
+        // Build a CollectLeft HashJoin candidate so the adaptive layer can
+        // inspect the exact build side DataFusion selected. It later flips
+        // only `prefer_hash_join` when that candidate does not fit, leaving
+        // repartitioning, sorting, spilling, and join execution to DataFusion.
+        .set_bool("datafusion.optimizer.prefer_hash_join", true)
+        .set_usize(
+            "datafusion.optimizer.hash_join_single_partition_threshold",
+            usize::MAX,
+        )
+        .set_usize(
+            "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+            usize::MAX,
+        )
+}
+
+/// Source-ingest configuration with the same automatic/user-selected
+/// parallelism as the downstream joins.
+///
+/// File-scan repartitioning is left enabled so plain CSV/TSV and Parquet can
+/// split large files into ordered byte/row-group ranges. Round-robin
+/// repartitioning is disabled because it destroys source order, which the
+/// keep-first dedup contract needs. Providers that cannot split an input (for
+/// example an unindexed VCF or the current BED provider) still correctly
+/// expose one physical partition; no caller-side `target_partitions = 1`
+/// restriction is imposed on providers that can parallelize.
+fn source_read_config(target_partitions: usize) -> SessionConfig {
+    SessionConfig::new()
+        .with_target_partitions(target_partitions)
+        .with_repartition_file_scans(true)
+        .set_bool("datafusion.optimizer.enable_round_robin_repartition", false)
+}
+
+/// Execute all normalized source partitions concurrently, then replay their
+/// batches in physical partition order.
+///
+/// `DataFrame::execute_stream()` inserts `CoalescePartitionsExec`, which emits
+/// whichever partition produces a batch first and therefore loses source-file
+/// order. `collect_partitioned()` also runs every partition concurrently, but
+/// DataFusion explicitly sorts the completed results by partition index. File
+/// scans and the indexed genomic partition balancer assign ranges in source
+/// order, so flattening that outer vector restores the deterministic order
+/// required by `dedup_keep_first` without serializing parsing.
+async fn ordered_parallel_source_stream(
+    df: DataFrame,
+) -> Result<(SendableRecordBatchStream, usize)> {
+    let schema: SchemaRef = df.schema().inner().clone();
+    let partitions = df.collect_partitioned().await?;
+    let partition_count = partitions.len();
+    let batches = partitions.into_iter().flatten().map(Ok);
+    Ok((
+        Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(batches),
+        )),
+        partition_count,
+    ))
 }
 
 /// Deletes the build's scratch shards unless the build reached the point of
@@ -191,7 +242,7 @@ fn tier_join_config() -> SessionConfig {
 ///
 /// `PluginShardWriter::create` truncates, so a leftover `.tmp` is harmless to
 /// the *next* build -- but a build that dies partway (a full disk during
-/// `writer.write`, an order violation the retry also fails) would otherwise
+/// `writer.write`, or a failed Hash-to-SMJ retry) would otherwise
 /// leave up to two chromosome-sized scratch files behind, on the same disk
 /// whose exhaustion caused the failure. Every early return from
 /// `build_plugin_chrom` past the point the paths are chosen runs this.
@@ -221,6 +272,12 @@ impl Drop for ScratchGuard {
     }
 }
 
+/// Consume `stream`, split rows by `tier` into warm (0) / cold (1), and write
+/// each run through its own `PluginShardWriter`. The monotonicity check is a
+/// final assertion of the adaptive plan's explicit sorted-output contract.
+///
+/// `PluginShardWriter::create` truncates its target path, so a runtime
+/// Hash-to-SMJ fallback safely overwrites any partial first attempt.
 async fn write_tiered_shard(
     mut stream: SendableRecordBatchStream,
     out_schema: &SchemaRef,
@@ -301,16 +358,13 @@ pub async fn build_plugin_chrom(
     // chr6's multi-hour "is it stuck?" investigation (no visibility into
     // which stage was running) into a 30-second log check.
     let t_start = Instant::now();
-    // Read context: single partition ONLY for the source scan → normalize →
-    // dedup leg, so the CSV scan yields rows in source-file order (a
-    // multi-partition scan reads byte ranges concurrently and coalescing does not
-    // restore file order). The dedup needs that order to keep VEP's first-in-file
-    // record for a duplicate probe key (see `dedup::dedup_keep_first`). The
-    // downstream tier join + write run in a separate, default-parallel context
-    // (`build_ctx` below) since post-dedup there is one row per key and order no
-    // longer matters — so only this cheap read leg is serialized, not the join
-    // over the (multi-GB) variation shard.
-    let read_ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+    let build_config = tier_join_config();
+    // Source parsing uses the same adaptive/user-selected parallelism as the
+    // downstream joins. Batches are collected concurrently per physical
+    // partition and replayed in source-range order below, preserving VEP's
+    // first-in-file duplicate semantics without a blanket serial scan.
+    let read_ctx =
+        SessionContext::new_with_config(source_read_config(build_config.target_partitions()));
     read_ctx.register_udf(canonical_contig_udf());
     // Held until this chrom's stream is fully materialized (dedup) below, then
     // dropped (deleting the decompressed temp) — so build_all keeps at most one temp.
@@ -359,13 +413,11 @@ pub async fn build_plugin_chrom(
     // the tier join (which reorders rows and would destroy the file-order
     // tiebreak). Two overlapping genes can map the same genomic variant + aa-change
     // to different scores; VEP takes the first-in-file record, so we must too. This
-    // reads the (single-partition, file-ordered) normalized stream and keeps the
-    // first row per `(start, allele_string, <match cols>)`.
-    let norm_stream = read_ctx
-        .sql(&format!("SELECT * FROM {norm_view}"))
-        .await?
-        .execute_stream()
-        .await?;
+    // executes the source partitions concurrently, restores physical
+    // partition order, and keeps the first row per
+    // `(start, allele_string, <match cols>)`.
+    let norm_df = read_ctx.sql(&format!("SELECT * FROM {norm_view}")).await?;
+    let (norm_stream, source_partitions) = ordered_parallel_source_stream(norm_df).await?;
     let norm_schema = norm_stream.schema();
     // `assume_unique` sources are claimed to never repeat a probe key, so the
     // exhaustive keep-first pass (a HashSet<String> with one entry per row —
@@ -383,31 +435,31 @@ pub async fn build_plugin_chrom(
     drop(src_temps);
     let read_rows: usize = deduped.iter().map(|b| b.num_rows()).sum();
     info!(
-        "plugin_cache[{}/{chrom}]: read+normalize+dedup done, {read_rows} rows, {:.1}s elapsed",
+        "plugin_cache[{}/{chrom}]: read+normalize+dedup done, {read_rows} rows, \
+         source_partitions={source_partitions}, {:.1}s elapsed",
         src.plugin_name,
         t_start.elapsed().as_secs_f64()
     );
 
-    // Build context: single partition, same reasoning as `read_ctx` above — the
-    // streaming write below (see `tiered_stream` consumption) relies on the join
-    // emitting rows in the same position-ascending order the dedup pass fed it,
-    // so it never has to buffer more than one batch. With `target_partitions=1`
-    // there is exactly one task for the whole join, so HashJoinExec has no
-    // opportunity to reorder rows across partitions. The join's build side
-    // (`plugin_variation_probe`, DISTINCT-projected and typically far smaller
-    // than the plugin's own per-chrom row count for whole-genome plugins like
-    // CADD/SpliceAI) is unaffected by this — it's still a single hash-table
-    // build regardless of partition count. The deduped survivors are
-    // re-registered here as a MemTable the join consumes in place of the raw
-    // normalized view.
-    // Kept for the sorted retry below (see the fast/retry split further down):
-    // cloning a `Vec<RecordBatch>` only clones the `Arc`-backed column data,
-    // not the underlying buffers, so holding a second copy here is cheap
-    // regardless of chromosome size.
-    let deduped_for_retry = deduped.clone();
-    let build_ctx = SessionContext::new_with_config(tier_join_config());
+    // The join and ORDER BY share one bounded spill pool. TracingPool is always
+    // installed because it also attributes a rejected reservation to the
+    // operator that requested it; detailed peak logging remains opt-in.
+    mem_trace::describe_batches(
+        "plugin dedup output (join build side when not swapped)",
+        &deduped,
+    );
+    let base_pool: Arc<dyn MemoryPool> =
+        Arc::new(FairSpillPool::new(retry_sort_memory_limit_bytes()));
+    let tracer = Arc::new(mem_trace::TracingPool::new(Arc::clone(&base_pool)));
+    let pool: Arc<dyn MemoryPool> = Arc::clone(&tracer) as _;
+    let build_runtime = RuntimeEnvBuilder::new()
+        .with_memory_pool(Arc::clone(&pool))
+        .build_arc()
+        .map_err(|e| DataFusionError::Execution(format!("tier runtime env: {e}")))?;
+    let deduped = partition_batches(deduped, build_config.target_partitions());
+    let build_ctx = SessionContext::new_with_config_rt(build_config, build_runtime);
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
-    let mem = MemTable::try_new(norm_schema.clone(), vec![deduped])
+    let mem = MemTable::try_new(norm_schema.clone(), deduped)
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
     build_ctx.register_table(&dedup_view, Arc::new(mem))?;
 
@@ -421,83 +473,59 @@ pub async fn build_plugin_chrom(
     let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
     let mut scratch = ScratchGuard::new([warm_tmp.clone(), cold_tmp.clone()]);
 
-    // Stream the tiered join output straight into two per-tier temp shards
-    // (warm run, cold run) instead of collecting the whole chromosome into one
-    // Vec<RecordBatch>, concat_batches-ing it into a single allocation, and
-    // sorting it in memory. That collect+concat+sort was the dominant remaining
-    // memory cost after `assume_unique` removed the dedup HashSet, and still
-    // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
-    // peak memory at O(one batch) instead of O(whole chromosome) -- this is
-    // the fast path, and it's correct as long as the plugin's own input
-    // already arrives position-ascending (see the module doc for why that's
-    // enough, regardless of the plugin's size relative to the variation
-    // shard). `write_tiered_shard`'s `assert_start_monotonic` check catches it
-    // directly if that assumption doesn't hold, and the fallback below
-    // re-runs the join with an explicit sort instead of failing.
-    let fast_stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
-    let (warm, cold) = match write_tiered_shard(
-        fast_stream,
+    // Execute the explicitly sorted parallel plan and stream it into two
+    // per-tier temp shards. If a HashJoin estimate was optimistic, retry only
+    // when the root error is ResourcesExhausted and the pool attributes the
+    // rejected reservation to HashJoinInput. Other failures propagate as-is.
+    let adaptive = match tiered_stream_sorted_adaptive(
+        &build_ctx,
+        &dedup_view,
+        variation_shard,
+        pool.as_ref(),
+        tracer.as_ref(),
+    )
+    .await
+    {
+        Ok(adaptive) => adaptive,
+        Err(error) => {
+            tracer.report();
+            return Err(error);
+        }
+    };
+    let algorithm = adaptive.algorithm;
+    let written = write_tiered_shard(
+        adaptive.stream,
         &out_schema,
         &warm_tmp,
         &cold_tmp,
         chrom,
         &src.plugin_name,
     )
-    .await
-    {
-        Ok(counts) => counts,
-        Err(e) if is_order_violation(&e) => {
-            // The plugin's input wasn't globally position-ascending by the
-            // time it reached the join (see the module doc), so a miss row
-            // surfaced out of order. Re-run with `ORDER BY` on a session
-            // whose memory pool can spill to disk -- this is the exception,
-            // not the common case the O(1)-memory streaming write above is
-            // optimized for.
+    .await;
+    let written = match written {
+        Err(error) if should_retry_hash_join(&error, algorithm, tracer.as_ref()) => {
             info!(
-                "plugin_cache[{}/{chrom}]: tier join did not preserve row order \
-                 ({read_rows} plugin rows this chrom) -- retrying with an explicit sort",
+                "plugin_cache[{}/{chrom}]: tier HashJoin exhausted its reservation \
+                 ({read_rows} plugin rows this chrom) -- retrying with DataFusion SortMergeJoin",
                 src.plugin_name
             );
-            // Wrap the pool when tracing is on: the exhaustion error names the
-            // consumer ("HashJoinInput") and this plan has two joins under that
-            // name, so only per-reservation tracking can say which one consumed
-            // the budget.
-            let base_pool: Arc<dyn MemoryPool> =
-                Arc::new(FairSpillPool::new(retry_sort_memory_limit_bytes()));
-            let tracer = mem_trace::tracing_enabled()
-                .then(|| Arc::new(mem_trace::TracingPool::new(Arc::clone(&base_pool))));
-            let pool: Arc<dyn MemoryPool> = match &tracer {
-                Some(t) => Arc::clone(t) as _,
-                None => Arc::clone(&base_pool),
-            };
-            let sort_runtime = RuntimeEnvBuilder::new()
-                .with_memory_pool(pool)
-                .build_arc()
-                .map_err(|e| DataFusionError::Execution(format!("retry runtime env: {e}")))?;
-            let sort_ctx = SessionContext::new_with_config_rt(tier_join_config(), sort_runtime);
-            let sort_mem = MemTable::try_new(norm_schema, vec![deduped_for_retry])
-                .map_err(|e| DataFusionError::Execution(format!("retry dedup memtable: {e}")))?;
-            sort_ctx.register_table(&dedup_view, Arc::new(sort_mem))?;
-            let sorted_stream =
-                tiered_stream_sorted(&sort_ctx, &dedup_view, variation_shard).await?;
-            let written = write_tiered_shard(
-                sorted_stream,
+            let merge_stream =
+                tiered_stream_sorted_sort_merge(&build_ctx, &dedup_view, tracer.as_ref()).await?;
+            write_tiered_shard(
+                merge_stream,
                 &out_schema,
                 &warm_tmp,
                 &cold_tmp,
                 chrom,
                 &src.plugin_name,
             )
-            .await;
-            // Report before propagating: the peak table is the whole point of
-            // tracing a build that ran out of memory.
-            if let Some(t) = &tracer {
-                t.report();
-            }
-            written?
+            .await
         }
-        Err(e) => return Err(e),
+        result => result,
     };
+    // Report before propagating: the peak table is most useful on failure.
+    tracer.report();
+    let (warm, cold) = written?;
     info!(
         "plugin_cache[{}/{chrom}]: tier-join+write done, warm={warm} cold={cold}, {:.1}s elapsed",
         src.plugin_name,
@@ -579,7 +607,7 @@ pub async fn build_plugin_chrom(
 mod tests {
     use super::*;
     use crate::plugin_cache::source_manifest::SourceManifest;
-    use datafusion::arrow::array::{Int8Array, StringArray, UInt32Array};
+    use datafusion::arrow::array::{Float32Array, Int8Array, Int64Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use parquet::arrow::ArrowWriter;
     use std::io::Write;
@@ -830,9 +858,8 @@ type = "Float32"
 
     // `write_tiered_shard` must surface a genuine reorder as the same
     // "not position-ascending" error `assert_start_monotonic` raises directly
-    // (this is what `build_plugin_chrom` pattern-matches on via
-    // `is_order_violation` to decide whether to retry with a sort), and it
-    // must do so without finishing the writers on the failing tier.
+    // The writer must still reject a broken sorted-output contract rather than
+    // silently creating a page directory whose lookups can miss rows.
     #[test]
     fn retry_memory_limit_defaults_and_honours_the_env_override() {
         // Serial within one test: these mutate process-wide env.
@@ -870,6 +897,79 @@ type = "Float32"
             limit > 2 * 1557 * 1024 * 1024,
             "must clear the measured dbNSFP join with headroom"
         );
+    }
+
+    #[test]
+    fn target_partitions_default_and_benchmark_override() {
+        assert_eq!(target_partitions_from(None, 1), 2);
+        assert_eq!(target_partitions_from(None, 16), 16);
+        for partitions in [1usize, 2, 4, 8] {
+            let raw = partitions.to_string();
+            assert_eq!(target_partitions_from(Some(&raw), 16), partitions);
+        }
+        assert_eq!(target_partitions_from(Some("0"), 16), 16);
+        assert_eq!(target_partitions_from(Some("invalid"), 16), 16);
+    }
+
+    #[test]
+    fn source_reads_use_requested_parallelism_without_round_robin_reordering() {
+        let config = source_read_config(8);
+        assert_eq!(config.target_partitions(), 8);
+        assert!(config.options().optimizer.repartition_file_scans);
+        assert!(!config.options().optimizer.enable_round_robin_repartition);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ordered_parallel_source_replay_preserves_keep_first_across_partitions() {
+        fn normalized_batch(score: f32) -> RecordBatch {
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![
+                    Field::new("chrom", DataType::Utf8, false),
+                    Field::new("start", DataType::Int64, false),
+                    Field::new("end", DataType::Int64, false),
+                    Field::new("allele_string", DataType::Utf8, false),
+                    Field::new("protein_variant", DataType::Utf8, false),
+                    Field::new("am_pathogenicity", DataType::Float32, false),
+                ])),
+                vec![
+                    Arc::new(StringArray::from(vec!["1"])),
+                    Arc::new(Int64Array::from(vec![100i64])),
+                    Arc::new(Int64Array::from(vec![100i64])),
+                    Arc::new(StringArray::from(vec!["A/G"])),
+                    Arc::new(StringArray::from(vec!["K1R"])),
+                    Arc::new(Float32Array::from(vec![score])),
+                ],
+            )
+            .unwrap()
+        }
+
+        let first = normalized_batch(0.1);
+        let later = normalized_batch(0.9);
+        let schema = first.schema();
+        let ctx = SessionContext::new_with_config(source_read_config(2));
+        ctx.register_table(
+            "normalized",
+            Arc::new(
+                MemTable::try_new(schema, vec![vec![first], vec![later]])
+                    .expect("two source partitions"),
+            ),
+        )
+        .unwrap();
+
+        let df = ctx.table("normalized").await.unwrap();
+        let (stream, source_partitions) = ordered_parallel_source_stream(df).await.unwrap();
+        assert_eq!(source_partitions, 2);
+        let deduped = dedup_keep_first(stream, &["protein_variant".into()])
+            .await
+            .unwrap();
+        assert_eq!(deduped.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        let score = deduped[0]
+            .column(deduped[0].schema().index_of("am_pathogenicity").unwrap())
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap()
+            .value(0);
+        assert_eq!(score, 0.1, "partition zero's source row must win");
     }
 
     #[test]
@@ -941,7 +1041,10 @@ type = "Float32"
         let err = write_tiered_shard(stream, &schema, &warm, &cold, "1", "demo")
             .await
             .unwrap_err();
-        assert!(is_order_violation(&err), "unexpected error: {err}");
+        assert!(
+            err.to_string().contains("is not position-ascending"),
+            "unexpected error: {err}"
+        );
     }
 
     // C1 regression, end-to-end: `HashJoinExec`'s `CollectLeft` mode collects
@@ -957,7 +1060,7 @@ type = "Float32"
     // just asserted) via a temporary EXPLAIN probe against this exact
     // mechanism before writing this test.
     //
-    // `build_plugin_chrom` must recover from that with a sort, not hard-fail.
+    // `build_plugin_chrom` must make the parallel result globally sorted.
     #[tokio::test(flavor = "multi_thread")]
     async fn sparse_plugin_with_disordered_source_still_builds_sorted() {
         let dir = tempfile::tempdir().unwrap();
@@ -973,11 +1076,11 @@ type = "Float32"
         write_gz(&tsv, &tsv_body);
 
         // Variation shard: none of the plugin's positions have an entry, so
-        // every plugin row misses (tier=1/cold) -- cold-row emission order
-        // follows the plugin's own (here: descending) row order, reproducing
-        // a genuine `assert_start_monotonic` violation. The other 5000 rows
-        // are unrelated positions, matching production's scale (chr22's
-        // variation shard vs. ClinVar's row count is a ~157x skew).
+        // every plugin row misses (tier=1/cold). This made the old unsorted
+        // HashJoin path emit descending cold rows; the adaptive parallel path
+        // must satisfy its explicit ORDER BY contract. The other 5000 rows are
+        // unrelated positions, matching production's scale (chr22's variation
+        // shard vs. ClinVar's row count is a ~157x skew).
         let mut var_rows: Vec<(&str, u32, String, i8)> = Vec::new();
         for i in 0..5000u32 {
             var_rows.push(("1", 10_000_000 + i, "C/T".to_string(), 1i8));

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -2,18 +2,22 @@
 //! normalization wrapper → variation-frequency join/tier → two-pass tiered
 //! shard write → cache-manifest chrom entry.
 //!
-//! Known tradeoff (noted during PR #196 review): the tiered join is only
-//! guaranteed to stream in position-ascending order per tier when the
-//! optimizer keeps the plugin on the join's probe side, which needs the
-//! plugin's own row count to be large relative to the chromosome's variation
-//! shard (true for whole-genome plugins like CADD/SpliceAI). A sparse or
-//! low-coverage-chromosome plugin can end up on the *build* side instead,
-//! whose order a hash join doesn't preserve -- `assert_start_monotonic`
-//! below then hard-fails that build rather than silently writing a
-//! wrong-order shard. There is currently no re-sort fallback for that case
-//! (see the review thread on PR #196 for the tradeoff analysis); a future
-//! sparse-plugin manifest that hits this needs one added here, not just a
-//! bigger `assume_unique`-style flag.
+//! The tiered join (`p LEFT JOIN v`) plans as `HashJoinExec` in `CollectLeft`
+//! mode: the plugin (`p`, the LEFT side) is collected into a hash table, and
+//! the variation probe (`v`) streams as the probe side. A row that MATCHES
+//! comes out in the probe's own scan order, which is fine -- a real variation
+//! shard is itself position-sorted. A row that MISSES gets appended
+//! afterward by iterating the plugin's own original row order. So this holds
+//! in position-ascending order for any plugin whose input already arrives
+//! globally sorted (true whenever the source is a single position-sorted
+//! file, or a `bcftools`/`tabix` query over one) -- but a source built by
+//! concatenating multiple files without a merge sort (the original CADD
+//! SNV+indel bug) surfaces here as soon as any of its rows miss the variation
+//! probe. `assert_start_monotonic` catches a real violation as it writes;
+//! `build_plugin_chrom` responds by re-running the join once with an explicit
+//! `ORDER BY` (see `join::tiered_stream_sorted`) rather than hard-failing the
+//! build. The sort only runs on the retry, so a normally-sorted source (every
+//! plugin shipped so far) pays nothing extra.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -24,6 +28,9 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
+use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use futures::StreamExt;
 use log::info;
@@ -32,7 +39,7 @@ use std::time::Instant;
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
 use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
-use crate::plugin_cache::join::tiered_stream;
+use crate::plugin_cache::join::{tiered_stream, tiered_stream_sorted};
 use crate::plugin_cache::normalize::{
     canonical_contig_str, canonical_contig_udf, wrap_normalization,
 };
@@ -61,15 +68,15 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
 /// final `start` on success.
 ///
 /// The streaming shard write below relies on the tiered join emitting rows in
-/// position-ascending order per tier; that holds by construction for the
-/// query shapes exercised so far (see the comment above the call site), but
-/// `HashJoinExec`'s build/probe side can flip based on table-size statistics
-/// for other plugin/variation size ratios, and a flipped build side does not
-/// preserve row order. Rather than trust that silently, check it: a real
-/// violation aborts the build immediately (no shard is written) instead of
-/// producing a page directory whose binary-search lookup can silently miss
-/// rows that are actually present (`PageDir::resolve_ranges` assumes a
-/// genuinely sorted run).
+/// position-ascending order per tier; that holds whenever the plugin's own
+/// input already arrives globally sorted (see the module doc for why), but a
+/// source that isn't -- multiple files concatenated without a merge sort,
+/// say -- can surface a genuine regression here. Rather than trust the
+/// assumption silently, check it: a real violation aborts the fast write
+/// immediately (no shard is written) instead of producing a page directory
+/// whose binary-search lookup can silently miss rows that are actually
+/// present (`PageDir::resolve_ranges` assumes a genuinely sorted run);
+/// `build_plugin_chrom` catches this and retries with an explicit sort.
 fn assert_start_monotonic(
     batch: &RecordBatch,
     start_idx: usize,
@@ -90,15 +97,108 @@ fn assert_start_monotonic(
         {
             return Err(DataFusionError::Execution(format!(
                 "plugin_cache[{chrom}]: tier {tier} shard write is not position-ascending \
-                 (start {v} follows {p}) -- the tier join did not preserve row order for \
-                 this plugin/variation size ratio; the on-disk point-lookup directory \
-                 requires a sorted shard, so refusing to write a corrupt one. This needs \
-                 a real re-sort of the tier's output, not just a bigger error message."
+                 (start {v} follows {p}) -- the tier join did not preserve row order; the \
+                 on-disk point-lookup directory requires a sorted shard, so refusing to \
+                 write a corrupt one from the fast path. The caller retries with an \
+                 explicit sort instead of trusting this shard."
             )));
         }
         prev = Some(v);
     }
     Ok(prev)
+}
+
+/// `assert_start_monotonic` reports a genuine reorder with this exact phrase;
+/// matching on it (rather than introducing a dedicated error variant threaded
+/// through every `Result<_, DataFusionError>` in this module) is enough to
+/// distinguish "the join lost row order, retry with a sort" from any other
+/// failure in the write pass (I/O, cast errors, tier-value corruption), which
+/// must still propagate as-is rather than trigger a pointless retry.
+fn is_order_violation(e: &DataFusionError) -> bool {
+    e.to_string().contains("is not position-ascending")
+}
+
+/// Memory budget for the sorted retry's `FairSpillPool`: generous for the
+/// sparse plugins this path exists for (ClinVar-scale, low hundreds of
+/// thousands of rows per chromosome), but bounded so a plugin that turns out
+/// far larger than expected spills to disk instead of raising the OOM risk
+/// the streaming write (the common/fast path) exists to avoid.
+const RETRY_SORT_MEMORY_LIMIT_BYTES: usize = 2 * 1024 * 1024 * 1024;
+
+/// Consume `stream`, split rows by `tier` into warm (0) / cold (1), and write
+/// each run through its own `PluginShardWriter`. Checks `start` is
+/// position-ascending within each tier as it writes (`assert_start_monotonic`)
+/// and returns that error immediately without finishing the writers -- the
+/// caller decides whether to retry with a sorted stream or propagate.
+///
+/// `PluginShardWriter::create` truncates its target path, so calling this
+/// twice at the same `warm_path`/`cold_path` (fast attempt, then sorted retry)
+/// is safe -- the first attempt's partial output is simply overwritten.
+async fn write_tiered_shard(
+    mut stream: SendableRecordBatchStream,
+    out_schema: &SchemaRef,
+    warm_path: &Path,
+    cold_path: &Path,
+    chrom: &str,
+    plugin_name: &str,
+) -> Result<(usize, usize)> {
+    let mut warm_writer = PluginShardWriter::create(warm_path, Arc::clone(out_schema))?;
+    let mut cold_writer = PluginShardWriter::create(cold_path, Arc::clone(out_schema))?;
+    let (mut warm, mut cold) = (0usize, 0usize);
+    let start_idx = out_schema.index_of("start")?;
+    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
+
+    while let Some(b) = stream.next().await {
+        let batch = b?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let reordered = reproject_cast(&batch, out_schema)?;
+        let tier_col = reordered
+            .column(out_schema.index_of("tier")?)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
+            .clone();
+        let mut kept_this_batch = 0usize;
+        for keep in [0i8, 1i8] {
+            let mask: BooleanArray = (0..reordered.num_rows())
+                .map(|i| Some(tier_col.value(i) == keep))
+                .collect();
+            let filtered = filter_record_batch(&reordered, &mask)
+                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
+            if filtered.num_rows() == 0 {
+                continue;
+            }
+            kept_this_batch += filtered.num_rows();
+            if keep == 0 {
+                warm_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
+                warm += filtered.num_rows();
+                warm_writer.write(&filtered)?;
+            } else {
+                cold_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
+                cold += filtered.num_rows();
+                cold_writer.write(&filtered)?;
+            }
+        }
+        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
+        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
+        // would silently drop a row with any other value rather than error,
+        // so check explicitly instead of trusting that invariant blindly.
+        if kept_this_batch != reordered.num_rows() {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{plugin_name}/{chrom}]: {} row(s) had a tier value outside {{0,1}} \
+                 and were dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
+                 impossible; investigate before trusting this shard",
+                reordered.num_rows() - kept_this_batch
+            )));
+        }
+    }
+    warm_writer.finish()?;
+    cold_writer.finish()?;
+    Ok((warm, cold))
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -213,9 +313,14 @@ pub async fn build_plugin_chrom(
     // build regardless of partition count. The deduped survivors are
     // re-registered here as a MemTable the join consumes in place of the raw
     // normalized view.
+    // Kept for the sorted retry below (see the fast/retry split further down):
+    // cloning a `Vec<RecordBatch>` only clones the `Arc`-backed column data,
+    // not the underlying buffers, so holding a second copy here is cheap
+    // regardless of chromosome size.
+    let deduped_for_retry = deduped.clone();
     let build_ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
-    let mem = MemTable::try_new(norm_schema, vec![deduped])
+    let mem = MemTable::try_new(norm_schema.clone(), vec![deduped])
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
     build_ctx.register_table(&dedup_view, Arc::new(mem))?;
 
@@ -225,6 +330,8 @@ pub async fn build_plugin_chrom(
         .map_err(|e| DataFusionError::Execution(format!("mkdir {}: {e}", plugin_dir.display())))?;
     let file_name = format!("{}.parquet", canonical_chrom_label(chrom));
     let shard_path = plugin_dir.join(&file_name);
+    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
+    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
 
     // Stream the tiered join output straight into two per-tier temp shards
     // (warm run, cold run) instead of collecting the whole chromosome into one
@@ -232,86 +339,64 @@ pub async fn build_plugin_chrom(
     // sorting it in memory. That collect+concat+sort was the dominant remaining
     // memory cost after `assume_unique` removed the dedup HashSet, and still
     // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
-    // peak memory at O(one batch) instead of O(whole chromosome).
-    //
-    // Correctness needs each tier's rows position-ascending on disk
-    // (`PageDir::resolve_ranges`'s binary search assumes a sorted run). That
-    // does NOT follow from `target_partitions=1` alone: `p LEFT JOIN v` plans
-    // as `HashJoinExec`, and the query optimizer picks which side to hash
-    // (`join_type`) based on relative table size -- for a whole-genome plugin
-    // bigger than the variation probe (CADD, SpliceAI: the configs actually
-    // built and shipped so far) it swaps to `join_type=Right` with the plugin
-    // on the probe side, which DOES stream through unreordered; for a plugin
-    // smaller than the probe (a sparse plugin, a small custom subset, a
-    // low-coverage chrom) it can plan `join_type=Left` with the plugin on the
-    // *build* side instead, whose row order a hash join does not preserve.
-    // `assert_start_monotonic` below checks the actual invariant directly
-    // rather than trusting which side the optimizer chose: a real violation
-    // aborts the build loudly instead of silently writing a shard whose
-    // point-lookup can miss rows that are actually present.
-    let mut stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
-
-    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
-    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
-    let mut warm_writer = PluginShardWriter::create(&warm_tmp, Arc::clone(&out_schema))?;
-    let mut cold_writer = PluginShardWriter::create(&cold_tmp, Arc::clone(&out_schema))?;
-    let (mut warm, mut cold) = (0usize, 0usize);
-    let start_idx = out_schema.index_of("start")?;
-    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
-
-    while let Some(b) = stream.next().await {
-        let batch = b?;
-        if batch.num_rows() == 0 {
-            continue;
+    // peak memory at O(one batch) instead of O(whole chromosome) -- this is
+    // the fast path, and it's correct as long as the plugin's own input
+    // already arrives position-ascending (see the module doc for why that's
+    // enough, regardless of the plugin's size relative to the variation
+    // shard). `write_tiered_shard`'s `assert_start_monotonic` check catches it
+    // directly if that assumption doesn't hold, and the fallback below
+    // re-runs the join with an explicit sort instead of failing.
+    let fast_stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
+    let (warm, cold) = match write_tiered_shard(
+        fast_stream,
+        &out_schema,
+        &warm_tmp,
+        &cold_tmp,
+        chrom,
+        &src.plugin_name,
+    )
+    .await
+    {
+        Ok(counts) => counts,
+        Err(e) if is_order_violation(&e) => {
+            // The plugin's input wasn't globally position-ascending by the
+            // time it reached the join (see the module doc), so a miss row
+            // surfaced out of order. Re-run with `ORDER BY` on a session
+            // whose memory pool can spill to disk -- this is the exception,
+            // not the common case the O(1)-memory streaming write above is
+            // optimized for.
+            info!(
+                "plugin_cache[{}/{chrom}]: tier join did not preserve row order \
+                 ({read_rows} plugin rows this chrom) -- retrying with an explicit sort",
+                src.plugin_name
+            );
+            let sort_runtime = RuntimeEnvBuilder::new()
+                .with_memory_pool(Arc::new(FairSpillPool::new(RETRY_SORT_MEMORY_LIMIT_BYTES)))
+                .build_arc()
+                .map_err(|e| DataFusionError::Execution(format!("retry runtime env: {e}")))?;
+            let sort_ctx = SessionContext::new_with_config_rt(
+                SessionConfig::new().with_target_partitions(1),
+                sort_runtime,
+            );
+            let sort_mem = MemTable::try_new(norm_schema, vec![deduped_for_retry])
+                .map_err(|e| DataFusionError::Execution(format!("retry dedup memtable: {e}")))?;
+            sort_ctx.register_table(&dedup_view, Arc::new(sort_mem))?;
+            let sorted_stream =
+                tiered_stream_sorted(&sort_ctx, &dedup_view, variation_shard).await?;
+            write_tiered_shard(
+                sorted_stream,
+                &out_schema,
+                &warm_tmp,
+                &cold_tmp,
+                chrom,
+                &src.plugin_name,
+            )
+            .await?
         }
-        let reordered = reproject_cast(&batch, &out_schema)?;
-        let tier_col = reordered
-            .column(out_schema.index_of("tier")?)
-            .as_any()
-            .downcast_ref::<Int8Array>()
-            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
-            .clone();
-        let mut kept_this_batch = 0usize;
-        for keep in [0i8, 1i8] {
-            let mask: BooleanArray = (0..reordered.num_rows())
-                .map(|i| Some(tier_col.value(i) == keep))
-                .collect();
-            let filtered = filter_record_batch(&reordered, &mask)
-                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
-            if filtered.num_rows() == 0 {
-                continue;
-            }
-            kept_this_batch += filtered.num_rows();
-            if keep == 0 {
-                warm_last_start =
-                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
-                warm += filtered.num_rows();
-                warm_writer.write(&filtered)?;
-            } else {
-                cold_last_start =
-                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
-                cold += filtered.num_rows();
-                cold_writer.write(&filtered)?;
-            }
-        }
-        // `tier` is derived as `COALESCE(v.tier, 1)` upstream, so it should
-        // never be anything but 0 or 1 -- but the `[0i8, 1i8]` split above
-        // would silently drop a row with any other value rather than error,
-        // so check explicitly instead of trusting that invariant blindly.
-        if kept_this_batch != reordered.num_rows() {
-            return Err(DataFusionError::Execution(format!(
-                "plugin_cache[{}/{chrom}]: {} row(s) had a tier value outside {{0,1}} and were \
-                 dropped by the warm/cold split -- COALESCE(v.tier,1) should make this \
-                 impossible; investigate before trusting this shard",
-                src.plugin_name,
-                reordered.num_rows() - kept_this_batch
-            )));
-        }
-    }
-    warm_writer.finish()?;
-    cold_writer.finish()?;
+        Err(e) => return Err(e),
+    };
     info!(
-        "plugin_cache[{}/{chrom}]: tier-join+streaming-write done, warm={warm} cold={cold}, {:.1}s elapsed",
+        "plugin_cache[{}/{chrom}]: tier-join+write done, warm={warm} cold={cold}, {:.1}s elapsed",
         src.plugin_name,
         t_start.elapsed().as_secs_f64()
     );
@@ -638,6 +723,170 @@ type = "Float32"
         .unwrap();
         let last_seen = assert_start_monotonic(&batch, 0, 0, "1", None).unwrap();
         assert_eq!(last_seen, Some(30));
+    }
+
+    // `write_tiered_shard` must surface a genuine reorder as the same
+    // "not position-ascending" error `assert_start_monotonic` raises directly
+    // (this is what `build_plugin_chrom` pattern-matches on via
+    // `is_order_violation` to decide whether to retry with a sort), and it
+    // must do so without finishing the writers on the failing tier.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_tiered_shard_flags_disordered_input_as_order_violation() {
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("end", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        let make_batch = |starts: &[u32]| {
+            let n = starts.len();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(StringArray::from(vec!["1"; n])),
+                    Arc::new(UInt32Array::from(starts.to_vec())),
+                    Arc::new(UInt32Array::from(starts.to_vec())),
+                    Arc::new(StringArray::from(vec!["A/G"; n])),
+                    Arc::new(Int8Array::from(vec![0i8; n])),
+                ],
+            )
+            .unwrap()
+        };
+        // Two batches, both internally sorted, but the second regresses
+        // relative to the first -- exactly what a hash join's build side can
+        // produce (each batch may look locally fine, the cross-batch order is
+        // what breaks).
+        let batches: Vec<Result<RecordBatch>> =
+            vec![Ok(make_batch(&[100, 200])), Ok(make_batch(&[50, 300]))];
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            futures::stream::iter(batches),
+        ));
+        let dir = tempfile::tempdir().unwrap();
+        let warm = dir.path().join("warm.tmp");
+        let cold = dir.path().join("cold.tmp");
+        let err = write_tiered_shard(stream, &schema, &warm, &cold, "1", "demo")
+            .await
+            .unwrap_err();
+        assert!(is_order_violation(&err), "unexpected error: {err}");
+    }
+
+    // C1 regression, end-to-end: `HashJoinExec`'s `CollectLeft` mode collects
+    // the plugin (LEFT of the LEFT JOIN) into a hash table and streams the
+    // variation probe; a MATCHED row's emission order follows the probe's
+    // scan (fine, since a real variation shard is itself position-sorted),
+    // but an UNMATCHED plugin row is appended afterward by iterating the
+    // plugin's own original row order. A plugin whose rows are already
+    // ascending never regresses under this mechanism regardless of its size
+    // relative to the probe -- but a source that isn't globally sorted (two
+    // files concatenated, an upstream ordering bug) surfaces here as soon as
+    // any of its rows miss the variation probe. Confirmed empirically (not
+    // just asserted) via a temporary EXPLAIN probe against this exact
+    // mechanism before writing this test.
+    //
+    // `build_plugin_chrom` must recover from that with a sort, not hard-fail.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sparse_plugin_with_disordered_source_still_builds_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Plugin: 20 rows, DESCENDING -- simulates a source that isn't
+        // globally position-sorted (e.g. two per-chrom files concatenated
+        // without a merge sort, à la the original CADD SNV+indel bug).
+        let mut tsv_body = String::new();
+        for i in (1..=20u32).rev() {
+            tsv_body.push_str(&format!("chr1\t{}\tA\tG\t0.{i}\n", i * 100));
+        }
+        let tsv = dir.path().join("sparse.tsv.gz");
+        write_gz(&tsv, &tsv_body);
+
+        // Variation shard: none of the plugin's positions have an entry, so
+        // every plugin row misses (tier=1/cold) -- cold-row emission order
+        // follows the plugin's own (here: descending) row order, reproducing
+        // a genuine `assert_start_monotonic` violation. The other 5000 rows
+        // are unrelated positions, matching production's scale (chr22's
+        // variation shard vs. ClinVar's row count is a ~157x skew).
+        let mut var_rows: Vec<(&str, u32, String, i8)> = Vec::new();
+        for i in 0..5000u32 {
+            var_rows.push(("1", 10_000_000 + i, "C/T".to_string(), 1i8));
+        }
+        let var_path = dir.path().join("var.parquet");
+        let var_rows_ref: Vec<(&str, u32, &str, i8)> = var_rows
+            .iter()
+            .map(|(c, s, a, t)| (*c, *s, a.as_str(), *t))
+            .collect();
+        write_synthetic_variation(&var_path, &var_rows_ref);
+
+        let toml = format!(
+            r##"
+plugin_name = "sparse"
+coordinate_system = "1-based"
+ingest_sql = """
+SELECT chrom, CAST(pos AS INT) AS start, CAST(pos AS INT) AS end,
+       concat(ref, '/', alt) AS allele_string, CAST(score AS FLOAT) AS demo_score
+FROM plugin_sparse_src
+"""
+
+[[source]]
+provider = "csv"
+path = "{}"
+  [source.csv]
+  delimiter = "\t"
+  has_header = false
+  compression = "gzip"
+  schema = [
+    {{ name = "chrom", type = "Utf8" }},
+    {{ name = "pos",   type = "Utf8" }},
+    {{ name = "ref",   type = "Utf8" }},
+    {{ name = "alt",   type = "Utf8" }},
+    {{ name = "score", type = "Utf8" }},
+  ]
+
+[[value_columns]]
+column = "demo_score"
+csq_field = "DEMO"
+type = "Float32"
+"##,
+            tsv.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let out = dir.path().join("out");
+        let entry = build_plugin_chrom(&manifest, "sparse.source.toml", &var_path, &out, "1")
+            .await
+            .unwrap();
+        assert_eq!(entry.rows, 20);
+        assert_eq!(entry.warm, 0);
+        assert_eq!(
+            entry.cold, 20,
+            "all 20 plugin rows miss the variation shard"
+        );
+
+        // The on-disk shard must actually be position-ascending -- this is
+        // the real invariant `PageDir::resolve_ranges` depends on, and the
+        // one thing a passing `entry.rows` count alone can't prove.
+        let shard_path = out.join("plugin").join("sparse").join("chr1.parquet");
+        let file = std::fs::File::open(&shard_path).unwrap();
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut starts = Vec::new();
+        for batch in reader {
+            let batch = batch.unwrap();
+            let col = batch
+                .column(batch.schema().index_of("start").unwrap())
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap()
+                .clone();
+            starts.extend((0..col.len()).map(|i| col.value(i)));
+        }
+        assert_eq!(starts.len(), 20);
+        let mut sorted = starts.clone();
+        sorted.sort_unstable();
+        assert_eq!(starts, sorted, "shard on disk is not position-ascending");
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, BooleanArray, Int8Array};
+use datafusion::arrow::array::{Array, BooleanArray, Int8Array, UInt32Array};
 use datafusion::arrow::compute::{cast, filter_record_batch};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -41,6 +41,51 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(Arc::clone(schema), cols)
         .map_err(|e| DataFusionError::Execution(format!("reproject: {e}")))
+}
+
+/// Verify `start` is non-decreasing within `batch` and against `last_seen` (the
+/// previous batch's final `start` for this tier), returning the batch's own
+/// final `start` on success.
+///
+/// The streaming shard write below relies on the tiered join emitting rows in
+/// position-ascending order per tier; that holds by construction for the
+/// query shapes exercised so far (see the comment above the call site), but
+/// `HashJoinExec`'s build/probe side can flip based on table-size statistics
+/// for other plugin/variation size ratios, and a flipped build side does not
+/// preserve row order. Rather than trust that silently, check it: a real
+/// violation aborts the build immediately (no shard is written) instead of
+/// producing a page directory whose binary-search lookup can silently miss
+/// rows that are actually present (`PageDir::resolve_ranges` assumes a
+/// genuinely sorted run).
+fn assert_start_monotonic(
+    batch: &RecordBatch,
+    start_idx: usize,
+    tier: i8,
+    chrom: &str,
+    last_seen: Option<u32>,
+) -> Result<Option<u32>> {
+    let starts = batch
+        .column(start_idx)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .ok_or_else(|| DataFusionError::Execution("start column not UInt32".into()))?;
+    let mut prev = last_seen;
+    for i in 0..starts.len() {
+        let v = starts.value(i);
+        if let Some(p) = prev
+            && v < p
+        {
+            return Err(DataFusionError::Execution(format!(
+                "plugin_cache[{chrom}]: tier {tier} shard write is not position-ascending \
+                 (start {v} follows {p}) -- the tier join did not preserve row order for \
+                 this plugin/variation size ratio; the on-disk point-lookup directory \
+                 requires a sorted shard, so refusing to write a corrupt one. This needs \
+                 a real re-sort of the tier's output, not just a bigger error message."
+            )));
+        }
+        prev = Some(v);
+    }
+    Ok(prev)
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -173,16 +218,21 @@ pub async fn build_plugin_chrom(
     // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
     // peak memory at O(one batch) instead of O(whole chromosome).
     //
-    // Correctness relies on the join preserving row order end to end: the
-    // source scan (`read_ctx`, single partition) yields rows in file order,
-    // which for these per-chrom tabix-extracted sources is position-ascending;
-    // dedup (`dedup_keep_first`/`try_collect`) filters within that order without
-    // reordering; and the tier join (`build_ctx`, now also single partition)
-    // streams the probe side through unreordered. A per-batch tier filter
-    // (`filter_record_batch`) never reorders survivors either, so each tier's
-    // rows stay position-ascending both within a batch and across batches —
-    // meeting the on-disk (tier, start)-sorted contract (`point_lookup_writer_
-    // properties`'s `sorting_columns`) without any explicit sort.
+    // Correctness needs each tier's rows position-ascending on disk
+    // (`PageDir::resolve_ranges`'s binary search assumes a sorted run). That
+    // does NOT follow from `target_partitions=1` alone: `p LEFT JOIN v` plans
+    // as `HashJoinExec`, and the query optimizer picks which side to hash
+    // (`join_type`) based on relative table size -- for a whole-genome plugin
+    // bigger than the variation probe (CADD, SpliceAI: the configs actually
+    // built and shipped so far) it swaps to `join_type=Right` with the plugin
+    // on the probe side, which DOES stream through unreordered; for a plugin
+    // smaller than the probe (a sparse plugin, a small custom subset, a
+    // low-coverage chrom) it can plan `join_type=Left` with the plugin on the
+    // *build* side instead, whose row order a hash join does not preserve.
+    // `assert_start_monotonic` below checks the actual invariant directly
+    // rather than trusting which side the optimizer chose: a real violation
+    // aborts the build loudly instead of silently writing a shard whose
+    // point-lookup can miss rows that are actually present.
     let mut stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
 
     let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
@@ -190,6 +240,8 @@ pub async fn build_plugin_chrom(
     let mut warm_writer = PluginShardWriter::create(&warm_tmp, Arc::clone(&out_schema))?;
     let mut cold_writer = PluginShardWriter::create(&cold_tmp, Arc::clone(&out_schema))?;
     let (mut warm, mut cold) = (0usize, 0usize);
+    let start_idx = out_schema.index_of("start")?;
+    let (mut warm_last_start, mut cold_last_start): (Option<u32>, Option<u32>) = (None, None);
 
     while let Some(b) = stream.next().await {
         let batch = b?;
@@ -213,9 +265,13 @@ pub async fn build_plugin_chrom(
                 continue;
             }
             if keep == 0 {
+                warm_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, warm_last_start)?;
                 warm += filtered.num_rows();
                 warm_writer.write(&filtered)?;
             } else {
+                cold_last_start =
+                    assert_start_monotonic(&filtered, start_idx, keep, chrom, cold_last_start)?;
                 cold += filtered.num_rows();
                 cold_writer.write(&filtered)?;
             }
@@ -477,6 +533,62 @@ type = "Float32"
             PluginScalar::F32(v) => assert!((v - 0.7).abs() < 1e-6),
             ref other => panic!("{other:?}"),
         }
+    }
+
+    // C1 regression: a tiered join that does NOT preserve row order (e.g. the
+    // planner puts the plugin on the hash-build side for a small-plugin/
+    // large-probe query shape) must fail the build loudly rather than write a
+    // shard whose on-disk (tier, start) sort claim is false.
+    #[test]
+    fn assert_start_monotonic_catches_within_batch_disorder() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "start",
+            DataType::UInt32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(UInt32Array::from(vec![10u32, 20, 15]))],
+        )
+        .unwrap();
+        let err = assert_start_monotonic(&batch, 0, 1, "1", None).unwrap_err();
+        assert!(err.to_string().contains("not position-ascending"));
+    }
+
+    #[test]
+    fn assert_start_monotonic_catches_cross_batch_regression() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "start",
+            DataType::UInt32,
+            false,
+        )]));
+        let first = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(UInt32Array::from(vec![100u32]))],
+        )
+        .unwrap();
+        let last_seen = assert_start_monotonic(&first, 0, 0, "1", None).unwrap();
+        assert_eq!(last_seen, Some(100));
+        let second =
+            RecordBatch::try_new(schema, vec![Arc::new(UInt32Array::from(vec![50u32]))]).unwrap();
+        let err = assert_start_monotonic(&second, 0, 0, "1", last_seen).unwrap_err();
+        assert!(err.to_string().contains("not position-ascending"));
+    }
+
+    #[test]
+    fn assert_start_monotonic_accepts_sorted_input() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "start",
+            DataType::UInt32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(UInt32Array::from(vec![10u32, 10, 20, 30]))],
+        )
+        .unwrap();
+        let last_seen = assert_start_monotonic(&batch, 0, 0, "1", None).unwrap();
+        assert_eq!(last_seen, Some(30));
     }
 
     // --chrom M / chrM / MT must all select the MT rows (data is folded to "MT"

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -1,6 +1,19 @@
 //! End-to-end per-chrom plugin cache build: register sources → ingest view →
 //! normalization wrapper → variation-frequency join/tier → two-pass tiered
 //! shard write → cache-manifest chrom entry.
+//!
+//! Known tradeoff (noted during PR #196 review): the tiered join is only
+//! guaranteed to stream in position-ascending order per tier when the
+//! optimizer keeps the plugin on the join's probe side, which needs the
+//! plugin's own row count to be large relative to the chromosome's variation
+//! shard (true for whole-genome plugins like CADD/SpliceAI). A sparse or
+//! low-coverage-chromosome plugin can end up on the *build* side instead,
+//! whose order a hash join doesn't preserve -- `assert_start_monotonic`
+//! below then hard-fails that build rather than silently writing a
+//! wrong-order shard. There is currently no re-sort fallback for that case
+//! (see the review thread on PR #196 for the tradeoff analysis); a future
+//! sparse-plugin manifest that hits this needs one added here, not just a
+//! bigger `assume_unique`-style flag.
 
 use std::path::Path;
 use std::sync::Arc;

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -349,6 +349,7 @@ pub async fn build_plugin_chrom(
     output_cache_root: &Path,
     chrom: &str,
 ) -> Result<ChromEntry> {
+    src.validate()?;
     // Coarse-grained stage timing at `info` level — cheap (a handful of
     // `Instant::now()` calls) and the only thing that would have turned CADD
     // chr6's multi-hour "is it stuck?" investigation (no visibility into

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -349,7 +349,6 @@ pub async fn build_plugin_chrom(
     output_cache_root: &Path,
     chrom: &str,
 ) -> Result<ChromEntry> {
-    src.validate()?;
     // Coarse-grained stage timing at `info` level — cheap (a handful of
     // `Instant::now()` calls) and the only thing that would have turned CADD
     // chr6's multi-hour "is it stuck?" investigation (no visibility into

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -6,15 +6,13 @@ use std::path::Path;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, BooleanArray, Int8Array};
-use datafusion::arrow::compute::{
-    cast, concat_batches, filter_record_batch, sort_to_indices, take,
-};
+use datafusion::arrow::compute::{cast, filter_record_batch};
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
 use datafusion::prelude::{SessionConfig, SessionContext};
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 
 use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
@@ -41,21 +39,6 @@ fn reproject_cast(batch: &RecordBatch, schema: &SchemaRef) -> Result<RecordBatch
         .collect::<Result<Vec<_>>>()?;
     RecordBatch::try_new(Arc::clone(schema), cols)
         .map_err(|e| DataFusionError::Execution(format!("reproject: {e}")))
-}
-
-/// Sort a batch ascending by `start` (the per-tier run order the PageDir needs).
-fn sort_by_start(batch: &RecordBatch) -> Result<RecordBatch> {
-    let start = batch.column(batch.schema().index_of("start")?);
-    let idx = sort_to_indices(start, None, None)
-        .map_err(|e| DataFusionError::Execution(format!("sort_to_indices: {e}")))?;
-    let cols = batch
-        .columns()
-        .iter()
-        .map(|c| take(c, &idx, None))
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| DataFusionError::Execution(format!("take: {e}")))?;
-    RecordBatch::try_new(batch.schema(), cols)
-        .map_err(|e| DataFusionError::Execution(format!("rebuild sorted: {e}")))
 }
 
 /// Build one chromosome's plugin shard. Returns the cache-manifest chrom entry.
@@ -132,14 +115,31 @@ pub async fn build_plugin_chrom(
         .execute_stream()
         .await?;
     let norm_schema = norm_stream.schema();
-    let deduped = dedup_keep_first(norm_stream, &match_cols).await?;
+    // `assume_unique` sources are structurally guaranteed to never repeat a
+    // probe key, so the keep-first pass (a HashSet<String> with one entry per
+    // row — the dominant memory cost on the largest chromosomes) is skipped;
+    // batches are collected as-is.
+    let deduped = if src.assume_unique {
+        norm_stream.try_collect::<Vec<_>>().await?
+    } else {
+        dedup_keep_first(norm_stream, &match_cols).await?
+    };
     // The source scan is done — drop the decompressed temp before the join leg.
     drop(src_temps);
 
-    // Build context: default parallelism for the tier join over the (multi-GB)
-    // variation shard + write. The deduped survivors are re-registered here as a
-    // MemTable the join consumes in place of the raw normalized view.
-    let build_ctx = SessionContext::new();
+    // Build context: single partition, same reasoning as `read_ctx` above — the
+    // streaming write below (see `tiered_stream` consumption) relies on the join
+    // emitting rows in the same position-ascending order the dedup pass fed it,
+    // so it never has to buffer more than one batch. With `target_partitions=1`
+    // there is exactly one task for the whole join, so HashJoinExec has no
+    // opportunity to reorder rows across partitions. The join's build side
+    // (`plugin_variation_probe`, DISTINCT-projected and typically far smaller
+    // than the plugin's own per-chrom row count for whole-genome plugins like
+    // CADD/SpliceAI) is unaffected by this — it's still a single hash-table
+    // build regardless of partition count. The deduped survivors are
+    // re-registered here as a MemTable the join consumes in place of the raw
+    // normalized view.
+    let build_ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
     let mem = MemTable::try_new(norm_schema, vec![deduped])
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
@@ -152,19 +152,71 @@ pub async fn build_plugin_chrom(
     let file_name = format!("{}.parquet", canonical_chrom_label(chrom));
     let shard_path = plugin_dir.join(&file_name);
 
-    // Materialize tiered rows (tier inherited from the variation cache) from the
-    // deduped rows.
+    // Stream the tiered join output straight into two per-tier temp shards
+    // (warm run, cold run) instead of collecting the whole chromosome into one
+    // Vec<RecordBatch>, concat_batches-ing it into a single allocation, and
+    // sorting it in memory. That collect+concat+sort was the dominant remaining
+    // memory cost after `assume_unique` removed the dedup HashSet, and still
+    // OOM'd on the largest chromosomes (chr7, chr8, chrX for CADD). This keeps
+    // peak memory at O(one batch) instead of O(whole chromosome).
+    //
+    // Correctness relies on the join preserving row order end to end: the
+    // source scan (`read_ctx`, single partition) yields rows in file order,
+    // which for these per-chrom tabix-extracted sources is position-ascending;
+    // dedup (`dedup_keep_first`/`try_collect`) filters within that order without
+    // reordering; and the tier join (`build_ctx`, now also single partition)
+    // streams the probe side through unreordered. A per-batch tier filter
+    // (`filter_record_batch`) never reorders survivors either, so each tier's
+    // rows stay position-ascending both within a batch and across batches —
+    // meeting the on-disk (tier, start)-sorted contract (`point_lookup_writer_
+    // properties`'s `sorting_columns`) without any explicit sort.
     let mut stream = tiered_stream(&build_ctx, &dedup_view, variation_shard).await?;
-    let mut batches = Vec::new();
+
+    let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
+    let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
+    let mut warm_writer = PluginShardWriter::create(&warm_tmp, Arc::clone(&out_schema))?;
+    let mut cold_writer = PluginShardWriter::create(&cold_tmp, Arc::clone(&out_schema))?;
+    let (mut warm, mut cold) = (0usize, 0usize);
+
     while let Some(b) = stream.next().await {
-        batches.push(b?);
+        let batch = b?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        let reordered = reproject_cast(&batch, &out_schema)?;
+        let tier_col = reordered
+            .column(out_schema.index_of("tier")?)
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
+            .clone();
+        for keep in [0i8, 1i8] {
+            let mask: BooleanArray = (0..reordered.num_rows())
+                .map(|i| Some(tier_col.value(i) == keep))
+                .collect();
+            let filtered = filter_record_batch(&reordered, &mask)
+                .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
+            if filtered.num_rows() == 0 {
+                continue;
+            }
+            if keep == 0 {
+                warm += filtered.num_rows();
+                warm_writer.write(&filtered)?;
+            } else {
+                cold += filtered.num_rows();
+                cold_writer.write(&filtered)?;
+            }
+        }
     }
+    warm_writer.finish()?;
+    cold_writer.finish()?;
 
     // Empty chrom → no shard (matches variation builder cleanup). Remove any
     // stale shard from a previous build so the manifest (rows: 0) matches disk
     // and the runtime never opens a leftover file for an empty chrom.
-    let non_empty: Vec<RecordBatch> = batches.into_iter().filter(|b| b.num_rows() > 0).collect();
-    if non_empty.is_empty() {
+    if warm + cold == 0 {
+        let _ = std::fs::remove_file(&warm_tmp);
+        let _ = std::fs::remove_file(&cold_tmp);
         let _ = std::fs::remove_file(&shard_path);
         return Ok(ChromEntry {
             chrom: canonical_chrom_label(chrom),
@@ -174,36 +226,25 @@ pub async fn build_plugin_chrom(
             cold: 0,
         });
     }
-    let joined_schema = non_empty[0].schema();
-    let full = concat_batches(&joined_schema, &non_empty)
-        .map_err(|e| DataFusionError::Execution(format!("concat: {e}")))?;
-    let reordered = reproject_cast(&full, &out_schema)?;
 
-    // Split into warm (0) then cold (1) runs, each start-sorted, and write.
-    let tier_col = reordered
-        .column(out_schema.index_of("tier")?)
-        .as_any()
-        .downcast_ref::<Int8Array>()
-        .ok_or_else(|| DataFusionError::Execution("tier column not Int8".into()))?
-        .clone();
-    let (mut warm, mut cold) = (0usize, 0usize);
+    // Merge: final shard = warm run then cold run. Both temps are already
+    // start-sorted by construction (see above), so this is a plain streaming
+    // batch-by-batch copy into the final writer (which carries the point-lookup
+    // page-index properties) — no sort, O(one batch) memory.
     let mut writer = PluginShardWriter::create(&shard_path, Arc::clone(&out_schema))?;
-    for keep in [0i8, 1i8] {
-        let mask: BooleanArray = (0..reordered.num_rows())
-            .map(|i| Some(tier_col.value(i) == keep))
-            .collect();
-        let filtered = filter_record_batch(&reordered, &mask)
-            .map_err(|e| DataFusionError::Execution(format!("filter tier {keep}: {e}")))?;
-        if filtered.num_rows() == 0 {
-            continue;
+    for tmp in [&warm_tmp, &cold_tmp] {
+        let file = std::fs::File::open(tmp)
+            .map_err(|e| DataFusionError::Execution(format!("open temp {}: {e}", tmp.display())))?;
+        let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+            .map_err(|e| DataFusionError::Execution(format!("open temp reader: {e}")))?
+            .build()
+            .map_err(|e| DataFusionError::Execution(format!("build temp reader: {e}")))?;
+        for batch in reader {
+            let batch =
+                batch.map_err(|e| DataFusionError::Execution(format!("read temp batch: {e}")))?;
+            writer.write(&batch)?;
         }
-        let sorted = sort_by_start(&filtered)?;
-        if keep == 0 {
-            warm += sorted.num_rows();
-        } else {
-            cold += sorted.num_rows();
-        }
-        writer.write(&sorted)?;
+        let _ = std::fs::remove_file(tmp);
     }
     let rows = writer.finish()?;
     if rows == 0 {

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -28,7 +28,7 @@ use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::MemTable;
-use datafusion::execution::memory_pool::FairSpillPool;
+use datafusion::execution::memory_pool::{FairSpillPool, MemoryPool};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -40,6 +40,7 @@ use crate::cache::manifest::canonical_chrom_label;
 use crate::plugin_cache::cache_manifest::ChromEntry;
 use crate::plugin_cache::dedup::{check_assume_unique_sample, dedup_keep_first};
 use crate::plugin_cache::join::{tiered_stream, tiered_stream_sorted};
+use crate::plugin_cache::mem_trace;
 use crate::plugin_cache::normalize::{
     canonical_contig_str, canonical_contig_udf, wrap_normalization,
 };
@@ -438,10 +439,20 @@ pub async fn build_plugin_chrom(
                  ({read_rows} plugin rows this chrom) -- retrying with an explicit sort",
                 src.plugin_name
             );
+            // Wrap the pool when tracing is on: the exhaustion error names the
+            // consumer ("HashJoinInput") and this plan has two joins under that
+            // name, so only per-reservation tracking can say which one consumed
+            // the budget.
+            let base_pool: Arc<dyn MemoryPool> =
+                Arc::new(FairSpillPool::new(retry_sort_memory_limit_bytes()));
+            let tracer = mem_trace::tracing_enabled()
+                .then(|| Arc::new(mem_trace::TracingPool::new(Arc::clone(&base_pool))));
+            let pool: Arc<dyn MemoryPool> = match &tracer {
+                Some(t) => Arc::clone(t) as _,
+                None => Arc::clone(&base_pool),
+            };
             let sort_runtime = RuntimeEnvBuilder::new()
-                .with_memory_pool(Arc::new(
-                    FairSpillPool::new(retry_sort_memory_limit_bytes()),
-                ))
+                .with_memory_pool(pool)
                 .build_arc()
                 .map_err(|e| DataFusionError::Execution(format!("retry runtime env: {e}")))?;
             let sort_ctx = SessionContext::new_with_config_rt(
@@ -453,7 +464,7 @@ pub async fn build_plugin_chrom(
             sort_ctx.register_table(&dedup_view, Arc::new(sort_mem))?;
             let sorted_stream =
                 tiered_stream_sorted(&sort_ctx, &dedup_view, variation_shard).await?;
-            write_tiered_shard(
+            let written = write_tiered_shard(
                 sorted_stream,
                 &out_schema,
                 &warm_tmp,
@@ -461,7 +472,13 @@ pub async fn build_plugin_chrom(
                 chrom,
                 &src.plugin_name,
             )
-            .await?
+            .await;
+            // Report before propagating: the peak table is the whole point of
+            // tracing a build that ran out of memory.
+            if let Some(t) = &tracer {
+                t.report();
+            }
+            written?
         }
         Err(e) => return Err(e),
     };

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -132,13 +132,10 @@ fn is_order_violation(e: &DataFusionError) -> bool {
 /// and failing the build outright. 8 GiB clears it with room to spare (peak
 /// RSS 1.7 GB, builds in 0.2 min) while still bounding a runaway plan.
 ///
-/// This does NOT fix CADD, and no pool size does. Its reservation grows to
-/// consume whatever budget it is given -- 2.03 GB at a 2 GiB pool, 6.4 GB at
-/// 8 GiB, 22.6 GB at 24 GiB -- and fails each time asking for the same
-/// 592.7 MB increment, while peak RSS plateaus around 17 GB. So the
-/// accounting outruns what is actually materialized, and raising the ceiling
-/// only moves the failure. See the tier-join analysis on PR #217; the fix
-/// there is structural, not a bigger number.
+/// CADD also fits this budget once `materialize_probe` copies its build input
+/// into execution-sized owned batches. Before that structural fix, DataFusion
+/// 53 repeatedly charged shared backing buffers and exhausted every tested
+/// ceiling while RSS stayed flat; raising this default only moved the failure.
 const DEFAULT_RETRY_SORT_MEMORY_MIB: usize = 8 * 1024;
 
 /// Env override for [`DEFAULT_RETRY_SORT_MEMORY_MIB`], in MiB.

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -167,6 +167,28 @@ fn retry_sort_memory_limit_bytes() -> usize {
 /// `PluginShardWriter::create` truncates its target path, so calling this
 /// twice at the same `warm_path`/`cold_path` (fast attempt, then sorted retry)
 /// is safe -- the first attempt's partial output is simply overwritten.
+/// Session config for the tier-join passes.
+///
+/// `schema_force_view_types` is DataFusion's default-on parquet behaviour of
+/// reading `Utf8` columns as `Utf8View`. It is off here for a specific reason:
+/// a `StringViewArray`'s views point into data buffers that are SHARED across
+/// the batches a scan emits, and `HashJoinExec` reserves memory per batch via
+/// `get_record_batch_memory_size`, which de-duplicates buffers only WITHIN one
+/// batch. So every batch re-counts the whole shared buffer, and the build-side
+/// reservation grows by (batch count) x (buffer size) while only one copy
+/// exists. Measured on CADD chr21: a ~600 MB build side reserved 6.95 GB at an
+/// 8 GiB pool and 23.15 GB at 24 GiB -- always the same 592.7 MB increment,
+/// once per batch -- while process RSS stayed flat near 16 GB. Reading plain
+/// `Utf8` gives each batch its own buffers, so the accounting matches reality.
+/// It also drops the `CAST(... AS Utf8View)` nodes the mismatch forced into
+/// the join keys.
+fn tier_join_config() -> SessionConfig {
+    SessionConfig::new().with_target_partitions(1).set_bool(
+        "datafusion.execution.parquet.schema_force_view_types",
+        false,
+    )
+}
+
 /// Deletes the build's scratch shards unless the build reached the point of
 /// consuming them.
 ///
@@ -386,7 +408,7 @@ pub async fn build_plugin_chrom(
     // not the underlying buffers, so holding a second copy here is cheap
     // regardless of chromosome size.
     let deduped_for_retry = deduped.clone();
-    let build_ctx = SessionContext::new_with_config(SessionConfig::new().with_target_partitions(1));
+    let build_ctx = SessionContext::new_with_config(tier_join_config());
     let dedup_view = format!("plugin_{}_dedup", src.plugin_name);
     let mem = MemTable::try_new(norm_schema.clone(), vec![deduped])
         .map_err(|e| DataFusionError::Execution(format!("dedup memtable: {e}")))?;
@@ -455,10 +477,7 @@ pub async fn build_plugin_chrom(
                 .with_memory_pool(pool)
                 .build_arc()
                 .map_err(|e| DataFusionError::Execution(format!("retry runtime env: {e}")))?;
-            let sort_ctx = SessionContext::new_with_config_rt(
-                SessionConfig::new().with_target_partitions(1),
-                sort_runtime,
-            );
+            let sort_ctx = SessionContext::new_with_config_rt(tier_join_config(), sort_runtime);
             let sort_mem = MemTable::try_new(norm_schema, vec![deduped_for_retry])
                 .map_err(|e| DataFusionError::Execution(format!("retry dedup memtable: {e}")))?;
             sort_ctx.register_table(&dedup_view, Arc::new(sort_mem))?;

--- a/datafusion/bio-function-vep/src/plugin_cache/build.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/build.rs
@@ -19,7 +19,7 @@
 //! build. The sort only runs on the retry, so a normally-sorted source (every
 //! plugin shipped so far) pays nothing extra.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, BooleanArray, Int8Array, UInt32Array};
@@ -134,6 +134,41 @@ const RETRY_SORT_MEMORY_LIMIT_BYTES: usize = 2 * 1024 * 1024 * 1024;
 /// `PluginShardWriter::create` truncates its target path, so calling this
 /// twice at the same `warm_path`/`cold_path` (fast attempt, then sorted retry)
 /// is safe -- the first attempt's partial output is simply overwritten.
+/// Deletes the build's scratch shards unless the build reached the point of
+/// consuming them.
+///
+/// `PluginShardWriter::create` truncates, so a leftover `.tmp` is harmless to
+/// the *next* build -- but a build that dies partway (a full disk during
+/// `writer.write`, an order violation the retry also fails) would otherwise
+/// leave up to two chromosome-sized scratch files behind, on the same disk
+/// whose exhaustion caused the failure. Every early return from
+/// `build_plugin_chrom` past the point the paths are chosen runs this.
+struct ScratchGuard(Vec<PathBuf>);
+
+impl ScratchGuard {
+    fn new(paths: impl IntoIterator<Item = PathBuf>) -> Self {
+        Self(paths.into_iter().collect())
+    }
+
+    fn watch(&mut self, path: PathBuf) {
+        self.0.push(path);
+    }
+
+    /// Stop watching: the scratch files have been consumed into the final
+    /// shard (or deliberately removed), so dropping must not delete anything.
+    fn disarm(mut self) {
+        self.0.clear();
+    }
+}
+
+impl Drop for ScratchGuard {
+    fn drop(&mut self) {
+        for path in &self.0 {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 async fn write_tiered_shard(
     mut stream: SendableRecordBatchStream,
     out_schema: &SchemaRef,
@@ -332,6 +367,7 @@ pub async fn build_plugin_chrom(
     let shard_path = plugin_dir.join(&file_name);
     let warm_tmp = plugin_dir.join(format!("{file_name}.warm.tmp"));
     let cold_tmp = plugin_dir.join(format!("{file_name}.cold.tmp"));
+    let mut scratch = ScratchGuard::new([warm_tmp.clone(), cold_tmp.clone()]);
 
     // Stream the tiered join output straight into two per-tier temp shards
     // (warm run, cold run) instead of collecting the whole chromosome into one
@@ -405,8 +441,6 @@ pub async fn build_plugin_chrom(
     // stale shard from a previous build so the manifest (rows: 0) matches disk
     // and the runtime never opens a leftover file for an empty chrom.
     if warm + cold == 0 {
-        let _ = std::fs::remove_file(&warm_tmp);
-        let _ = std::fs::remove_file(&cold_tmp);
         let _ = std::fs::remove_file(&shard_path);
         return Ok(ChromEntry {
             chrom: canonical_chrom_label(chrom),
@@ -430,6 +464,7 @@ pub async fn build_plugin_chrom(
     // overwrites it -- a rename is atomic on the same filesystem, so a crash
     // here instead leaves either the previous good shard (if any) or nothing.
     let merge_tmp = plugin_dir.join(format!("{file_name}.merge.tmp"));
+    scratch.watch(merge_tmp.clone());
     let mut writer = PluginShardWriter::create(&merge_tmp, Arc::clone(&out_schema))?;
     for tmp in [&warm_tmp, &cold_tmp] {
         let file = std::fs::File::open(tmp)
@@ -458,6 +493,7 @@ pub async fn build_plugin_chrom(
             ))
         })?;
     }
+    scratch.disarm();
     info!(
         "plugin_cache[{}/{chrom}]: done, rows={rows}, {:.1}s total",
         src.plugin_name,
@@ -730,6 +766,34 @@ type = "Float32"
     // (this is what `build_plugin_chrom` pattern-matches on via
     // `is_order_violation` to decide whether to retry with a sort), and it
     // must do so without finishing the writers on the failing tier.
+    #[test]
+    fn scratch_guard_removes_watched_files_unless_disarmed() {
+        let dir = tempfile::tempdir().unwrap();
+        let (dropped, kept) = (dir.path().join("a.tmp"), dir.path().join("b.tmp"));
+        std::fs::write(&dropped, b"x").unwrap();
+        std::fs::write(&kept, b"x").unwrap();
+
+        drop(ScratchGuard::new([dropped.clone()]));
+        assert!(
+            !dropped.exists(),
+            "a failed build must not leave scratch behind"
+        );
+
+        ScratchGuard::new([kept.clone()]).disarm();
+        assert!(
+            kept.exists(),
+            "disarm must not delete a consumed scratch file"
+        );
+    }
+
+    #[test]
+    fn scratch_guard_tolerates_files_the_merge_already_consumed() {
+        let dir = tempfile::tempdir().unwrap();
+        let gone = dir.path().join("already-removed.tmp");
+        drop(ScratchGuard::new([gone.clone()]));
+        assert!(!gone.exists());
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn write_tiered_shard_flags_disordered_input_as_order_violation() {
         use datafusion::physical_plan::stream::RecordBatchStreamAdapter;

--- a/datafusion/bio-function-vep/src/plugin_cache/builder.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/builder.rs
@@ -357,9 +357,13 @@ type = "Float32"
                 column: "score".into(),
                 csq_field: csq.into(),
                 ty: "Float32".into(),
+                description: None,
             }],
             chroms: vec![],
             cache_source_version: None,
+            allele_match: Default::default(),
+            csq_rank: 0,
+            field_order: Default::default(),
         };
         assert!(schema_matches(&mk("DEMO"), &mk("DEMO")));
         assert!(!schema_matches(&mk("DEMO"), &mk("DEMO2")));

--- a/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use datafusion::common::{DataFusionError, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::plugin_cache::source_manifest::{SourceManifest, ValueType};
+use crate::plugin_cache::source_manifest::{SourceManifest, ValueType, validate_csq_field_name};
 
 /// Per-chromosome build result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,6 +117,13 @@ fn ty_str(t: ValueType) -> &'static str {
 }
 
 impl CacheManifest {
+    fn validate(&self) -> Result<()> {
+        for value in &self.value_columns {
+            validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
+        }
+        Ok(())
+    }
+
     /// Seed a cache manifest from a source manifest (chroms filled in by the build).
     pub fn from_source(src: &SourceManifest, source_manifest_file: &str) -> Self {
         CacheManifest {
@@ -156,6 +163,7 @@ impl CacheManifest {
 
     /// Write `manifest.json` into `plugin_dir`.
     pub fn write(&self, plugin_dir: &Path) -> Result<()> {
+        self.validate()?;
         let json = serde_json::to_string_pretty(self)
             .map_err(|e| DataFusionError::Execution(format!("serialize manifest: {e}")))?;
         std::fs::write(plugin_dir.join("manifest.json"), json)
@@ -182,11 +190,10 @@ pub fn discover_plugins(cache_root: &Path) -> Result<Vec<CacheManifest>> {
         if mf.exists() {
             let text = std::fs::read_to_string(&mf)
                 .map_err(|e| DataFusionError::Execution(format!("read {}: {e}", mf.display())))?;
-            out.push(
-                serde_json::from_str(&text).map_err(|e| {
-                    DataFusionError::Execution(format!("parse {}: {e}", mf.display()))
-                })?,
-            );
+            let manifest: CacheManifest = serde_json::from_str(&text)
+                .map_err(|e| DataFusionError::Execution(format!("parse {}: {e}", mf.display())))?;
+            manifest.validate()?;
+            out.push(manifest);
         }
     }
     out.sort_by(|a: &CacheManifest, b: &CacheManifest| {
@@ -204,7 +211,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plugin_dir = dir.path().join("plugin").join("demo");
         std::fs::create_dir_all(&plugin_dir).unwrap();
-        let m = CacheManifest {
+        let mut m = CacheManifest {
             plugin_name: "demo".into(),
             source_manifest: "demo.source.toml".into(),
             key_columns: vec![
@@ -232,5 +239,30 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].plugin_name, "demo");
         assert_eq!(found[0].chroms[0].rows, 3);
+
+        m.value_columns = vec![ValueColumnRecord {
+            column: "score".into(),
+            csq_field: "INFO".into(),
+            ty: "Utf8".into(),
+            description: Some("reserved collision".into()),
+        }];
+        let error = m.write(&plugin_dir).unwrap_err().to_string();
+        assert!(
+            error.contains("reserved VCF meta-information key"),
+            "{error}"
+        );
+
+        // Runtime discovery validates older or externally-created manifests too,
+        // rather than trusting that every cache passed through `write`.
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&m).unwrap(),
+        )
+        .unwrap();
+        let error = discover_plugins(dir.path()).unwrap_err().to_string();
+        assert!(
+            error.contains("reserved VCF meta-information key"),
+            "{error}"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
@@ -27,6 +27,11 @@ pub struct ValueColumnRecord {
     pub csq_field: String,
     #[serde(rename = "type")]
     pub ty: String,
+    /// Free text for this field's `##<CSQ_FIELD>=<description>` VCF header
+    /// line. Ensembl plugins supply one via `get_header_info()`; absent here
+    /// means no header line is written for the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// A per-transcript match discriminator binding, recorded so the runtime knows
@@ -48,6 +53,59 @@ pub struct CacheManifest {
     pub value_columns: Vec<ValueColumnRecord>,
     pub chroms: Vec<ChromEntry>,
     pub cache_source_version: Option<String>,
+    /// How Ensembl's own plugin matches a variant to a data row. Defaults to
+    /// [`AlleleMatch::Exact`], which is what most plugins do.
+    #[serde(default)]
+    pub allele_match: AlleleMatch,
+    /// Position of this plugin's field block in the CSQ string. Ensembl emits
+    /// `--plugin` blocks in the order the flags were given and appends
+    /// `--custom` blocks last, so the order is a convention rather than
+    /// something derivable from the cache; it is pinned here. Plugins sharing a
+    /// rank fall back to plugin-name order.
+    #[serde(default = "default_csq_rank")]
+    pub csq_rank: u32,
+    /// Field order *within* this plugin's block. Ensembl's plugin framework
+    /// emits a plugin's own fields sorted by name, while `--custom` fields keep
+    /// the order the user listed them in.
+    #[serde(default)]
+    pub field_order: FieldOrder,
+}
+
+fn default_csq_rank() -> u32 {
+    u32::MAX
+}
+
+/// Same default, reachable from the source manifest's serde attribute.
+pub fn default_csq_rank_pub() -> u32 {
+    default_csq_rank()
+}
+
+/// Field ordering within one plugin's CSQ block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FieldOrder {
+    /// Manifest declaration order — matches Ensembl `--custom` behaviour.
+    #[default]
+    Declared,
+    /// Sorted by CSQ field name — matches Ensembl's `--plugin` behaviour.
+    Alphabetical,
+}
+
+/// The allele-comparison rule a plugin's Ensembl implementation uses, which
+/// decides whether an equal-length substitution may be reduced before probing.
+///
+/// `Minimised` plugins call `get_matched_variant_alleles()`, which runs
+/// `trim_sequences()` over both the variant and the data row — so an untrimmed
+/// MNV such as `TTGTGTGTGTGTG/GTGTGTGTGTGTG` matches CADD's `T/G` row.
+/// `Exact` plugins compare `(start, ref, alt)` verbatim (SpliceAI, dbNSFP) and
+/// must never be probed with a reduced allele, or they gain hits Ensembl does
+/// not report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AlleleMatch {
+    #[default]
+    Exact,
+    Minimised,
 }
 
 fn ty_str(t: ValueType) -> &'static str {
@@ -85,10 +143,14 @@ impl CacheManifest {
                     column: v.column.clone(),
                     csq_field: v.csq_field.clone(),
                     ty: ty_str(v.ty).into(),
+                    description: v.description.clone(),
                 })
                 .collect(),
             chroms: vec![],
             cache_source_version: None,
+            allele_match: src.allele_match,
+            csq_rank: src.csq_rank,
+            field_order: src.field_order,
         }
     }
 
@@ -101,8 +163,9 @@ impl CacheManifest {
     }
 }
 
-/// Discover built plugins under `<cache_root>/plugin/*/manifest.json`, sorted by
-/// plugin name for deterministic CSQ field ordering.
+/// Discover built plugins under `<cache_root>/plugin/*/manifest.json`, ordered by
+/// `csq_rank` then plugin name so the emitted CSQ field blocks are deterministic
+/// and can be pinned to the order Ensembl VEP writes them in.
 pub fn discover_plugins(cache_root: &Path) -> Result<Vec<CacheManifest>> {
     let plugin_root = cache_root.join("plugin");
     let mut out = Vec::new();
@@ -126,7 +189,9 @@ pub fn discover_plugins(cache_root: &Path) -> Result<Vec<CacheManifest>> {
             );
         }
     }
-    out.sort_by(|a: &CacheManifest, b: &CacheManifest| a.plugin_name.cmp(&b.plugin_name));
+    out.sort_by(|a: &CacheManifest, b: &CacheManifest| {
+        (a.csq_rank, &a.plugin_name).cmp(&(b.csq_rank, &b.plugin_name))
+    });
     Ok(out)
 }
 
@@ -158,6 +223,9 @@ mod tests {
                 cold: 2,
             }],
             cache_source_version: None,
+            allele_match: Default::default(),
+            csq_rank: 0,
+            field_order: Default::default(),
         };
         m.write(&plugin_dir).unwrap();
         let found = discover_plugins(dir.path()).unwrap();

--- a/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
@@ -264,5 +264,14 @@ mod tests {
             error.contains("reserved VCF meta-information key"),
             "{error}"
         );
+
+        m.value_columns[0].csq_field = "SCORE\n##injected".into();
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&m).unwrap(),
+        )
+        .unwrap();
+        let error = discover_plugins(dir.path()).unwrap_err().to_string();
+        assert!(error.contains("invalid CSQ field name"), "{error}");
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use datafusion::common::{DataFusionError, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::plugin_cache::source_manifest::{SourceManifest, ValueType};
+use crate::plugin_cache::source_manifest::{SourceManifest, ValueType, validate_csq_field_name};
 
 /// Per-chromosome build result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,6 +117,13 @@ fn ty_str(t: ValueType) -> &'static str {
 }
 
 impl CacheManifest {
+    fn validate(&self) -> Result<()> {
+        for value in &self.value_columns {
+            validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
+        }
+        Ok(())
+    }
+
     /// Seed a cache manifest from a source manifest (chroms filled in by the build).
     pub fn from_source(src: &SourceManifest, source_manifest_file: &str) -> Self {
         CacheManifest {
@@ -156,6 +163,7 @@ impl CacheManifest {
 
     /// Write `manifest.json` into `plugin_dir`.
     pub fn write(&self, plugin_dir: &Path) -> Result<()> {
+        self.validate()?;
         let json = serde_json::to_string_pretty(self)
             .map_err(|e| DataFusionError::Execution(format!("serialize manifest: {e}")))?;
         std::fs::write(plugin_dir.join("manifest.json"), json)
@@ -182,11 +190,10 @@ pub fn discover_plugins(cache_root: &Path) -> Result<Vec<CacheManifest>> {
         if mf.exists() {
             let text = std::fs::read_to_string(&mf)
                 .map_err(|e| DataFusionError::Execution(format!("read {}: {e}", mf.display())))?;
-            out.push(
-                serde_json::from_str(&text).map_err(|e| {
-                    DataFusionError::Execution(format!("parse {}: {e}", mf.display()))
-                })?,
-            );
+            let manifest: CacheManifest = serde_json::from_str(&text)
+                .map_err(|e| DataFusionError::Execution(format!("parse {}: {e}", mf.display())))?;
+            manifest.validate()?;
+            out.push(manifest);
         }
     }
     out.sort_by(|a: &CacheManifest, b: &CacheManifest| {
@@ -204,7 +211,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plugin_dir = dir.path().join("plugin").join("demo");
         std::fs::create_dir_all(&plugin_dir).unwrap();
-        let m = CacheManifest {
+        let mut m = CacheManifest {
             plugin_name: "demo".into(),
             source_manifest: "demo.source.toml".into(),
             key_columns: vec![
@@ -232,5 +239,30 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].plugin_name, "demo");
         assert_eq!(found[0].chroms[0].rows, 3);
+
+        m.value_columns = vec![ValueColumnRecord {
+            column: "score".into(),
+            csq_field: "fileformat".into(),
+            ty: "Utf8".into(),
+            description: Some("must not replace VCFv4.2".into()),
+        }];
+        let error = m.write(&plugin_dir).unwrap_err().to_string();
+        assert!(
+            error.contains("reserved VCF meta-information key"),
+            "{error}"
+        );
+
+        // Runtime discovery also protects old or externally-created caches
+        // that did not pass through this version's `write` method.
+        std::fs::write(
+            plugin_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&m).unwrap(),
+        )
+        .unwrap();
+        let error = discover_plugins(dir.path()).unwrap_err().to_string();
+        assert!(
+            error.contains("reserved VCF meta-information key"),
+            "{error}"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use datafusion::common::{DataFusionError, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::plugin_cache::source_manifest::{SourceManifest, ValueType, validate_csq_field_name};
+use crate::plugin_cache::source_manifest::{SourceManifest, ValueType};
 
 /// Per-chromosome build result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,13 +117,6 @@ fn ty_str(t: ValueType) -> &'static str {
 }
 
 impl CacheManifest {
-    fn validate(&self) -> Result<()> {
-        for value in &self.value_columns {
-            validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
-        }
-        Ok(())
-    }
-
     /// Seed a cache manifest from a source manifest (chroms filled in by the build).
     pub fn from_source(src: &SourceManifest, source_manifest_file: &str) -> Self {
         CacheManifest {
@@ -163,7 +156,6 @@ impl CacheManifest {
 
     /// Write `manifest.json` into `plugin_dir`.
     pub fn write(&self, plugin_dir: &Path) -> Result<()> {
-        self.validate()?;
         let json = serde_json::to_string_pretty(self)
             .map_err(|e| DataFusionError::Execution(format!("serialize manifest: {e}")))?;
         std::fs::write(plugin_dir.join("manifest.json"), json)
@@ -190,10 +182,11 @@ pub fn discover_plugins(cache_root: &Path) -> Result<Vec<CacheManifest>> {
         if mf.exists() {
             let text = std::fs::read_to_string(&mf)
                 .map_err(|e| DataFusionError::Execution(format!("read {}: {e}", mf.display())))?;
-            let manifest: CacheManifest = serde_json::from_str(&text)
-                .map_err(|e| DataFusionError::Execution(format!("parse {}: {e}", mf.display())))?;
-            manifest.validate()?;
-            out.push(manifest);
+            out.push(
+                serde_json::from_str(&text).map_err(|e| {
+                    DataFusionError::Execution(format!("parse {}: {e}", mf.display()))
+                })?,
+            );
         }
     }
     out.sort_by(|a: &CacheManifest, b: &CacheManifest| {
@@ -211,7 +204,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let plugin_dir = dir.path().join("plugin").join("demo");
         std::fs::create_dir_all(&plugin_dir).unwrap();
-        let mut m = CacheManifest {
+        let m = CacheManifest {
             plugin_name: "demo".into(),
             source_manifest: "demo.source.toml".into(),
             key_columns: vec![
@@ -239,30 +232,5 @@ mod tests {
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].plugin_name, "demo");
         assert_eq!(found[0].chroms[0].rows, 3);
-
-        m.value_columns = vec![ValueColumnRecord {
-            column: "score".into(),
-            csq_field: "INFO".into(),
-            ty: "Utf8".into(),
-            description: Some("reserved collision".into()),
-        }];
-        let error = m.write(&plugin_dir).unwrap_err().to_string();
-        assert!(
-            error.contains("reserved VCF meta-information key"),
-            "{error}"
-        );
-
-        // Runtime discovery validates older or externally-created manifests too,
-        // rather than trusting that every cache passed through `write`.
-        std::fs::write(
-            plugin_dir.join("manifest.json"),
-            serde_json::to_string_pretty(&m).unwrap(),
-        )
-        .unwrap();
-        let error = discover_plugins(dir.path()).unwrap_err().to_string();
-        assert!(
-            error.contains("reserved VCF meta-information key"),
-            "{error}"
-        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/csq.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/csq.rs
@@ -8,16 +8,18 @@
 use crate::plugin_cache::lookup::PluginScalar;
 
 /// Escape a plugin string value for the CSQ payload, mirroring the engine's
-/// built-in `csq_escape`: `,`/`|` → `&`, `;` → `%3B`, whitespace → `_`. Without
-/// this a Utf8 plugin value containing a CSQ/INFO delimiter would corrupt field
-/// or entry boundaries. (The built-in `-`→empty convention is deliberately NOT
-/// applied to plugin values, so a legitimate `-` is preserved.)
+/// built-in `csq_escape`: `,`/`|` → `&`, `;` → `%3B`, `=` → `%3D`,
+/// whitespace → `_`. Without this a Utf8 plugin value containing a CSQ/INFO
+/// delimiter would corrupt field or entry boundaries. (The built-in
+/// `-`→empty convention is deliberately NOT applied to plugin values, so a
+/// legitimate `-` is preserved.)
 fn escape_csq_value(val: &str) -> String {
     let mut out = String::with_capacity(val.len());
     for ch in val.chars() {
         match ch {
             ',' | '|' => out.push('&'),
             ';' => out.push_str("%3B"),
+            '=' => out.push_str("%3D"),
             c if c.is_whitespace() => out.push('_'),
             c => out.push(c),
         }
@@ -66,6 +68,10 @@ mod tests {
             "a&b%3Bc_d"
         );
         assert_eq!(format_scalar(&PluginScalar::Str("x,y".into())), "x&y");
+        assert_eq!(
+            format_scalar(&PluginScalar::Str("base_change=G_to_A".into())),
+            "base_change%3DG_to_A"
+        );
         // AlphaMissense-style values contain none → unchanged (parity-safe)
         assert_eq!(
             format_scalar(&PluginScalar::Str("likely_benign".into())),

--- a/datafusion/bio-function-vep/src/plugin_cache/dedup.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/dedup.rs
@@ -96,6 +96,77 @@ pub async fn dedup_keep_first(
     Ok(out)
 }
 
+/// Bound on how many distinct keys `check_assume_unique_sample` tracks before
+/// it stops checking. An `assume_unique` source skips `dedup_keep_first`
+/// entirely to avoid materializing a `HashSet<String>` sized to the whole
+/// chromosome (the dominant remaining memory cost on CADD/SpliceAI's largest
+/// chromosomes) -- so this check trades exhaustive coverage for a hard,
+/// small memory ceiling: it validates the FIRST `SAMPLE_CAP` distinct keys
+/// seen (in source-file order) and then stops, rather than either costing
+/// nothing (leaving the assumption fully untested) or costing exactly what
+/// the flag exists to avoid (an exhaustive `HashSet`).
+const SAMPLE_CAP: usize = 2_000_000;
+
+/// Validate (a bounded prefix of) an `assume_unique` source's claim that it
+/// never repeats a runtime probe key, without filtering anything.
+///
+/// A violated assumption is caught here rather than left to the runtime
+/// lookup `HashMap`, which keeps the *last* row of a duplicate key --
+/// silently inverting VEP's first-in-file rule (see module docs). This
+/// checks only the first `SAMPLE_CAP` distinct keys encountered so memory
+/// stays bounded regardless of chromosome size; a source whose duplicates
+/// only occur past that prefix will not be caught by this pass.
+pub async fn check_assume_unique_sample(
+    mut stream: SendableRecordBatchStream,
+    match_columns: &[String],
+) -> Result<Vec<RecordBatch>> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<RecordBatch> = Vec::new();
+    let opts = FormatOptions::default().with_null("\u{0}NULL");
+
+    let mut key_names: Vec<&str> = vec!["start", "allele_string"];
+    key_names.extend(match_columns.iter().map(|s| s.as_str()));
+
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        if seen.len() < SAMPLE_CAP {
+            let schema = batch.schema();
+            let formatters = key_names
+                .iter()
+                .map(|name| {
+                    let idx = schema.index_of(name)?;
+                    ArrayFormatter::try_new(batch.column(idx).as_ref(), &opts).map_err(|e| {
+                        DataFusionError::Execution(format!("key formatter {name}: {e}"))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let mut key = String::new();
+            for r in 0..batch.num_rows() {
+                if seen.len() >= SAMPLE_CAP {
+                    break;
+                }
+                use std::fmt::Write;
+                key.clear();
+                for f in &formatters {
+                    let _ = write!(key, "{}{KEY_SEP}", f.value(r));
+                }
+                if !seen.insert(std::mem::take(&mut key)) {
+                    return Err(DataFusionError::Execution(
+                        "assume_unique source violated its own claim: a duplicate runtime \
+                         probe key was found in the first sampled rows. The manifest's \
+                         `assume_unique = true` is unsafe for this source -- remove it so \
+                         the keep-first dedup pass runs (VEP's first-in-file rule), or fix \
+                         the source if the duplicate is unexpected."
+                            .into(),
+                    ));
+                }
+            }
+        }
+        out.push(batch);
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,6 +259,44 @@ mod tests {
         // The distinct aa-change at the same position survives (not over-deduped).
         assert!(survivors.iter().any(|(pv, _)| pv == "K55N"));
         assert!(survivors.iter().any(|(pv, _)| pv == "D43Y"));
+    }
+
+    // I2 fix: an `assume_unique` source that actually repeats a probe key must
+    // be caught, not silently accepted (the runtime lookup would then keep the
+    // *last* duplicate, inverting VEP's first-in-file rule).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_assume_unique_sample_rejects_a_real_duplicate() {
+        let stream = stream_of(norm_batch()).await;
+        let err = check_assume_unique_sample(stream, &["protein_variant".to_string()])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("violated its own claim"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_assume_unique_sample_passes_genuinely_unique_input() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::Int64, false),
+            Field::new("end", DataType::Int64, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("score", DataType::Float32, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(Int64Array::from(vec![50i64, 51])),
+                Arc::new(Int64Array::from(vec![50i64, 51])),
+                Arc::new(StringArray::from(vec!["A/G", "C/T"])),
+                Arc::new(Float32Array::from(vec![Some(1.0f32), Some(2.0)])),
+            ],
+        )
+        .unwrap();
+        let stream = stream_of(batch).await;
+        let out = check_assume_unique_sample(stream, &[]).await.unwrap();
+        let rows: usize = out.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(rows, 2, "unique input must pass through untouched");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/datafusion/bio-function-vep/src/plugin_cache/dedup.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/dedup.rs
@@ -9,10 +9,11 @@
 //! `HashMap` keyed on the probe key, so a duplicate key silently keeps whichever
 //! row the shard emits *last* — the opposite of VEP.
 //!
-//! This pass collapses each key to its **first** occurrence in stream order. It
-//! MUST run over a single-partition, file-ordered stream (the builder sets
-//! `target_partitions = 1`) and BEFORE the tier LEFT-JOIN, which reorders rows and
-//! would otherwise destroy the file-order tiebreak.
+//! This pass collapses each key to its **first** occurrence in stream order. The
+//! builder parses physical source partitions concurrently, collects them while
+//! preserving partition identity, and replays them in source-range order before
+//! calling this pass. It MUST run before the tier LEFT-JOIN, which reorders rows
+//! and would otherwise destroy the file-order tiebreak.
 
 use std::collections::HashSet;
 
@@ -28,7 +29,7 @@ use futures::StreamExt;
 /// allele / amino-acid-change strings, so it can't collide two distinct keys.
 const KEY_SEP: char = '\u{1f}';
 
-/// Consume `stream` (single-partition, source-file order) and return its batches
+/// Consume `stream` (ordered source-partition replay) and return its batches
 /// with only the **first** row per `(start, allele_string, <match col values…>)`
 /// key retained — matching VEP's first-in-file rule. Later duplicates are dropped.
 ///

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -58,6 +58,66 @@ pub async fn tiered_stream_sorted(
     tiered_stream_impl(ctx, normalized_view, variation_shard, true).await
 }
 
+/// Rows per materialized probe batch. Each batch is built by its own `concat`,
+/// so it owns its buffers; the size is a balance between allocation count and
+/// keeping a single batch small enough to stay cheap to copy.
+const PROBE_BATCH_ROWS: usize = 1024 * 1024;
+
+/// Replace the `plugin_variation_probe` view with an equivalent table whose
+/// batches own their buffers.
+///
+/// The view is a `GROUP BY`, and `GroupedHashAggregateStream` emits its output
+/// as batches that SHARE underlying buffers. `HashJoinExec` reserves memory per
+/// build-side batch using `get_record_batch_memory_size`, which de-duplicates
+/// buffers only WITHIN one batch -- so a shared buffer is charged once per
+/// batch that references it. Measured on chr21's variation shard: the grouped
+/// output is 181.4 MB of distinct buffers but accounts as 5756.8 MB across its
+/// 1791 batches, a 31.7x over-count. The same scan WITHOUT the `GROUP BY`
+/// accounts at exactly 1.0x, so this is the aggregate's doing, not the scan's.
+///
+/// That over-count is what made CADD chr21 unbuildable: the tier join's build
+/// side is this probe (its plan swaps to `join_type=Right` because 120M plugin
+/// rows dwarf the 10.8M-row probe), so the join reserved ~6.8 GB for ~200 MB of
+/// data and exhausted any pool it was given.
+///
+/// Materializing with a `concat` per batch gives each batch fresh, unshared
+/// buffers, so the reservation matches reality. It also lifts the aggregate out
+/// of the join plan, so it runs once and the optimizer sees exact statistics
+/// for the side it is choosing.
+async fn materialize_probe(ctx: &SessionContext) -> Result<()> {
+    use datafusion::arrow::compute::concat_batches;
+
+    let df = ctx.sql("SELECT * FROM plugin_variation_probe").await?;
+    let schema: datafusion::arrow::datatypes::SchemaRef = df.schema().inner().clone();
+    let collected = df.collect().await?;
+
+    let mut batches = Vec::new();
+    let mut group = Vec::new();
+    let mut rows = 0usize;
+    for batch in collected {
+        rows += batch.num_rows();
+        group.push(batch);
+        if rows >= PROBE_BATCH_ROWS {
+            batches.push(concat_batches(&schema, &group)?);
+            group.clear();
+            rows = 0;
+        }
+    }
+    if !group.is_empty() {
+        batches.push(concat_batches(&schema, &group)?);
+    }
+
+    ctx.deregister_table("plugin_variation_probe")?;
+    ctx.register_table(
+        "plugin_variation_probe",
+        std::sync::Arc::new(datafusion::datasource::MemTable::try_new(
+            schema,
+            vec![batches],
+        )?),
+    )?;
+    Ok(())
+}
+
 async fn tiered_stream_impl(
     ctx: &SessionContext,
     normalized_view: &str,
@@ -110,6 +170,7 @@ async fn tiered_stream_impl(
          GROUP BY v.chrom, v.start, v.allele_string"
     ))
     .await?;
+    materialize_probe(ctx).await?;
     let sql = if sorted {
         tier_sql_sorted(normalized_view, "plugin_variation_probe")
     } else {

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -21,12 +21,47 @@ pub fn tier_sql(normalized_view: &str, variation_probe: &str) -> String {
     )
 }
 
+/// Same join, with an explicit `ORDER BY` so the output is position-ascending
+/// regardless of which side of the physical `HashJoinExec` the optimizer put
+/// the plugin on (see `build.rs`'s module doc). Used only as the retry path
+/// after the cheap, unsorted `tiered_stream` trips `assert_start_monotonic` --
+/// the sort is real work, so it's not paid by the common case (a whole-genome
+/// plugin bigger than the variation probe, which streams through unreordered
+/// already).
+pub fn tier_sql_sorted(normalized_view: &str, variation_probe: &str) -> String {
+    format!(
+        "{} ORDER BY p.start",
+        tier_sql(normalized_view, variation_probe)
+    )
+}
+
 /// Register the variation shard as a `tier`-bearing probe view, then stream the
-/// tiered rows (tier inherited from the variation record).
+/// tiered rows (tier inherited from the variation record) in whatever order
+/// the join happens to produce.
 pub async fn tiered_stream(
     ctx: &SessionContext,
     normalized_view: &str,
     variation_shard: &Path,
+) -> Result<SendableRecordBatchStream> {
+    tiered_stream_impl(ctx, normalized_view, variation_shard, false).await
+}
+
+/// Same as `tiered_stream`, but the output is guaranteed position-ascending on
+/// `start` (see `tier_sql_sorted`). Costs a real sort -- use only as the
+/// fallback once the unsorted stream has been shown to need it.
+pub async fn tiered_stream_sorted(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    variation_shard: &Path,
+) -> Result<SendableRecordBatchStream> {
+    tiered_stream_impl(ctx, normalized_view, variation_shard, true).await
+}
+
+async fn tiered_stream_impl(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    variation_shard: &Path,
+    sorted: bool,
 ) -> Result<SendableRecordBatchStream> {
     let shard = variation_shard.to_string_lossy();
     ctx.register_parquet(
@@ -74,9 +109,12 @@ pub async fn tiered_stream(
          GROUP BY v.chrom, v.start, v.allele_string"
     ))
     .await?;
-    let df = ctx
-        .sql(&tier_sql(normalized_view, "plugin_variation_probe"))
-        .await?;
+    let sql = if sorted {
+        tier_sql_sorted(normalized_view, "plugin_variation_probe")
+    } else {
+        tier_sql(normalized_view, "plugin_variation_probe")
+    };
+    let df = ctx.sql(&sql).await?;
     df.execute_stream().await
 }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -39,11 +39,13 @@ pub fn tier_sql(normalized_view: &str, variation_probe: &str) -> String {
     )
 }
 
-/// Same join, with an explicit `ORDER BY` so the output is position-ascending
-/// regardless of the chosen join algorithm or execution partition count.
+/// Same join, with the exact physical shard order: warm rows first, then cold,
+/// and position-ascending inside each tier. This lets the consumer write one
+/// Parquet file directly instead of encoding two tier files and decoding them
+/// again for a final merge.
 pub fn tier_sql_sorted(normalized_view: &str, variation_probe: &str) -> String {
     format!(
-        "{} ORDER BY p.start",
+        "SELECT * FROM ({}) tiered ORDER BY tier, start",
         tier_sql(normalized_view, variation_probe)
     )
 }
@@ -59,8 +61,8 @@ pub async fn tiered_stream(
     tiered_stream_impl(ctx, normalized_view, variation_shard, false).await
 }
 
-/// Same as `tiered_stream`, but the output is guaranteed position-ascending on
-/// `start` (see `tier_sql_sorted`).
+/// Same as `tiered_stream`, but output is guaranteed lexicographically sorted
+/// by `(tier, start)` (see `tier_sql_sorted`).
 pub async fn tiered_stream_sorted(
     ctx: &SessionContext,
     normalized_view: &str,
@@ -319,7 +321,7 @@ async fn materialize_probe_adaptive(
 
 async fn register_variation_probe_view(
     ctx: &SessionContext,
-    normalized_view: &str,
+    variation_key_view: &str,
     variation_shard: &Path,
 ) -> Result<()> {
     let shard = variation_shard.to_string_lossy();
@@ -348,9 +350,9 @@ async fn register_variation_probe_view(
         // fan out, which is a (data-dependent) join-skew risk this GROUP BY
         // removes entirely rather than merely reduces.
         //
-        // The inner JOIN against a DISTINCT projection of the plugin's own
-        // per-chromosome keys is a semi-join emulation that restricts the
-        // aggregation to keys the plugin table actually has, computed BEFORE
+        // The LEFT SEMI JOIN against the plugin's own per-chromosome keys
+        // restricts the aggregation to keys the plugin table actually has,
+        // computed BEFORE
         // the `GROUP BY` rather than after: for a sparse plugin (far fewer
         // rows than the chromosome's full variation shard), grouping the
         // *entire* shard
@@ -358,13 +360,14 @@ async fn register_variation_probe_view(
         // JOIN below never uses (variation rows with no matching plugin key
         // can never survive a `p.*`-projected LEFT JOIN regardless).
         // Semantically a no-op — this narrows which rows get grouped, not
-        // which key wins ties or what a hit resolves to. The DISTINCT makes
-        // the plugin-side key unique, preventing duplicate plugin keys from
-        // multiplying rows before the variation GROUP BY collapses them.
+        // which key wins ties or what a hit resolves to. A true semi join
+        // cannot multiply variation rows when a plugin key is duplicated, so
+        // it removes the DISTINCT aggregate and its shared-buffer output from
+        // directly below the join while preserving the previous semantics.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
          SELECT v.start, v.allele_string, MIN(v.tier) AS tier \
          FROM plugin_variation_raw v \
-         INNER JOIN (SELECT DISTINCT start, allele_string FROM {normalized_view}) p \
+         LEFT SEMI JOIN {variation_key_view} p \
          ON v.start = p.start AND v.allele_string = p.allele_string \
          GROUP BY v.start, v.allele_string"
     ))
@@ -407,11 +410,12 @@ async fn tiered_stream_impl(
 pub(crate) async fn tiered_stream_sorted_adaptive(
     ctx: &SessionContext,
     normalized_view: &str,
+    variation_key_view: &str,
     variation_shard: &Path,
     pool: &dyn MemoryPool,
     tracer: &TracingPool,
 ) -> Result<AdaptiveTieredStream> {
-    register_variation_probe_view(ctx, normalized_view, variation_shard).await?;
+    register_variation_probe_view(ctx, variation_key_view, variation_shard).await?;
     materialize_probe_adaptive(ctx, pool, tracer).await?;
 
     let sql = tier_sql_sorted(normalized_view, "plugin_variation_probe");
@@ -745,6 +749,7 @@ mod tests {
         let adaptive = tiered_stream_sorted_adaptive(
             &ctx,
             "plugin_demo_norm",
+            "plugin_demo_norm",
             &variation_path,
             tracer.as_ref(),
             tracer.as_ref(),
@@ -859,6 +864,81 @@ mod tests {
         // absence from `plugin_variation_raw`'s post-semi-join scan is the
         // thing under test, not something directly observable in the output.
         assert_eq!(rows, vec![(100, 0), (300, 1)]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn variation_probe_uses_true_semi_join_without_distinct_aggregate() {
+        let dir = tempfile::tempdir().unwrap();
+        let variation_schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        let variation = RecordBatch::try_new(
+            variation_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 100, 999])),
+                Arc::new(StringArray::from(vec!["A/G", "A/G", "C/T"])),
+                Arc::new(Int8Array::from(vec![1i8, 0, 0])),
+            ],
+        )
+        .unwrap();
+        let variation_path = dir.path().join("variation.parquet");
+        let file = std::fs::File::create(&variation_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, variation_schema, None).unwrap();
+        writer.write(&variation).unwrap();
+        writer.close().unwrap();
+
+        // Duplicate right-side keys must not multiply the variation rows.
+        let key_schema = Arc::new(Schema::new(vec![
+            Field::new("start", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+        ]));
+        let keys = RecordBatch::try_new(
+            key_schema,
+            vec![
+                Arc::new(UInt32Array::from(vec![100u32, 100])),
+                Arc::new(StringArray::from(vec!["A/G", "A/G"])),
+            ],
+        )
+        .unwrap();
+        let ctx = SessionContext::new();
+        ctx.register_batch("plugin_keys", keys).unwrap();
+        register_variation_probe_view(&ctx, "plugin_keys", &variation_path)
+            .await
+            .unwrap();
+
+        let df = ctx
+            .sql("SELECT * FROM plugin_variation_probe")
+            .await
+            .unwrap();
+        let logical = df.logical_plan().display_indent().to_string();
+        assert!(
+            logical.contains("LeftSemi Join"),
+            "unexpected plan:\n{logical}"
+        );
+        assert_eq!(
+            logical.matches("Aggregate:").count(),
+            1,
+            "the MIN(tier) aggregation should be the only aggregate:\n{logical}"
+        );
+
+        let batches = df.collect().await.unwrap();
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        let batch = &batches[0];
+        let starts = batch
+            .column(batch.schema().index_of("start").unwrap())
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let tiers = batch
+            .column(batch.schema().index_of("tier").unwrap())
+            .as_any()
+            .downcast_ref::<Int8Array>()
+            .unwrap();
+        assert_eq!((starts.value(0), tiers.value(0)), (100, 0));
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -36,8 +36,13 @@ pub async fn tiered_stream(
     )
     .await?;
     ctx.sql(
+        // DISTINCT: the variation shard can carry multiple source rows for the
+        // same (chrom, start, allele_string) (e.g. distinct dbSNP/COSMIC-origin
+        // entries for one variant). Without it, the tier LEFT JOIN below fans
+        // out the plugin row once per matching variation row, inflating the
+        // built cache with duplicate (but value-identical) rows.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT chrom, start, allele_string, tier FROM plugin_variation_raw",
+         SELECT DISTINCT chrom, start, allele_string, tier FROM plugin_variation_raw",
     )
     .await?;
     let df = ctx

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -5,6 +5,9 @@
 
 use std::path::Path;
 
+use datafusion::arrow::compute::concat_batches;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::Result;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::SessionContext;
@@ -58,10 +61,66 @@ pub async fn tiered_stream_sorted(
     tiered_stream_impl(ctx, normalized_view, variation_shard, true).await
 }
 
-/// Rows per materialized probe batch. Each batch is built by its own `concat`,
-/// so it owns its buffers; the size is a balance between allocation count and
-/// keeping a single batch small enough to stay cheap to copy.
-const PROBE_BATCH_ROWS: usize = 1024 * 1024;
+/// Concatenate `parts` into a batch that owns its buffers even when there is
+/// only one part. Arrow's one-input `concat_batches` fast path is zero-copy, so
+/// split that input into two logical parts to force the normal copying path.
+fn concat_probe_parts_owned(schema: &SchemaRef, parts: &[RecordBatch]) -> Result<RecordBatch> {
+    debug_assert!(!parts.is_empty());
+    if parts.len() == 1 {
+        let batch = &parts[0];
+        let midpoint = batch.num_rows() / 2;
+        let first = batch.slice(0, midpoint);
+        let second = batch.slice(midpoint, batch.num_rows() - midpoint);
+        Ok(concat_batches(schema, [&first, &second])?)
+    } else {
+        Ok(concat_batches(schema, parts)?)
+    }
+}
+
+/// Copy input into independently allocated batches no larger than the
+/// execution batch size. DataFusion 53 wraps MemTables in `BatchSplitStream`;
+/// oversized parents would otherwise be split into zero-copy children and the
+/// hash join would reserve the full parent once per child.
+fn rechunk_probe_owned(
+    schema: &SchemaRef,
+    input: Vec<RecordBatch>,
+    target_rows: usize,
+) -> Result<Vec<RecordBatch>> {
+    if target_rows == 0 {
+        return datafusion::common::exec_err!("probe materialization batch size must be non-zero");
+    }
+
+    let total_rows: usize = input.iter().map(RecordBatch::num_rows).sum();
+    let mut output = Vec::with_capacity(total_rows.div_ceil(target_rows));
+    let mut parts = Vec::new();
+    let mut part_rows = 0usize;
+
+    for batch in input {
+        let mut offset = 0usize;
+        while offset < batch.num_rows() {
+            let take = (target_rows - part_rows).min(batch.num_rows() - offset);
+            parts.push(batch.slice(offset, take));
+            part_rows += take;
+            offset += take;
+
+            if part_rows == target_rows {
+                output.push(concat_probe_parts_owned(schema, &parts)?);
+                parts.clear();
+                part_rows = 0;
+            }
+        }
+    }
+
+    if part_rows != 0 {
+        output.push(concat_probe_parts_owned(schema, &parts)?);
+    }
+    debug_assert_eq!(
+        output.iter().map(RecordBatch::num_rows).sum::<usize>(),
+        total_rows
+    );
+    debug_assert!(output.iter().all(|batch| batch.num_rows() <= target_rows));
+    Ok(output)
+}
 
 /// Replace the `plugin_variation_probe` view with an equivalent table whose
 /// batches own their buffers.
@@ -75,37 +134,23 @@ const PROBE_BATCH_ROWS: usize = 1024 * 1024;
 /// 1791 batches, a 31.7x over-count. The same scan WITHOUT the `GROUP BY`
 /// accounts at exactly 1.0x, so this is the aggregate's doing, not the scan's.
 ///
-/// That over-count is what made CADD chr21 unbuildable: the tier join's build
-/// side is this probe (its plan swaps to `join_type=Right` because 120M plugin
-/// rows dwarf the 10.8M-row probe), so the join reserved ~6.8 GB for ~200 MB of
-/// data and exhausted any pool it was given.
+/// CADD exposes this because the tier join's build side is this probe (its plan
+/// swaps to `join_type=Right` because 120M plugin rows dwarf the 10.8M-row
+/// probe). An earlier 1,048,576-row materialization removed the aggregate's
+/// sharing, but DataFusion's MemTable scan split each parent into 128 zero-copy
+/// 8,192-row slices and charged the full parent for every slice. The resulting
+/// reservation exceeded 20 GB for ~180 MB of distinct probe buffers.
 ///
-/// Materializing with a `concat` per batch gives each batch fresh, unshared
-/// buffers, so the reservation matches reality. It also lifts the aggregate out
-/// of the join plan, so it runs once and the optimizer sees exact statistics
-/// for the side it is choosing.
+/// Materializing into owned batches no larger than the execution batch size
+/// gives each batch fresh, unshared buffers and prevents DataFusion 53 from
+/// re-slicing large MemTable parents into zero-copy children. The reservation
+/// therefore matches reality. It also lifts the aggregate out of the join plan,
+/// so it runs once and the optimizer sees exact statistics for side selection.
 async fn materialize_probe(ctx: &SessionContext) -> Result<()> {
-    use datafusion::arrow::compute::concat_batches;
-
     let df = ctx.sql("SELECT * FROM plugin_variation_probe").await?;
-    let schema: datafusion::arrow::datatypes::SchemaRef = df.schema().inner().clone();
+    let schema: SchemaRef = df.schema().inner().clone();
     let collected = df.collect().await?;
-
-    let mut batches = Vec::new();
-    let mut group = Vec::new();
-    let mut rows = 0usize;
-    for batch in collected {
-        rows += batch.num_rows();
-        group.push(batch);
-        if rows >= PROBE_BATCH_ROWS {
-            batches.push(concat_batches(&schema, &group)?);
-            group.clear();
-            rows = 0;
-        }
-    }
-    if !group.is_empty() {
-        batches.push(concat_batches(&schema, &group)?);
-    }
+    let batches = rechunk_probe_owned(&schema, collected, ctx.copied_config().batch_size())?;
 
     ctx.deregister_table("plugin_variation_probe")?;
     ctx.register_table(
@@ -347,5 +392,132 @@ mod tests {
         // value column preserved, variation columns dropped
         assert!(b.schema().index_of("demo_score").is_ok());
         assert!(b.schema().index_of("tier").is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn owned_probe_chunks_are_not_resplit_or_overcounted() {
+        use datafusion::common::utils::memory::get_record_batch_memory_size;
+        use datafusion::datasource::MemTable;
+        use datafusion::execution::memory_pool::FairSpillPool;
+        use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+        use datafusion::physical_plan::displayable;
+        use datafusion::prelude::SessionConfig;
+
+        const EXECUTION_BATCH_ROWS: usize = 8192;
+        const PARENT_ROWS: usize = 1024 * 1024;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::UInt32,
+            false,
+        )]));
+        let parent = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(UInt32Array::from_iter_values(
+                (0..PARENT_ROWS).map(|value| value as u32),
+            ))],
+        )
+        .unwrap();
+        let parent_size = get_record_batch_memory_size(&parent);
+
+        // Model aggregate output: execution-sized zero-copy slices retaining
+        // one large parent. Rechunking must copy even though each output group
+        // consists of exactly one input slice.
+        let shared_chunks = (0..PARENT_ROWS)
+            .step_by(EXECUTION_BATCH_ROWS)
+            .map(|offset| parent.slice(offset, EXECUTION_BATCH_ROWS))
+            .collect();
+        let owned_chunks =
+            rechunk_probe_owned(&schema, shared_chunks, EXECUTION_BATCH_ROWS).unwrap();
+        assert_eq!(owned_chunks.len(), PARENT_ROWS / EXECUTION_BATCH_ROWS);
+        assert!(
+            owned_chunks
+                .iter()
+                .all(|batch| batch.num_rows() <= EXECUTION_BATCH_ROWS)
+        );
+        assert_eq!(
+            owned_chunks
+                .iter()
+                .map(get_record_batch_memory_size)
+                .sum::<usize>(),
+            parent_size
+        );
+
+        // DataSourceExec must emit the owned batches unchanged and retain 1x
+        // accounting, rather than turning large parents into shared slices.
+        let ctx = SessionContext::new();
+        ctx.register_table(
+            "owned_probe",
+            Arc::new(MemTable::try_new(schema.clone(), vec![owned_chunks.clone()]).unwrap()),
+        )
+        .unwrap();
+        let executed = ctx
+            .sql("SELECT * FROM owned_probe")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(executed.len(), PARENT_ROWS / EXECUTION_BATCH_ROWS);
+        assert_eq!(
+            executed
+                .iter()
+                .map(get_record_batch_memory_size)
+                .sum::<usize>(),
+            parent_size
+        );
+
+        // Confirm the exact CADD plan shape now fits a bounded pool far below
+        // the old 128x (512 MiB) reservation.
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(Arc::new(FairSpillPool::new(64 * 1024 * 1024)))
+            .build_arc()
+            .unwrap();
+        let bounded_ctx = SessionContext::new_with_config_rt(
+            SessionConfig::new().with_target_partitions(1),
+            runtime,
+        );
+        bounded_ctx
+            .register_table(
+                "owned_probe",
+                Arc::new(MemTable::try_new(schema.clone(), vec![owned_chunks]).unwrap()),
+            )
+            .unwrap();
+        bounded_ctx
+            .register_batch(
+                "plugin",
+                RecordBatch::try_new(
+                    schema,
+                    vec![Arc::new(UInt32Array::from_iter_values(
+                        (0..(2 * PARENT_ROWS)).map(|value| value as u32),
+                    ))],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let joined = bounded_ctx
+            .sql(
+                "SELECT p.value FROM plugin p \
+                 LEFT JOIN owned_probe o ON p.value = o.value",
+            )
+            .await
+            .unwrap();
+        let plan = joined.clone().create_physical_plan().await.unwrap();
+        assert!(
+            displayable(plan.as_ref())
+                .indent(true)
+                .to_string()
+                .contains("mode=CollectLeft, join_type=Right")
+        );
+        assert_eq!(
+            joined
+                .collect()
+                .await
+                .unwrap()
+                .iter()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            2 * PARENT_ROWS
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -76,10 +76,10 @@ pub(crate) struct AdaptiveTieredStream {
     pub algorithm: JoinAlgorithm,
 }
 
-fn is_hash_join_resources_exhausted(error: &DataFusionError) -> bool {
+fn is_consumer_resources_exhausted(error: &DataFusionError, consumer: &str) -> bool {
     matches!(
         error.find_root(),
-        DataFusionError::ResourcesExhausted(message) if message.contains("HashJoinInput")
+        DataFusionError::ResourcesExhausted(message) if message.contains(consumer)
     )
 }
 
@@ -89,8 +89,24 @@ pub(crate) fn should_retry_hash_join(
     pool: &TracingPool,
 ) -> bool {
     algorithm == JoinAlgorithm::Hash
-        && is_hash_join_resources_exhausted(error)
+        && is_consumer_resources_exhausted(error, "HashJoinInput")
         && pool.hash_join_failed()
+}
+
+/// Retry the final sorted query when either its unspillable hash build or the
+/// downstream external sorter exhausts the pool. The sorter case matters when
+/// the hash estimate technically fits but leaves too little working memory for
+/// `ORDER BY tier, start`; dropping the hash plan before replanning as SMJ frees
+/// that reservation without relying on a fixed headroom guess.
+pub(crate) fn should_retry_final_hash_plan(
+    error: &DataFusionError,
+    algorithm: JoinAlgorithm,
+    pool: &TracingPool,
+) -> bool {
+    should_retry_hash_join(error, algorithm, pool)
+        || (algorithm == JoinAlgorithm::Hash
+            && is_consumer_resources_exhausted(error, "ExternalSorter")
+            && pool.external_sorter_failed())
 }
 
 async fn set_prefer_hash_join(ctx: &SessionContext, prefer: bool) -> Result<()> {
@@ -424,9 +440,9 @@ pub(crate) async fn tiered_stream_sorted_adaptive(
     tracer.clear_failures();
     match execute_stream(plan, ctx.task_ctx()) {
         Ok(stream) => Ok(AdaptiveTieredStream { stream, algorithm }),
-        Err(error) if should_retry_hash_join(&error, algorithm, tracer) => {
+        Err(error) if should_retry_final_hash_plan(&error, algorithm, tracer) => {
             info!(
-                "plugin_cache: tier HashJoin exhausted its reservation before streaming; retrying with DataFusion SortMergeJoin"
+                "plugin_cache: final HashJoin plan exhausted the pool before streaming; retrying with DataFusion SortMergeJoin"
             );
             Ok(AdaptiveTieredStream {
                 stream: tiered_stream_sorted_sort_merge(ctx, normalized_view, tracer).await?,
@@ -589,6 +605,37 @@ mod tests {
             JoinAlgorithm::Hash,
             tracer.as_ref()
         ));
+        assert!(should_retry_final_hash_plan(
+            &sort_error,
+            JoinAlgorithm::Hash,
+            tracer.as_ref()
+        ));
+        assert!(!should_retry_final_hash_plan(
+            &sort_error,
+            JoinAlgorithm::SortMerge,
+            tracer.as_ref()
+        ));
+    }
+
+    #[test]
+    fn final_hash_plan_retries_when_live_hash_starves_external_sorter() {
+        let tracer = Arc::new(TracingPool::new(Arc::new(FairSpillPool::new(100))));
+        let pool: Arc<dyn MemoryPool> = Arc::clone(&tracer) as _;
+        let hash_reservation = MemoryConsumer::new("HashJoinInput").register(&pool);
+        hash_reservation.try_grow(90).unwrap();
+
+        let sort_reservation = MemoryConsumer::new("ExternalSorter").register(&pool);
+        let error = sort_reservation.try_grow(20).unwrap_err();
+        assert!(should_retry_final_hash_plan(
+            &error,
+            JoinAlgorithm::Hash,
+            tracer.as_ref()
+        ));
+
+        // Replanning drops the unspillable build, leaving the same bounded
+        // pool able to grant the sorter's working reservation.
+        drop(hash_reservation);
+        sort_reservation.try_grow(20).unwrap();
     }
 
     #[tokio::test]

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -1,37 +1,46 @@
-//! Variation-tier inheritance: LEFT-joins the normalized plugin rows against the
-//! variation shard on `(chrom, start, allele_string)` and inherits the variation
-//! record's `tier` (`COALESCE(v.tier, 1)` — no match → cold). Variation columns
-//! drop; only the plugin's value columns plus `tier` survive.
+//! Variation-tier inheritance: within one validated chromosome, LEFT-joins the
+//! normalized plugin rows against the variation shard on `(start, allele_string)`
+//! and inherits the variation record's `tier` (`COALESCE(v.tier, 1)` — no match
+//! → cold). Variation columns drop; only the plugin's value columns plus `tier`
+//! survive.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use datafusion::arrow::compute::concat_batches;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::common::Result;
-use datafusion::physical_plan::SendableRecordBatchStream;
+use datafusion::common::utils::memory::get_record_batch_memory_size;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::MemTable;
+use datafusion::execution::memory_pool::MemoryPool;
+use datafusion::physical_plan::{
+    ExecutionPlan, SendableRecordBatchStream, collect, displayable, execute_stream,
+};
 use datafusion::prelude::SessionContext;
 use log::info;
 
+use crate::plugin_cache::join_strategy::{
+    JoinAlgorithm, JoinDecision, choose_for_hash_plan, contains_sort_merge_join,
+};
+use crate::plugin_cache::mem_trace::TracingPool;
+
 /// SQL that LEFT-joins `normalized_view` to a registered `variation_probe`
-/// exposing `(chrom, start, allele_string, tier)` and inherits `tier`. The value
-/// columns of `normalized_view` pass through (`p.*`); variation columns drop.
+/// exposing `(start, allele_string, tier)` and inherits `tier`. Both inputs are
+/// already restricted to one chromosome, so carrying that constant string in
+/// the physical join key only increases memory. The value columns of
+/// `normalized_view` pass through (`p.*`); variation columns drop.
 pub fn tier_sql(normalized_view: &str, variation_probe: &str) -> String {
     format!(
         "SELECT p.*, CAST(COALESCE(v.tier, 1) AS TINYINT) AS tier \
          FROM {normalized_view} p \
          LEFT JOIN {variation_probe} v \
-         ON p.chrom = v.chrom AND p.start = v.start AND p.allele_string = v.allele_string"
+         ON p.start = v.start AND p.allele_string = v.allele_string"
     )
 }
 
 /// Same join, with an explicit `ORDER BY` so the output is position-ascending
-/// regardless of which side of the physical `HashJoinExec` the optimizer put
-/// the plugin on (see `build.rs`'s module doc). Used only as the retry path
-/// after the cheap, unsorted `tiered_stream` trips `assert_start_monotonic` --
-/// the sort is real work, so it's not paid by the common case (a whole-genome
-/// plugin bigger than the variation probe, which streams through unreordered
-/// already).
+/// regardless of the chosen join algorithm or execution partition count.
 pub fn tier_sql_sorted(normalized_view: &str, variation_probe: &str) -> String {
     format!(
         "{} ORDER BY p.start",
@@ -51,14 +60,101 @@ pub async fn tiered_stream(
 }
 
 /// Same as `tiered_stream`, but the output is guaranteed position-ascending on
-/// `start` (see `tier_sql_sorted`). Costs a real sort -- use only as the
-/// fallback once the unsorted stream has been shown to need it.
+/// `start` (see `tier_sql_sorted`).
 pub async fn tiered_stream_sorted(
     ctx: &SessionContext,
     normalized_view: &str,
     variation_shard: &Path,
 ) -> Result<SendableRecordBatchStream> {
     tiered_stream_impl(ctx, normalized_view, variation_shard, true).await
+}
+
+pub(crate) struct AdaptiveTieredStream {
+    pub stream: SendableRecordBatchStream,
+    pub algorithm: JoinAlgorithm,
+}
+
+fn is_hash_join_resources_exhausted(error: &DataFusionError) -> bool {
+    matches!(
+        error.find_root(),
+        DataFusionError::ResourcesExhausted(message) if message.contains("HashJoinInput")
+    )
+}
+
+pub(crate) fn should_retry_hash_join(
+    error: &DataFusionError,
+    algorithm: JoinAlgorithm,
+    pool: &TracingPool,
+) -> bool {
+    algorithm == JoinAlgorithm::Hash
+        && is_hash_join_resources_exhausted(error)
+        && pool.hash_join_failed()
+}
+
+async fn set_prefer_hash_join(ctx: &SessionContext, prefer: bool) -> Result<()> {
+    ctx.sql(&format!(
+        "SET datafusion.optimizer.prefer_hash_join = {prefer}"
+    ))
+    .await?;
+    Ok(())
+}
+
+fn log_decision(stage: &str, target_partitions: usize, decision: &JoinDecision) {
+    info!(
+        "plugin_cache: adaptive join stage={stage} target_partitions={target_partitions} algorithm={:?} reason={:?} \
+         build_rows={:?} build_data_bytes={:?} hash_build_bytes={:?} available_bytes={:?}",
+        decision.algorithm,
+        decision.reason,
+        decision.build_rows,
+        decision.build_data_bytes,
+        decision.hash_build_bytes,
+        decision.available_bytes,
+    );
+}
+
+fn log_plan(stage: &str, plan: &dyn ExecutionPlan) {
+    if std::env::var("VEPYR_EXPLAIN_TIER_JOIN").is_ok() {
+        info!(
+            "plugin_cache: adaptive join stage={stage} physical plan:\n{}",
+            displayable(plan).indent(true)
+        );
+    }
+}
+
+async fn sort_merge_plan(
+    ctx: &SessionContext,
+    sql: &str,
+    stage: &str,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    set_prefer_hash_join(ctx, false).await?;
+    let plan = ctx.sql(sql).await?.create_physical_plan().await?;
+    if !contains_sort_merge_join(plan.as_ref()) {
+        return datafusion::common::exec_err!(
+            "adaptive join stage {stage} requested SortMergeJoin but DataFusion emitted:\n{}",
+            displayable(plan.as_ref()).indent(true)
+        );
+    }
+    Ok(plan)
+}
+
+async fn adaptive_plan(
+    ctx: &SessionContext,
+    sql: &str,
+    stage: &str,
+    pool: &dyn MemoryPool,
+) -> Result<(Arc<dyn ExecutionPlan>, JoinAlgorithm)> {
+    set_prefer_hash_join(ctx, true).await?;
+    let hash_plan = ctx.sql(sql).await?.create_physical_plan().await?;
+    let decision = choose_for_hash_plan(&hash_plan, pool)?;
+    log_decision(stage, ctx.copied_config().target_partitions(), &decision);
+    if decision.algorithm == JoinAlgorithm::Hash {
+        return Ok((hash_plan, JoinAlgorithm::Hash));
+    }
+
+    Ok((
+        sort_merge_plan(ctx, sql, stage).await?,
+        JoinAlgorithm::SortMerge,
+    ))
 }
 
 /// Concatenate `parts` into a batch that owns its buffers even when there is
@@ -122,6 +218,32 @@ fn rechunk_probe_owned(
     Ok(output)
 }
 
+/// Distribute already-owned batches across source partitions without copying
+/// their Arrow buffers. Greedy byte balancing avoids assigning all large
+/// batches to one worker while adapting naturally when a chromosome has only
+/// enough batches to occupy a subset of the configured workers.
+pub(crate) fn partition_batches(
+    batches: Vec<RecordBatch>,
+    target_partitions: usize,
+) -> Vec<Vec<RecordBatch>> {
+    let partition_count = target_partitions.max(1).min(batches.len().max(1));
+    let mut partitions = (0..partition_count).map(|_| Vec::new()).collect::<Vec<_>>();
+    let mut partition_bytes = vec![0usize; partition_count];
+
+    for batch in batches {
+        let partition = partition_bytes
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, bytes)| **bytes)
+            .map(|(index, _)| index)
+            .expect("at least one batch partition");
+        partition_bytes[partition] =
+            partition_bytes[partition].saturating_add(get_record_batch_memory_size(&batch));
+        partitions[partition].push(batch);
+    }
+    partitions
+}
+
 /// Replace the `plugin_variation_probe` view with an equivalent table whose
 /// batches own their buffers.
 ///
@@ -146,29 +268,60 @@ fn rechunk_probe_owned(
 /// re-slicing large MemTable parents into zero-copy children. The reservation
 /// therefore matches reality. It also lifts the aggregate out of the join plan,
 /// so it runs once and the optimizer sees exact statistics for side selection.
-async fn materialize_probe(ctx: &SessionContext) -> Result<()> {
-    let df = ctx.sql("SELECT * FROM plugin_variation_probe").await?;
-    let schema: SchemaRef = df.schema().inner().clone();
-    let collected = df.collect().await?;
+fn replace_probe_table(
+    ctx: &SessionContext,
+    schema: SchemaRef,
+    collected: Vec<RecordBatch>,
+) -> Result<()> {
     let batches = rechunk_probe_owned(&schema, collected, ctx.copied_config().batch_size())?;
-
+    let partitions = partition_batches(batches, ctx.copied_config().target_partitions());
     ctx.deregister_table("plugin_variation_probe")?;
     ctx.register_table(
         "plugin_variation_probe",
-        std::sync::Arc::new(datafusion::datasource::MemTable::try_new(
-            schema,
-            vec![batches],
-        )?),
+        Arc::new(MemTable::try_new(schema, partitions)?),
     )?;
     Ok(())
 }
 
-async fn tiered_stream_impl(
+async fn materialize_probe(ctx: &SessionContext) -> Result<()> {
+    let df = ctx.sql("SELECT * FROM plugin_variation_probe").await?;
+    let schema: SchemaRef = df.schema().inner().clone();
+    let collected = df.collect().await?;
+    replace_probe_table(ctx, schema, collected)
+}
+
+async fn materialize_probe_adaptive(
+    ctx: &SessionContext,
+    pool: &dyn MemoryPool,
+    tracer: &TracingPool,
+) -> Result<()> {
+    const SQL: &str = "SELECT * FROM plugin_variation_probe";
+    let (hash_or_merge_plan, algorithm) = adaptive_plan(ctx, SQL, "probe", pool).await?;
+    let schema = hash_or_merge_plan.schema();
+    log_plan("probe", hash_or_merge_plan.as_ref());
+    tracer.clear_failures();
+
+    let collected = match collect(hash_or_merge_plan, ctx.task_ctx()).await {
+        Ok(batches) => batches,
+        Err(error) if should_retry_hash_join(&error, algorithm, tracer) => {
+            info!(
+                "plugin_cache: probe HashJoin exhausted its reservation; retrying with DataFusion SortMergeJoin"
+            );
+            let merge_plan = sort_merge_plan(ctx, SQL, "probe_runtime_fallback").await?;
+            log_plan("probe_runtime_fallback", merge_plan.as_ref());
+            tracer.clear_failures();
+            collect(merge_plan, ctx.task_ctx()).await?
+        }
+        Err(error) => return Err(error),
+    };
+    replace_probe_table(ctx, schema, collected)
+}
+
+async fn register_variation_probe_view(
     ctx: &SessionContext,
     normalized_view: &str,
     variation_shard: &Path,
-    sorted: bool,
-) -> Result<SendableRecordBatchStream> {
+) -> Result<()> {
     let shard = variation_shard.to_string_lossy();
     ctx.register_parquet(
         "plugin_variation_raw",
@@ -178,10 +331,11 @@ async fn tiered_stream_impl(
     .await?;
     ctx.sql(&format!(
         // GROUP BY (not DISTINCT): the variation shard can carry multiple
-        // source rows for the same (chrom, start, allele_string) (e.g.
+        // source rows for the same (start, allele_string) within this
+        // already-selected chromosome (e.g.
         // distinct dbSNP/COSMIC-origin entries for one variant). If those
         // duplicates ever disagree on `tier` (one warm, one cold), a plain
-        // `SELECT DISTINCT chrom, start, allele_string, tier` keeps BOTH rows
+        // `SELECT DISTINCT start, allele_string, tier` keeps BOTH rows
         // — the join key is then non-unique on the build side, so the tier
         // LEFT JOIN below fans out the plugin row once per surviving variant,
         // silently inflating the cache with duplicate rows for that key
@@ -195,26 +349,36 @@ async fn tiered_stream_impl(
         // removes entirely rather than merely reduces.
         //
         // The inner JOIN against a DISTINCT projection of the plugin's own
-        // keys is a semi-join emulation that restricts the aggregation to
-        // keys the plugin table actually has, computed BEFORE the `GROUP BY`
-        // rather than after: for a sparse plugin (far fewer rows than the
-        // chromosome's full variation shard), grouping the *entire* shard
+        // per-chromosome keys is a semi-join emulation that restricts the
+        // aggregation to keys the plugin table actually has, computed BEFORE
+        // the `GROUP BY` rather than after: for a sparse plugin (far fewer
+        // rows than the chromosome's full variation shard), grouping the
+        // *entire* shard
         // just to inherit tier for a handful of keys is wasted work the LEFT
         // JOIN below never uses (variation rows with no matching plugin key
         // can never survive a `p.*`-projected LEFT JOIN regardless).
         // Semantically a no-op — this narrows which rows get grouped, not
-        // which key wins ties or what a hit resolves to. The DISTINCT on the
-        // plugin side keeps this join's build side small and its own key
-        // unique, so it can't reintroduce the fan-out risk the GROUP BY
-        // above exists to remove.
+        // which key wins ties or what a hit resolves to. The DISTINCT makes
+        // the plugin-side key unique, preventing duplicate plugin keys from
+        // multiplying rows before the variation GROUP BY collapses them.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT v.chrom, v.start, v.allele_string, MIN(v.tier) AS tier \
+         SELECT v.start, v.allele_string, MIN(v.tier) AS tier \
          FROM plugin_variation_raw v \
-         INNER JOIN (SELECT DISTINCT chrom, start, allele_string FROM {normalized_view}) p \
-         ON v.chrom = p.chrom AND v.start = p.start AND v.allele_string = p.allele_string \
-         GROUP BY v.chrom, v.start, v.allele_string"
+         INNER JOIN (SELECT DISTINCT start, allele_string FROM {normalized_view}) p \
+         ON v.start = p.start AND v.allele_string = p.allele_string \
+         GROUP BY v.start, v.allele_string"
     ))
     .await?;
+    Ok(())
+}
+
+async fn tiered_stream_impl(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    variation_shard: &Path,
+    sorted: bool,
+) -> Result<SendableRecordBatchStream> {
+    register_variation_probe_view(ctx, normalized_view, variation_shard).await?;
     materialize_probe(ctx).await?;
     let sql = if sorted {
         tier_sql_sorted(normalized_view, "plugin_variation_probe")
@@ -236,16 +400,382 @@ async fn tiered_stream_impl(
     df.execute_stream().await
 }
 
+/// Build both joins with DataFusion, selecting HashJoin only when its actual
+/// optimized build-side statistics fit the active pool. The final SQL always
+/// carries an explicit ORDER BY because parallel joins do not preserve a
+/// globally useful source order.
+pub(crate) async fn tiered_stream_sorted_adaptive(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    variation_shard: &Path,
+    pool: &dyn MemoryPool,
+    tracer: &TracingPool,
+) -> Result<AdaptiveTieredStream> {
+    register_variation_probe_view(ctx, normalized_view, variation_shard).await?;
+    materialize_probe_adaptive(ctx, pool, tracer).await?;
+
+    let sql = tier_sql_sorted(normalized_view, "plugin_variation_probe");
+    let (plan, algorithm) = adaptive_plan(ctx, &sql, "tier", pool).await?;
+    log_plan("tier", plan.as_ref());
+    tracer.clear_failures();
+    match execute_stream(plan, ctx.task_ctx()) {
+        Ok(stream) => Ok(AdaptiveTieredStream { stream, algorithm }),
+        Err(error) if should_retry_hash_join(&error, algorithm, tracer) => {
+            info!(
+                "plugin_cache: tier HashJoin exhausted its reservation before streaming; retrying with DataFusion SortMergeJoin"
+            );
+            Ok(AdaptiveTieredStream {
+                stream: tiered_stream_sorted_sort_merge(ctx, normalized_view, tracer).await?,
+                algorithm: JoinAlgorithm::SortMerge,
+            })
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Re-plan only the already-materialized final join as SortMergeJoin. Used
+/// when a hash build passed the estimate but DataFusion rejected its runtime
+/// reservation while the output stream was being consumed.
+pub(crate) async fn tiered_stream_sorted_sort_merge(
+    ctx: &SessionContext,
+    normalized_view: &str,
+    tracer: &TracingPool,
+) -> Result<SendableRecordBatchStream> {
+    let sql = tier_sql_sorted(normalized_view, "plugin_variation_probe");
+    let plan = sort_merge_plan(ctx, &sql, "tier_runtime_fallback").await?;
+    log_plan("tier_runtime_fallback", plan.as_ref());
+    tracer.clear_failures();
+    execute_stream(plan, ctx.task_ctx())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use datafusion::arrow::array::{Float32Array, Int8Array, StringArray, UInt32Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
-    use datafusion::prelude::col;
-    use futures::StreamExt;
+    use datafusion::execution::memory_pool::{
+        FairSpillPool, MemoryConsumer, MemoryLimit, MemoryReservation, UnboundedMemoryPool,
+    };
+    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion::prelude::{SessionConfig, col};
+    use futures::{StreamExt, TryStreamExt};
     use parquet::arrow::ArrowWriter;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Reports a roomy limit to the preflight selector but rejects every hash
+    /// build reservation. Other consumers are unbounded so the forced SMJ can
+    /// complete; this models optimistic statistics deterministically.
+    #[derive(Debug, Default)]
+    struct RejectHashPool {
+        inner: UnboundedMemoryPool,
+        rejected_hash_grows: AtomicUsize,
+    }
+
+    impl MemoryPool for RejectHashPool {
+        fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+            self.inner.grow(reservation, additional);
+        }
+
+        fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+            self.inner.shrink(reservation, shrink);
+        }
+
+        fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
+            if reservation.consumer().name().starts_with("HashJoinInput") {
+                self.rejected_hash_grows.fetch_add(1, Ordering::Relaxed);
+                return Err(DataFusionError::ResourcesExhausted(format!(
+                    "Additional allocation failed for {}",
+                    reservation.consumer().name()
+                )));
+            }
+            self.inner.try_grow(reservation, additional)
+        }
+
+        fn reserved(&self) -> usize {
+            self.inner.reserved()
+        }
+
+        fn memory_limit(&self) -> MemoryLimit {
+            MemoryLimit::Finite(1024 * 1024)
+        }
+    }
+
+    fn rejecting_context() -> (SessionContext, Arc<RejectHashPool>, Arc<TracingPool>) {
+        let rejecting_pool = Arc::new(RejectHashPool::default());
+        let base_pool: Arc<dyn MemoryPool> = Arc::clone(&rejecting_pool) as _;
+        let tracer = Arc::new(TracingPool::new(base_pool));
+        let runtime_pool: Arc<dyn MemoryPool> = Arc::clone(&tracer) as _;
+        let runtime = RuntimeEnvBuilder::new()
+            .with_memory_pool(runtime_pool)
+            .build_arc()
+            .unwrap();
+        let ctx = SessionContext::new_with_config_rt(
+            SessionConfig::new()
+                .with_target_partitions(2)
+                .set_bool("datafusion.optimizer.prefer_hash_join", true)
+                .set_usize(
+                    "datafusion.optimizer.hash_join_single_partition_threshold",
+                    usize::MAX,
+                )
+                .set_usize(
+                    "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+                    usize::MAX,
+                ),
+            runtime,
+        );
+        (ctx, rejecting_pool, tracer)
+    }
+
+    #[test]
+    fn owned_batches_are_distributed_across_available_workers() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::UInt32,
+            false,
+        )]));
+        let batches = (0..6u32)
+            .map(|value| {
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![Arc::new(UInt32Array::from(vec![value; 16]))],
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let partitions = partition_batches(batches, 3);
+        assert_eq!(partitions.len(), 3);
+        assert!(partitions.iter().all(|partition| partition.len() == 2));
+        assert_eq!(
+            partitions
+                .iter()
+                .flatten()
+                .map(RecordBatch::num_rows)
+                .sum::<usize>(),
+            96
+        );
+    }
+
+    #[test]
+    fn hash_retry_requires_matching_error_and_pool_attribution() {
+        let tracer = Arc::new(TracingPool::new(Arc::new(FairSpillPool::new(1))));
+        let pool: Arc<dyn MemoryPool> = Arc::clone(&tracer) as _;
+        assert!(matches!(pool.memory_limit(), MemoryLimit::Finite(1)));
+        let hash_reservation = MemoryConsumer::new("HashJoinInput").register(&pool);
+        let hash_error = hash_reservation.try_grow(2).unwrap_err();
+
+        assert!(should_retry_hash_join(
+            &hash_error,
+            JoinAlgorithm::Hash,
+            tracer.as_ref()
+        ));
+        assert!(!should_retry_hash_join(
+            &hash_error,
+            JoinAlgorithm::SortMerge,
+            tracer.as_ref()
+        ));
+
+        tracer.clear_failures();
+        let sort_reservation = MemoryConsumer::new("ExternalSorter").register(&pool);
+        let sort_error = sort_reservation.try_grow(2).unwrap_err();
+        assert!(!should_retry_hash_join(
+            &sort_error,
+            JoinAlgorithm::Hash,
+            tracer.as_ref()
+        ));
+    }
+
+    #[tokio::test]
+    async fn adaptive_plan_replans_with_datafusion_sort_merge_join() {
+        let ctx = SessionContext::new_with_config(
+            SessionConfig::new()
+                .with_target_partitions(2)
+                .set_usize(
+                    "datafusion.optimizer.hash_join_single_partition_threshold",
+                    usize::MAX,
+                )
+                .set_usize(
+                    "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+                    usize::MAX,
+                ),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::UInt32,
+            false,
+        )]));
+        for (name, rows) in [("build", 128usize), ("probe", 4096usize)] {
+            ctx.register_batch(
+                name,
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![Arc::new(UInt32Array::from_iter_values(
+                        (0..rows).map(|value| value as u32),
+                    ))],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        }
+
+        let (plan, algorithm) = adaptive_plan(
+            &ctx,
+            "SELECT p.value FROM probe p INNER JOIN build b ON p.value = b.value",
+            "test",
+            &FairSpillPool::new(64),
+        )
+        .await
+        .unwrap();
+        assert_eq!(algorithm, JoinAlgorithm::SortMerge);
+        assert!(contains_sort_merge_join(plan.as_ref()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn probe_runtime_hash_rejection_retries_with_sort_merge() {
+        let (ctx, rejecting_pool, tracer) = rejecting_context();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        for name in ["variation_side", "plugin_side"] {
+            ctx.register_batch(
+                name,
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![
+                        Arc::new(StringArray::from(vec!["1", "1"])),
+                        Arc::new(UInt32Array::from(vec![100u32, 200])),
+                        Arc::new(StringArray::from(vec!["A/G", "C/T"])),
+                        Arc::new(Int8Array::from(vec![0i8, 1])),
+                    ],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        }
+        ctx.sql(
+            "CREATE VIEW plugin_variation_probe AS \
+             SELECT v.start, v.allele_string, v.tier \
+             FROM variation_side v INNER JOIN plugin_side p \
+             ON v.start = p.start AND v.allele_string = p.allele_string",
+        )
+        .await
+        .unwrap();
+
+        materialize_probe_adaptive(&ctx, tracer.as_ref(), tracer.as_ref())
+            .await
+            .unwrap();
+        assert_eq!(
+            rejecting_pool.rejected_hash_grows.load(Ordering::Relaxed),
+            1
+        );
+        let probe = ctx
+            .sql("SELECT * FROM plugin_variation_probe")
+            .await
+            .unwrap();
+        assert_eq!(
+            probe
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            vec!["start", "allele_string", "tier"]
+        );
+        let rows = probe
+            .collect()
+            .await
+            .unwrap()
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>();
+        assert_eq!(rows, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn final_runtime_hash_rejection_retries_with_sort_merge() {
+        let (ctx, rejecting_pool, tracer) = rejecting_context();
+
+        let dir = tempfile::tempdir().unwrap();
+        let variation_schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        let variation = RecordBatch::try_new(
+            Arc::clone(&variation_schema),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 200])),
+                Arc::new(StringArray::from(vec!["A/G", "C/T"])),
+                Arc::new(Int8Array::from(vec![0i8, 1])),
+            ],
+        )
+        .unwrap();
+        let variation_path = dir.path().join("variation.parquet");
+        let file = std::fs::File::create(&variation_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, variation_schema, None).unwrap();
+        writer.write(&variation).unwrap();
+        writer.close().unwrap();
+
+        let plugin = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("chrom", DataType::Utf8, false),
+                Field::new("start", DataType::UInt32, false),
+                Field::new("end", DataType::UInt32, false),
+                Field::new("allele_string", DataType::Utf8, false),
+                Field::new("demo_score", DataType::Float32, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 300])),
+                Arc::new(UInt32Array::from(vec![100u32, 300])),
+                Arc::new(StringArray::from(vec!["A/G", "G/A"])),
+                Arc::new(Float32Array::from(vec![Some(0.9f32), Some(0.7)])),
+            ],
+        )
+        .unwrap();
+        ctx.register_batch("plugin_demo_norm", plugin).unwrap();
+
+        let adaptive = tiered_stream_sorted_adaptive(
+            &ctx,
+            "plugin_demo_norm",
+            &variation_path,
+            tracer.as_ref(),
+            tracer.as_ref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(adaptive.algorithm, JoinAlgorithm::Hash);
+
+        let error = adaptive
+            .stream
+            .try_collect::<Vec<RecordBatch>>()
+            .await
+            .unwrap_err();
+        assert!(should_retry_hash_join(
+            &error,
+            adaptive.algorithm,
+            tracer.as_ref()
+        ));
+        assert!(
+            rejecting_pool.rejected_hash_grows.load(Ordering::Relaxed) >= 1,
+            "the final tier HashJoin must reach the injected rejecting pool"
+        );
+
+        let batches = tiered_stream_sorted_sort_merge(&ctx, "plugin_demo_norm", tracer.as_ref())
+            .await
+            .unwrap()
+            .try_collect::<Vec<RecordBatch>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 2);
+    }
 
     // Codex review, PR #196: for a sparse plugin the pre-fix
     // `plugin_variation_probe` unconditionally grouped the ENTIRE variation
@@ -401,7 +931,6 @@ mod tests {
         use datafusion::execution::memory_pool::FairSpillPool;
         use datafusion::execution::runtime_env::RuntimeEnvBuilder;
         use datafusion::physical_plan::displayable;
-        use datafusion::prelude::SessionConfig;
 
         const EXECUTION_BATCH_ROWS: usize = 8192;
         const PARENT_ROWS: usize = 1024 * 1024;

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -35,7 +35,7 @@ pub async fn tiered_stream(
         datafusion::prelude::ParquetReadOptions::default(),
     )
     .await?;
-    ctx.sql(
+    ctx.sql(&format!(
         // GROUP BY (not DISTINCT): the variation shard can carry multiple
         // source rows for the same (chrom, start, allele_string) (e.g.
         // distinct dbSNP/COSMIC-origin entries for one variant). If those
@@ -52,10 +52,27 @@ pub async fn tiered_stream(
         // warm. This also guarantees `HashJoinExec`'s build side can never
         // fan out, which is a (data-dependent) join-skew risk this GROUP BY
         // removes entirely rather than merely reduces.
+        //
+        // The inner JOIN against a DISTINCT projection of the plugin's own
+        // keys is a semi-join emulation that restricts the aggregation to
+        // keys the plugin table actually has, computed BEFORE the `GROUP BY`
+        // rather than after: for a sparse plugin (far fewer rows than the
+        // chromosome's full variation shard), grouping the *entire* shard
+        // just to inherit tier for a handful of keys is wasted work the LEFT
+        // JOIN below never uses (variation rows with no matching plugin key
+        // can never survive a `p.*`-projected LEFT JOIN regardless).
+        // Semantically a no-op — this narrows which rows get grouped, not
+        // which key wins ties or what a hit resolves to. The DISTINCT on the
+        // plugin side keeps this join's build side small and its own key
+        // unique, so it can't reintroduce the fan-out risk the GROUP BY
+        // above exists to remove.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT chrom, start, allele_string, MIN(tier) AS tier \
-         FROM plugin_variation_raw GROUP BY chrom, start, allele_string",
-    )
+         SELECT v.chrom, v.start, v.allele_string, MIN(v.tier) AS tier \
+         FROM plugin_variation_raw v \
+         INNER JOIN (SELECT DISTINCT chrom, start, allele_string FROM {normalized_view}) p \
+         ON v.chrom = p.chrom AND v.start = p.start AND v.allele_string = p.allele_string \
+         GROUP BY v.chrom, v.start, v.allele_string"
+    ))
     .await?;
     let df = ctx
         .sql(&tier_sql(normalized_view, "plugin_variation_probe"))
@@ -70,7 +87,93 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::arrow::record_batch::RecordBatch;
     use datafusion::prelude::col;
+    use futures::StreamExt;
+    use parquet::arrow::ArrowWriter;
     use std::sync::Arc;
+
+    // Codex review, PR #196: for a sparse plugin the pre-fix
+    // `plugin_variation_probe` unconditionally grouped the ENTIRE variation
+    // shard, including keys no plugin row will ever reference. The semi-join
+    // narrowing must be a pure performance change, not a semantic one --
+    // verify a large-relative-to-plugin variation shard (rows the plugin
+    // never touches, PLUS a conflicting-tier duplicate at a key the plugin
+    // DOES touch) still tiers exactly as before.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tiered_stream_ignores_variation_rows_no_plugin_key_references() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("chrom", DataType::Utf8, false),
+            Field::new("start", DataType::UInt32, false),
+            Field::new("allele_string", DataType::Utf8, false),
+            Field::new("tier", DataType::Int8, false),
+        ]));
+        // 100: two conflicting-tier duplicates (must still collapse to warm).
+        // 999/1000/1001: irrelevant rows no plugin key ever probes.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1", "1", "1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 100, 999, 1000, 1001])),
+                Arc::new(StringArray::from(vec!["A/G", "A/G", "G/T", "C/A", "T/G"])),
+                Arc::new(Int8Array::from(vec![1i8, 0, 0, 0, 1])),
+            ],
+        )
+        .unwrap();
+        let var_path = dir.path().join("var.parquet");
+        let file = std::fs::File::create(&var_path).unwrap();
+        let mut w = ArrowWriter::try_new(file, schema, None).unwrap();
+        w.write(&batch).unwrap();
+        w.close().unwrap();
+
+        let ctx = SessionContext::new();
+        let plug = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("chrom", DataType::Utf8, false),
+                Field::new("start", DataType::UInt32, false),
+                Field::new("end", DataType::UInt32, false),
+                Field::new("allele_string", DataType::Utf8, false),
+                Field::new("demo_score", DataType::Float32, true),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 300])),
+                Arc::new(UInt32Array::from(vec![100u32, 300])),
+                Arc::new(StringArray::from(vec!["A/G", "G/A"])),
+                Arc::new(Float32Array::from(vec![Some(0.9f32), Some(0.7)])),
+            ],
+        )
+        .unwrap();
+        ctx.register_batch("plugin_demo_norm", plug).unwrap();
+
+        let mut stream = tiered_stream(&ctx, "plugin_demo_norm", &var_path)
+            .await
+            .unwrap();
+        let mut rows: Vec<(u32, i8)> = Vec::new();
+        while let Some(b) = stream.next().await {
+            let b = b.unwrap();
+            let starts = b
+                .column(b.schema().index_of("start").unwrap())
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .unwrap();
+            let tiers = b
+                .column(b.schema().index_of("tier").unwrap())
+                .as_any()
+                .downcast_ref::<Int8Array>()
+                .unwrap();
+            for i in 0..b.num_rows() {
+                rows.push((starts.value(i), tiers.value(i)));
+            }
+        }
+        rows.sort();
+        // 100: conflicting-tier duplicate collapses to warm (0), matching
+        // pre-semi-join behavior exactly. 300: no variation match -> cold (1).
+        // The three irrelevant variation rows (999/1000/1001) never surface
+        // here since only the plugin's own rows are projected -- their
+        // absence from `plugin_variation_raw`'s post-semi-join scan is the
+        // thing under test, not something directly observable in the output.
+        assert_eq!(rows, vec![(100, 0), (300, 1)]);
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn inherits_tier_from_variation_and_miss_is_cold() {

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -36,13 +36,25 @@ pub async fn tiered_stream(
     )
     .await?;
     ctx.sql(
-        // DISTINCT: the variation shard can carry multiple source rows for the
-        // same (chrom, start, allele_string) (e.g. distinct dbSNP/COSMIC-origin
-        // entries for one variant). Without it, the tier LEFT JOIN below fans
-        // out the plugin row once per matching variation row, inflating the
-        // built cache with duplicate (but value-identical) rows.
+        // GROUP BY (not DISTINCT): the variation shard can carry multiple
+        // source rows for the same (chrom, start, allele_string) (e.g.
+        // distinct dbSNP/COSMIC-origin entries for one variant). If those
+        // duplicates ever disagree on `tier` (one warm, one cold), a plain
+        // `SELECT DISTINCT chrom, start, allele_string, tier` keeps BOTH rows
+        // — the join key is then non-unique on the build side, so the tier
+        // LEFT JOIN below fans out the plugin row once per surviving variant,
+        // silently inflating the cache with duplicate rows for that key
+        // (worse: two rows with the same (start, allele_string) but different
+        // tier, which the point-lookup path never expects). `MIN(tier)`
+        // collapses to exactly one row per key regardless of how many
+        // conflicting-tier duplicates the raw shard has — 0 (warm) wins over
+        // 1 (cold), i.e. any evidence of a known/frequent variant marks it
+        // warm. This also guarantees `HashJoinExec`'s build side can never
+        // fan out, which is a (data-dependent) join-skew risk this GROUP BY
+        // removes entirely rather than merely reduces.
         "CREATE OR REPLACE VIEW plugin_variation_probe AS \
-         SELECT DISTINCT chrom, start, allele_string, tier FROM plugin_variation_raw",
+         SELECT chrom, start, allele_string, MIN(tier) AS tier \
+         FROM plugin_variation_raw GROUP BY chrom, start, allele_string",
     )
     .await?;
     let df = ctx

--- a/datafusion/bio-function-vep/src/plugin_cache/join.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use datafusion::common::Result;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion::prelude::SessionContext;
+use log::info;
 
 /// SQL that LEFT-joins `normalized_view` to a registered `variation_probe`
 /// exposing `(chrom, start, allele_string, tier)` and inherits `tier`. The value
@@ -115,6 +116,17 @@ async fn tiered_stream_impl(
         tier_sql(normalized_view, "plugin_variation_probe")
     };
     let df = ctx.sql(&sql).await?;
+    // Opt-in plan dump. The tier join's memory behaviour depends on which side
+    // of each HashJoinExec the optimizer collects, and that is decided from
+    // statistics -- so it cannot be reasoned out from the SQL, it has to be
+    // read off the physical plan for the actual data. Costs nothing unset.
+    if std::env::var("VEPYR_EXPLAIN_TIER_JOIN").is_ok() {
+        let plan = df.clone().create_physical_plan().await?;
+        info!(
+            "plugin_cache: tier join physical plan (sorted={sorted}):\n{}",
+            datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
+        );
+    }
     df.execute_stream().await
 }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/join_strategy.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/join_strategy.rs
@@ -1,0 +1,247 @@
+//! Pool-aware choice between DataFusion's built-in hash and sort-merge joins.
+//!
+//! DataFusion 53 uses statistics to choose a hash-join build side and
+//! partition mode, but its HashJoin-vs-SortMergeJoin choice is controlled only
+//! by `prefer_hash_join`. This module supplies the missing memory-feasibility
+//! check. It does not implement either join.
+
+use std::mem::size_of;
+use std::sync::Arc;
+
+use datafusion::common::Result;
+use datafusion::common::utils::memory::estimate_memory_size;
+use datafusion::execution::memory_pool::{MemoryLimit, MemoryPool};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::joins::join_hash_map::{JoinHashMapU32, JoinHashMapU64};
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode, SortMergeJoinExec};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JoinAlgorithm {
+    Hash,
+    SortMerge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JoinDecisionReason {
+    BuildFits,
+    BuildExceedsPool,
+    MissingStatistics,
+    UnknownPoolLimit,
+    UnexpectedHashMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct JoinDecision {
+    pub algorithm: JoinAlgorithm,
+    pub reason: JoinDecisionReason,
+    pub build_rows: Option<usize>,
+    pub build_data_bytes: Option<usize>,
+    pub hash_build_bytes: Option<usize>,
+    pub available_bytes: Option<usize>,
+}
+
+fn find_hash_join(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
+    if let Some(join) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        return Some(join);
+    }
+    plan.children()
+        .into_iter()
+        .find_map(|child| find_hash_join(child.as_ref()))
+}
+
+pub(crate) fn contains_sort_merge_join(plan: &dyn ExecutionPlan) -> bool {
+    plan.as_any().is::<SortMergeJoinExec>()
+        || plan
+            .children()
+            .into_iter()
+            .any(|child| contains_sort_merge_join(child.as_ref()))
+}
+
+fn hash_table_bytes(rows: usize) -> Result<usize> {
+    if rows > u32::MAX as usize {
+        estimate_memory_size::<(u64, u64)>(rows, size_of::<JoinHashMapU64>())
+    } else {
+        estimate_memory_size::<(u32, u64)>(rows, size_of::<JoinHashMapU32>())
+    }
+}
+
+/// Decide whether the actual build side in an optimized HashJoin plan fits the
+/// active pool. The estimate mirrors the reservations made by DataFusion 53's
+/// `collect_left_input`: input batches, hash table, and (conservatively) an
+/// outer-join visited bitmap.
+pub(crate) fn choose_for_hash_plan(
+    plan: &Arc<dyn ExecutionPlan>,
+    pool: &dyn MemoryPool,
+) -> Result<JoinDecision> {
+    let Some(join) = find_hash_join(plan.as_ref()) else {
+        return Ok(JoinDecision {
+            algorithm: JoinAlgorithm::SortMerge,
+            reason: JoinDecisionReason::MissingStatistics,
+            build_rows: None,
+            build_data_bytes: None,
+            hash_build_bytes: None,
+            available_bytes: None,
+        });
+    };
+
+    if join.partition_mode() != &PartitionMode::CollectLeft {
+        return Ok(JoinDecision {
+            algorithm: JoinAlgorithm::SortMerge,
+            reason: JoinDecisionReason::UnexpectedHashMode,
+            build_rows: None,
+            build_data_bytes: None,
+            hash_build_bytes: None,
+            available_bytes: None,
+        });
+    }
+
+    let stats = join.left().partition_statistics(None)?;
+    let rows = stats.num_rows.get_value().copied();
+    let data_bytes = stats.total_byte_size.get_value().copied();
+    let (Some(rows), Some(data_bytes)) = (rows, data_bytes) else {
+        return Ok(JoinDecision {
+            algorithm: JoinAlgorithm::SortMerge,
+            reason: JoinDecisionReason::MissingStatistics,
+            build_rows: rows,
+            build_data_bytes: data_bytes,
+            hash_build_bytes: None,
+            available_bytes: None,
+        });
+    };
+
+    let build_bytes = data_bytes
+        .checked_add(hash_table_bytes(rows)?)
+        .and_then(|bytes| bytes.checked_add(rows.div_ceil(8)))
+        .ok_or_else(|| {
+            datafusion::common::DataFusionError::Execution(
+                "hash join build-size estimate overflowed usize".into(),
+            )
+        })?;
+
+    let available = match pool.memory_limit() {
+        MemoryLimit::Finite(limit) => Some(limit.saturating_sub(pool.reserved())),
+        MemoryLimit::Infinite => Some(usize::MAX),
+        MemoryLimit::Unknown => None,
+    };
+    let Some(available) = available else {
+        return Ok(JoinDecision {
+            algorithm: JoinAlgorithm::SortMerge,
+            reason: JoinDecisionReason::UnknownPoolLimit,
+            build_rows: Some(rows),
+            build_data_bytes: Some(data_bytes),
+            hash_build_bytes: Some(build_bytes),
+            available_bytes: None,
+        });
+    };
+
+    let (algorithm, reason) = if build_bytes <= available {
+        (JoinAlgorithm::Hash, JoinDecisionReason::BuildFits)
+    } else {
+        (
+            JoinAlgorithm::SortMerge,
+            JoinDecisionReason::BuildExceedsPool,
+        )
+    };
+    Ok(JoinDecision {
+        algorithm,
+        reason,
+        build_rows: Some(rows),
+        build_data_bytes: Some(data_bytes),
+        hash_build_bytes: Some(build_bytes),
+        available_bytes: Some(available),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::UInt32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::execution::memory_pool::FairSpillPool;
+    use datafusion::prelude::{SessionConfig, SessionContext};
+
+    async fn hash_plan(build_rows: usize) -> Arc<dyn ExecutionPlan> {
+        let ctx = SessionContext::new_with_config(
+            SessionConfig::new()
+                .with_target_partitions(2)
+                .set_usize(
+                    "datafusion.optimizer.hash_join_single_partition_threshold",
+                    usize::MAX,
+                )
+                .set_usize(
+                    "datafusion.optimizer.hash_join_single_partition_threshold_rows",
+                    usize::MAX,
+                ),
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::UInt32,
+            false,
+        )]));
+        for (name, rows) in [("build", build_rows), ("probe", build_rows * 2)] {
+            ctx.register_batch(
+                name,
+                RecordBatch::try_new(
+                    Arc::clone(&schema),
+                    vec![Arc::new(UInt32Array::from_iter_values(
+                        (0..rows).map(|value| value as u32),
+                    ))],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        }
+        ctx.sql("SELECT p.value FROM probe p INNER JOIN build b ON p.value = b.value")
+            .await
+            .unwrap()
+            .create_physical_plan()
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn pool_size_switches_hash_to_sort_merge() {
+        let plan = hash_plan(128).await;
+        let roomy = FairSpillPool::new(1024 * 1024);
+        let tight = FairSpillPool::new(64);
+        assert_eq!(
+            choose_for_hash_plan(&plan, &roomy).unwrap().algorithm,
+            JoinAlgorithm::Hash
+        );
+        assert_eq!(
+            choose_for_hash_plan(&plan, &tight).unwrap().algorithm,
+            JoinAlgorithm::SortMerge
+        );
+    }
+
+    #[tokio::test]
+    async fn build_statistics_switch_algorithm_for_the_same_pool() {
+        let small_plan = hash_plan(16).await;
+        let large_plan = hash_plan(4096).await;
+        let measuring_pool = FairSpillPool::new(1024 * 1024);
+        let small_bytes = choose_for_hash_plan(&small_plan, &measuring_pool)
+            .unwrap()
+            .hash_build_bytes
+            .unwrap();
+        let large_bytes = choose_for_hash_plan(&large_plan, &measuring_pool)
+            .unwrap()
+            .hash_build_bytes
+            .unwrap();
+        assert!(small_bytes < large_bytes);
+
+        let same_pool = FairSpillPool::new(small_bytes + (large_bytes - small_bytes) / 2);
+        assert_eq!(
+            choose_for_hash_plan(&small_plan, &same_pool)
+                .unwrap()
+                .algorithm,
+            JoinAlgorithm::Hash
+        );
+        assert_eq!(
+            choose_for_hash_plan(&large_plan, &same_pool)
+                .unwrap()
+                .algorithm,
+            JoinAlgorithm::SortMerge
+        );
+    }
+}

--- a/datafusion/bio-function-vep/src/plugin_cache/lookup.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/lookup.rs
@@ -345,6 +345,7 @@ mod tests {
             column: "am".into(),
             csq_field: "am".into(),
             ty: ValueType::Float32,
+            description: None,
         }];
         let schema = plugin_output_schema(&matches, &vals);
         let batch = RecordBatch::try_new(

--- a/datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs
@@ -1,22 +1,24 @@
 //! Per-reservation memory tracing for the plugin-cache build.
 //!
 //! DataFusion's pool-exhaustion error names the *consumer* ("HashJoinInput"),
-//! and the tier-join plan contains two `HashJoinExec`s -- the semi-join inside
+//! and the build has two join stages -- the semi-join inside
 //! `plugin_variation_probe` and the tier LEFT JOIN itself. Both register under
-//! that same name, so the error alone cannot say which one consumed the pool,
-//! and the answer decides whether a bigger budget is a fix or a distraction.
+//! that same name, so stage-scoped attribution is needed before retrying.
 //!
 //! This wraps any [`MemoryPool`] and tracks each *reservation* separately
 //! (keyed by consumer identity, not name), reporting each one's peak. Opt-in
-//! via `VEPYR_TRACE_MEMORY=1`; unset it costs nothing because the pool is only
-//! wrapped when the variable is set.
+//! via `VEPYR_TRACE_MEMORY=1`. The wrapper is always present in the adaptive
+//! join context so it can attribute rejected reservations, but detailed
+//! tracking and logging are disabled when the variable is unset.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use datafusion::common::Result;
-use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation};
+use datafusion::execution::memory_pool::{
+    MemoryConsumer, MemoryLimit, MemoryPool, MemoryReservation,
+};
 use log::info;
 
 pub const TRACE_ENV: &str = "VEPYR_TRACE_MEMORY";
@@ -40,7 +42,9 @@ struct Tracked {
 pub struct TracingPool {
     inner: std::sync::Arc<dyn MemoryPool>,
     seen: Mutex<HashMap<usize, Tracked>>,
+    failed_consumers: Mutex<HashSet<String>>,
     next_id: AtomicUsize,
+    trace: bool,
 }
 
 const STEP: usize = 256 * 1024 * 1024;
@@ -50,8 +54,29 @@ impl TracingPool {
         Self {
             inner,
             seen: Mutex::new(HashMap::new()),
+            failed_consumers: Mutex::new(HashSet::new()),
             next_id: AtomicUsize::new(0),
+            trace: tracing_enabled(),
         }
+    }
+
+    /// Remove any failure attributed to the preceding stage/query.
+    pub fn clear_failures(&self) {
+        self.failed_consumers
+            .lock()
+            .expect("memory failure trace poisoned")
+            .clear();
+    }
+
+    /// True when a reservation rejected during the current stage belonged to
+    /// a hash join build. The error itself is also checked at the retry site,
+    /// so an unrelated concurrent rejection cannot cause a false retry.
+    pub fn hash_join_failed(&self) -> bool {
+        self.failed_consumers
+            .lock()
+            .expect("memory failure trace poisoned")
+            .iter()
+            .any(|name| name.starts_with("HashJoinInput"))
     }
 
     /// Identity of the reservation's consumer. Two consumers sharing a name
@@ -62,6 +87,9 @@ impl TracingPool {
     }
 
     fn record(&self, reservation: &MemoryReservation, additional: usize) {
+        if !self.trace {
+            return;
+        }
         let key = Self::key(reservation);
         let size = reservation.size() + additional;
         let mut seen = self.seen.lock().expect("memory trace poisoned");
@@ -90,6 +118,9 @@ impl TracingPool {
     /// done (or has failed) -- this is the line that says which operator
     /// actually consumed the pool.
     pub fn report(&self) {
+        if !self.trace {
+            return;
+        }
         let seen = self.seen.lock().expect("memory trace poisoned");
         let mut rows: Vec<_> = seen.values().map(|t| (t.label.clone(), t.peak)).collect();
         rows.sort_by_key(|(_, peak)| std::cmp::Reverse(*peak));
@@ -123,10 +154,70 @@ impl MemoryPool for TracingPool {
 
     fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
         self.record(reservation, additional);
-        self.inner.try_grow(reservation, additional)
+        let result = self.inner.try_grow(reservation, additional);
+        if result.is_err() {
+            self.failed_consumers
+                .lock()
+                .expect("memory failure trace poisoned")
+                .insert(reservation.consumer().name().to_string());
+        }
+        result
     }
 
     fn reserved(&self) -> usize {
         self.inner.reserved()
     }
+
+    fn memory_limit(&self) -> MemoryLimit {
+        self.inner.memory_limit()
+    }
+}
+
+/// Report how a batch vector will be *charged* versus what it actually holds.
+///
+/// `HashJoinExec` reserves per batch with `get_record_batch_memory_size`, which
+/// de-duplicates buffers only within one batch. So a vector whose batches share
+/// buffers is charged once per sharing batch. This logs both numbers plus the
+/// max batch size, which separates the two ways that happens: oversized parents
+/// (DataFusion's `BatchSplitStream` re-slices them into zero-copy children) and
+/// batches that already share on arrival.
+///
+/// Gated on [`tracing_enabled`]; costs nothing unset.
+pub fn describe_batches(label: &str, batches: &[datafusion::arrow::record_batch::RecordBatch]) {
+    use datafusion::arrow::array::Array;
+    use std::collections::HashSet;
+
+    if !tracing_enabled() {
+        return;
+    }
+    let mut charged = 0usize;
+    let mut global: HashSet<usize> = HashSet::new();
+    let mut distinct = 0usize;
+    let mut max_rows = 0usize;
+    let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+
+    for batch in batches {
+        max_rows = max_rows.max(batch.num_rows());
+        let mut local: HashSet<usize> = HashSet::new();
+        for column in batch.columns() {
+            for buffer in column.to_data().buffers() {
+                let key = buffer.as_ptr() as usize;
+                if local.insert(key) {
+                    charged += buffer.capacity();
+                }
+                if global.insert(key) {
+                    distinct += buffer.capacity();
+                }
+            }
+        }
+    }
+    let gb = |n: usize| n as f64 / 1024.0 / 1024.0 / 1024.0;
+    info!(
+        "mem_trace: {label}: {} batches, {rows} rows, max {max_rows} rows/batch -- \
+         charged {:.2} GB vs {:.2} GB distinct ({:.1}x)",
+        batches.len(),
+        gb(charged),
+        gb(distinct),
+        charged as f64 / distinct.max(1) as f64,
+    );
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs
@@ -68,15 +68,25 @@ impl TracingPool {
             .clear();
     }
 
-    /// True when a reservation rejected during the current stage belonged to
-    /// a hash join build. The error itself is also checked at the retry site,
-    /// so an unrelated concurrent rejection cannot cause a false retry.
-    pub fn hash_join_failed(&self) -> bool {
+    fn consumer_failed(&self, prefix: &str) -> bool {
         self.failed_consumers
             .lock()
             .expect("memory failure trace poisoned")
             .iter()
-            .any(|name| name.starts_with("HashJoinInput"))
+            .any(|name| name.starts_with(prefix))
+    }
+
+    /// True when a reservation rejected during the current stage belonged to
+    /// a hash join build. The error itself is also checked at the retry site,
+    /// so an unrelated concurrent rejection cannot cause a false retry.
+    pub fn hash_join_failed(&self) -> bool {
+        self.consumer_failed("HashJoinInput")
+    }
+
+    /// True when the final query's external sorter was the consumer whose
+    /// reservation failed while an unspillable hash build remained live.
+    pub fn external_sorter_failed(&self) -> bool {
+        self.consumer_failed("ExternalSorter")
     }
 
     /// Identity of the reservation's consumer. Two consumers sharing a name

--- a/datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs
@@ -1,0 +1,132 @@
+//! Per-reservation memory tracing for the plugin-cache build.
+//!
+//! DataFusion's pool-exhaustion error names the *consumer* ("HashJoinInput"),
+//! and the tier-join plan contains two `HashJoinExec`s -- the semi-join inside
+//! `plugin_variation_probe` and the tier LEFT JOIN itself. Both register under
+//! that same name, so the error alone cannot say which one consumed the pool,
+//! and the answer decides whether a bigger budget is a fix or a distraction.
+//!
+//! This wraps any [`MemoryPool`] and tracks each *reservation* separately
+//! (keyed by consumer identity, not name), reporting each one's peak. Opt-in
+//! via `VEPYR_TRACE_MEMORY=1`; unset it costs nothing because the pool is only
+//! wrapped when the variable is set.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use datafusion::common::Result;
+use datafusion::execution::memory_pool::{MemoryConsumer, MemoryPool, MemoryReservation};
+use log::info;
+
+pub const TRACE_ENV: &str = "VEPYR_TRACE_MEMORY";
+
+pub fn tracing_enabled() -> bool {
+    std::env::var(TRACE_ENV).is_ok_and(|v| !v.is_empty() && v != "0")
+}
+
+#[derive(Debug, Default)]
+struct Tracked {
+    /// Stable label for this reservation, e.g. "HashJoinInput#2".
+    label: String,
+    peak: usize,
+    /// Highest 256 MiB step already logged, so a growing reservation reports
+    /// progress without one line per batch.
+    logged_steps: usize,
+}
+
+/// Wraps a pool and reports the peak of every individual reservation.
+#[derive(Debug)]
+pub struct TracingPool {
+    inner: std::sync::Arc<dyn MemoryPool>,
+    seen: Mutex<HashMap<usize, Tracked>>,
+    next_id: AtomicUsize,
+}
+
+const STEP: usize = 256 * 1024 * 1024;
+
+impl TracingPool {
+    pub fn new(inner: std::sync::Arc<dyn MemoryPool>) -> Self {
+        Self {
+            inner,
+            seen: Mutex::new(HashMap::new()),
+            next_id: AtomicUsize::new(0),
+        }
+    }
+
+    /// Identity of the reservation's consumer. Two consumers sharing a name
+    /// are distinct objects, and the reservation owns its consumer, so the
+    /// address is stable for as long as we need to attribute growth to it.
+    fn key(reservation: &MemoryReservation) -> usize {
+        std::ptr::from_ref(reservation.consumer()) as usize
+    }
+
+    fn record(&self, reservation: &MemoryReservation, additional: usize) {
+        let key = Self::key(reservation);
+        let size = reservation.size() + additional;
+        let mut seen = self.seen.lock().expect("memory trace poisoned");
+        let id = self.next_id.load(Ordering::Relaxed);
+        let entry = seen.entry(key).or_insert_with(|| {
+            self.next_id.fetch_add(1, Ordering::Relaxed);
+            Tracked {
+                label: format!("{}#{id}", reservation.consumer().name()),
+                ..Tracked::default()
+            }
+        });
+        entry.peak = entry.peak.max(size);
+        let step = size / STEP;
+        if step > entry.logged_steps {
+            entry.logged_steps = step;
+            info!(
+                "mem_trace: {} grew to {:.2} GB (pool reserved {:.2} GB)",
+                entry.label,
+                size as f64 / 1024.0 / 1024.0 / 1024.0,
+                self.inner.reserved() as f64 / 1024.0 / 1024.0 / 1024.0,
+            );
+        }
+    }
+
+    /// Log every reservation's peak, largest first. Call once the build is
+    /// done (or has failed) -- this is the line that says which operator
+    /// actually consumed the pool.
+    pub fn report(&self) {
+        let seen = self.seen.lock().expect("memory trace poisoned");
+        let mut rows: Vec<_> = seen.values().map(|t| (t.label.clone(), t.peak)).collect();
+        rows.sort_by_key(|(_, peak)| std::cmp::Reverse(*peak));
+        info!("mem_trace: peak per reservation ({} total):", rows.len());
+        for (label, peak) in rows {
+            info!(
+                "mem_trace:   {label:<24} {:.2} GB",
+                peak as f64 / 1024.0 / 1024.0 / 1024.0
+            );
+        }
+    }
+}
+
+impl MemoryPool for TracingPool {
+    fn register(&self, consumer: &MemoryConsumer) {
+        self.inner.register(consumer);
+    }
+
+    fn unregister(&self, consumer: &MemoryConsumer) {
+        self.inner.unregister(consumer);
+    }
+
+    fn grow(&self, reservation: &MemoryReservation, additional: usize) {
+        self.record(reservation, additional);
+        self.inner.grow(reservation, additional);
+    }
+
+    fn shrink(&self, reservation: &MemoryReservation, shrink: usize) {
+        self.inner.shrink(reservation, shrink);
+    }
+
+    fn try_grow(&self, reservation: &MemoryReservation, additional: usize) -> Result<()> {
+        self.record(reservation, additional);
+        self.inner.try_grow(reservation, additional)
+    }
+
+    fn reserved(&self) -> usize {
+        self.inner.reserved()
+    }
+}

--- a/datafusion/bio-function-vep/src/plugin_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mod.rs
@@ -14,6 +14,7 @@ pub mod csq;
 pub mod dedup;
 pub mod join;
 pub mod lookup;
+pub mod mem_trace;
 pub mod normalize;
 pub mod provider;
 pub mod registry;

--- a/datafusion/bio-function-vep/src/plugin_cache/mod.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/mod.rs
@@ -13,6 +13,7 @@ pub mod cache_manifest;
 pub mod csq;
 pub mod dedup;
 pub mod join;
+mod join_strategy;
 pub mod lookup;
 pub mod mem_trace;
 pub mod normalize;

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -1,12 +1,19 @@
 //! Provider factory: register a source manifest's raw tables under their
 //! `plugin_<name>_src[_<part>]` names. CSV/TSV/Parquet use builtin DataFusion
-//! providers; VCF/BED (bio-formats) are not wired in the prototype.
+//! providers; VCF uses `datafusion-bio-format-vcf`'s `VcfTableProvider` (INFO
+//! fields come back as typed top-level columns named after the raw INFO tag —
+//! query them directly in `ingest_sql`). BED is not wired in the prototype.
+
+use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
+use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
-use crate::plugin_cache::source_manifest::{CsvParams, ProviderKind, SourceManifest, ValueType};
+use crate::plugin_cache::source_manifest::{
+    CoordinateSystem, CsvParams, ProviderKind, SourceManifest, ValueType,
+};
 
 fn arrow_type(ty: ValueType) -> DataType {
     match ty {
@@ -108,7 +115,27 @@ pub async fn register_sources(
                 ctx.register_parquet(&table, &spec.path, ParquetReadOptions::default())
                     .await?;
             }
-            ProviderKind::Vcf | ProviderKind::Bed => {
+            ProviderKind::Vcf => {
+                // `coordinate_system` describes how the manifest's `ingest_sql`
+                // should interpret positions; the VCF provider's own
+                // `coordinate_system_zero_based` flag controls how IT reports
+                // `start`/`end` from the file's native 1-based VCF `POS` — keep
+                // them in lock-step so `ingest_sql` always sees the coordinate
+                // system the manifest declares, regardless of source format.
+                let zero_based = matches!(manifest.coordinate_system, CoordinateSystem::ZeroBasedHalfOpen);
+                // No manifest knob yet for selecting a INFO/FORMAT subset — read
+                // every INFO field the VCF header declares (`None`) and let
+                // `ingest_sql` project down to what it needs, same as the CSV
+                // path relies on `ingest_sql` rather than a narrower provider
+                // schema. Revisit if a source has so many INFO fields that
+                // schema inference itself becomes the bottleneck.
+                let provider = VcfTableProvider::new(spec.path.clone(), None, None, None, zero_based)
+                    .map_err(|e| {
+                        DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
+                    })?;
+                ctx.register_table(&table, Arc::new(provider))?;
+            }
+            ProviderKind::Bed => {
                 return Err(DataFusionError::NotImplemented(format!(
                     "provider {:?} not wired in prototype (table '{table}')",
                     spec.provider

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -144,6 +144,15 @@ pub async fn register_sources(
                         .map_err(|e| {
                             DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
                         })?;
+                let provider = if spec.record_layout {
+                    provider.with_record_layout().map_err(|e| {
+                        DataFusionError::Execution(format!(
+                            "carry VCF record layout for source '{table}': {e}"
+                        ))
+                    })?
+                } else {
+                    provider
+                };
                 ctx.register_table(&table, Arc::new(provider))?;
             }
             ProviderKind::Bed => {
@@ -176,7 +185,7 @@ pub async fn register_sources(
 mod tests {
     use super::*;
     use crate::plugin_cache::source_manifest::SourceManifest;
-    use datafusion::arrow::array::{Int64Array, StringArray};
+    use datafusion::arrow::array::{Array, Int64Array, StringArray};
     use std::io::Write;
 
     fn write_gz(path: &std::path::Path, body: &str) {
@@ -247,6 +256,62 @@ threshold = 0.01
             .unwrap()
             .value(0);
         assert_eq!(c, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vcf_record_layout_distinguishes_explicit_null_from_absent_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("missing-info.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.3\n\
+             ##INFO=<ID=CLNDN,Number=.,Type=String,Description=\"Disease name\">\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             1\t100\t.\tG\tA\t.\t.\tCLNDN=.\n\
+             1\t101\t.\tG\tA\t.\t.\t.\n",
+        )
+        .unwrap();
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+value_columns = []
+
+[[source]]
+provider = "vcf"
+path = "{}"
+record_layout = true
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+        let batches = ctx
+            .sql(
+                "SELECT start, \"CLNDN\", \"_vcf_info_keys\" \
+                 FROM plugin_demo_src ORDER BY start",
+            )
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let batch = &batches[0];
+        assert_eq!(batch.num_rows(), 2);
+        let clndn = batch.column(1);
+        assert!(clndn.is_null(0));
+        assert!(clndn.is_null(1));
+        let info_keys = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(info_keys.value(0), "CLNDN");
+        assert_eq!(info_keys.value(1), "");
     }
 
     // I4: document (and pin, so a `datafusion-bio-format-vcf` version bump that

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -122,17 +122,21 @@ pub async fn register_sources(
                 // `start`/`end` from the file's native 1-based VCF `POS` — keep
                 // them in lock-step so `ingest_sql` always sees the coordinate
                 // system the manifest declares, regardless of source format.
-                let zero_based = matches!(manifest.coordinate_system, CoordinateSystem::ZeroBasedHalfOpen);
+                let zero_based = matches!(
+                    manifest.coordinate_system,
+                    CoordinateSystem::ZeroBasedHalfOpen
+                );
                 // No manifest knob yet for selecting a INFO/FORMAT subset — read
                 // every INFO field the VCF header declares (`None`) and let
                 // `ingest_sql` project down to what it needs, same as the CSV
                 // path relies on `ingest_sql` rather than a narrower provider
                 // schema. Revisit if a source has so many INFO fields that
                 // schema inference itself becomes the bottleneck.
-                let provider = VcfTableProvider::new(spec.path.clone(), None, None, None, zero_based)
-                    .map_err(|e| {
-                        DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
-                    })?;
+                let provider =
+                    VcfTableProvider::new(spec.path.clone(), None, None, None, zero_based)
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!("open VCF source '{table}': {e}"))
+                        })?;
                 ctx.register_table(&table, Arc::new(provider))?;
             }
             ProviderKind::Bed => {
@@ -150,7 +154,7 @@ pub async fn register_sources(
 mod tests {
     use super::*;
     use crate::plugin_cache::source_manifest::SourceManifest;
-    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::array::{Int64Array, StringArray};
     use std::io::Write;
 
     fn write_gz(path: &std::path::Path, body: &str) {
@@ -221,5 +225,71 @@ threshold = 0.01
             .unwrap()
             .value(0);
         assert_eq!(c, 2);
+    }
+
+    // I4: document (and pin, so a `datafusion-bio-format-vcf` version bump that
+    // changes this can't slip by silently) how the VCF provider actually
+    // reports a multi-allelic ALT. It comes back as one string joined per-
+    // allele (confirmed below: '|', not the VCF spec's own ','), not split
+    // into separate rows -- an `ingest_sql` that assumes the wrong separator
+    // (or assumes it's split already) builds an `allele_string` that never
+    // matches the per-allele variation key, i.e. a silent miss on every
+    // multi-allelic site. This test exists so that would fail loudly here
+    // instead of being discovered downstream.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn vcf_source_multiallelic_alt_shape_is_pinned() {
+        let dir = tempfile::tempdir().unwrap();
+        let vcf = dir.path().join("multiallelic.vcf");
+        std::fs::write(
+            &vcf,
+            "##fileformat=VCFv4.2\n\
+             #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n\
+             1\t100\t.\tG\tA,C\t.\t.\t.\n",
+        )
+        .unwrap();
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+value_columns = []
+
+[[source]]
+provider = "vcf"
+path = "{}"
+"##,
+            vcf.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+        let rows = ctx
+            .sql("SELECT alt FROM plugin_demo_src")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "one row per VCF line, not per allele");
+        let alt = rows[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("alt column is a plain string, not a list -- if this ever fails, the ALT shape changed and every manifest built on this provider needs re-auditing");
+        // Pinned current behavior: `datafusion-bio-format-vcf` v1.8.8 joins a
+        // multi-allelic ALT with '|' (NOT ',' -- the naive guess from the VCF
+        // spec's own comma-separated ALT column would be wrong here). Any
+        // manifest built directly on `ProviderKind::Vcf` for a source that can
+        // be multi-allelic MUST split `alt` on '|' in its own `ingest_sql`
+        // (the way the CADD/ClinVar bcftools-flatten preprocessing already
+        // splits multi-value INFO tags for VCF sources that go through the
+        // CSV path instead).
+        assert_eq!(
+            alt.value(0),
+            "A|C",
+            "ALT shape changed -- re-audit every VCF-provider manifest's \
+             ingest_sql for correct multi-allelic splitting"
+        );
     }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -2,13 +2,20 @@
 //! `plugin_<name>_src[_<part>]` names. CSV/TSV/Parquet use builtin DataFusion
 //! providers; VCF uses `datafusion-bio-format-vcf`'s `VcfTableProvider` (INFO
 //! fields come back as typed top-level columns named after the raw INFO tag —
-//! query them directly in `ingest_sql`). BED is not wired in the prototype.
+//! query them directly in `ingest_sql`); BED uses `datafusion-bio-format-bed`'s
+//! `BedTableProvider`, whose schema is only ever `chrom, start, end, name`
+//! regardless of the declared column count (`BEDFields` selects how many
+//! columns the reader parses off each line, not how many it exposes) — a
+//! source needing more than one extra field packs it into `name` and splits
+//! it back out in `ingest_sql`, the same trick SpliceAI's flattened INFO tag
+//! uses.
 
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::prelude::{CsvReadOptions, ParquetReadOptions, SessionContext};
+use datafusion_bio_format_bed::table_provider::{BEDFields, BedTableProvider};
 use datafusion_bio_format_vcf::table_provider::VcfTableProvider;
 
 use crate::plugin_cache::source_manifest::{
@@ -140,10 +147,25 @@ pub async fn register_sources(
                 ctx.register_table(&table, Arc::new(provider))?;
             }
             ProviderKind::Bed => {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "provider {:?} not wired in prototype (table '{table}')",
-                    spec.provider
-                )));
+                // Same reasoning as the VCF branch above: the manifest's
+                // `coordinate_system` drives what `ingest_sql` expects, so
+                // keep the provider's own zero-based flag in lock-step with
+                // it rather than trusting the file's own convention.
+                let zero_based = matches!(
+                    manifest.coordinate_system,
+                    CoordinateSystem::ZeroBasedHalfOpen
+                );
+                // No manifest knob yet for BED4/5/6 -- `determine_schema` in
+                // `datafusion-bio-format-bed` only ever exposes `chrom, start,
+                // end, name` regardless of variant, so BED4 is the only
+                // choice that matters until a source needs more raw columns
+                // parsed off each line than that.
+                let provider =
+                    BedTableProvider::new(spec.path.clone(), BEDFields::BED4, None, zero_based)
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!("open BED source '{table}': {e}"))
+                        })?;
+                ctx.register_table(&table, Arc::new(provider))?;
             }
         }
     }

--- a/datafusion/bio-function-vep/src/plugin_cache/provider.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/provider.rs
@@ -314,4 +314,71 @@ path = "{}"
              ingest_sql for correct multi-allelic splitting"
         );
     }
+
+    /// The BED branch hardcodes `BEDFields::BED4` on the claim that
+    /// `determine_schema` exposes exactly `chrom, start, end, name` whatever
+    /// the variant, so a source needing more than one extra field packs it
+    /// into `name` and splits it back out in `ingest_sql`. That claim is load
+    /// bearing for every BED manifest and was only ever checked by hand
+    /// against one bio-formats release. Pin it the way the VCF ALT shape above
+    /// is pinned: a bump that widens or renames the BED schema fails here
+    /// rather than silently producing an `ingest_sql` that selects the wrong
+    /// column.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bed_source_schema_is_pinned_to_chrom_start_end_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let bed = dir.path().join("packed.bed");
+        // BED is 0-based half-open; `name` carries the packed extra fields.
+        std::fs::write(&bed, "chr1\t99\t100\trs1|A/G|Pathogenic\n").unwrap();
+
+        let toml = format!(
+            r##"
+plugin_name = "demo"
+coordinate_system = "0-based-half-open"
+ingest_sql = "SELECT 1"
+value_columns = []
+
+[[source]]
+provider = "bed"
+path = "{}"
+"##,
+            bed.display()
+        );
+        let manifest: SourceManifest = toml::from_str(&toml).unwrap();
+        let ctx = SessionContext::new();
+        let _temps = register_sources(&ctx, &manifest).await.unwrap();
+
+        let schema = ctx
+            .table_provider("plugin_demo_src")
+            .await
+            .unwrap()
+            .schema();
+        let columns: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            columns,
+            vec!["chrom", "start", "end", "name"],
+            "BED4 schema changed -- the `name`-packing trick every BED manifest \
+             relies on needs re-auditing, and the hardcoded BEDFields::BED4 in \
+             the ProviderKind::Bed branch may no longer be the right choice"
+        );
+
+        let rows = ctx
+            .sql("SELECT name FROM plugin_demo_src")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let name = rows[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("name is a plain string; packed extra fields are split in ingest_sql");
+        assert_eq!(
+            name.value(0),
+            "rs1|A/G|Pathogenic",
+            "BED `name` must arrive verbatim -- any splitting or trimming here \
+             would silently corrupt every packed BED manifest"
+        );
+    }
 }

--- a/datafusion/bio-function-vep/src/plugin_cache/registry.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/registry.rs
@@ -277,6 +277,7 @@ mod tests {
             "",
             "",
             "",
+            "",
             "78",
             "R/G",
             "",
@@ -291,6 +292,7 @@ mod tests {
         // non-missense (no aa-change) → Null (gate)
         let ns_miss = build_attr_namespace(
             "synonymous_variant",
+            "",
             "",
             "",
             "",

--- a/datafusion/bio-function-vep/src/plugin_cache/registry.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/registry.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 use datafusion::common::{DataFusionError, Result};
 
 use crate::cache::manifest::canonical_chrom_label;
-use crate::plugin_cache::cache_manifest::discover_plugins;
+use crate::plugin_cache::cache_manifest::{
+    AlleleMatch, CacheManifest, FieldOrder, discover_plugins,
+};
 use crate::plugin_cache::lookup::{PluginBufferSlice, PluginLookup, PluginScalar};
 use crate::plugin_cache::template::CompiledTemplate;
 
@@ -16,6 +18,10 @@ use crate::plugin_cache::template::CompiledTemplate;
 /// shard for the current chrom).
 struct PluginEntry {
     csq_fields: Vec<String>,
+    /// Indices into the shard's value columns, in emitted-field order.
+    emit_order: Vec<usize>,
+    /// Ensembl's comparison rule for this plugin; gates allele reduction.
+    allele_match: AlleleMatch,
     /// The compiled discriminator template for each match column, in order.
     match_templates: Vec<CompiledTemplate>,
     n_match: usize,
@@ -28,6 +34,21 @@ pub struct PluginRegistry {
     plugins: Vec<PluginEntry>,
 }
 
+/// Indices into a plugin's `value_columns`, in the order its CSQ fields are
+/// emitted: declaration order, or sorted by field name when the plugin's
+/// Ensembl counterpart sorts its own fields ([`FieldOrder::Alphabetical`]).
+fn emit_order(m: &CacheManifest) -> Vec<usize> {
+    let mut order: Vec<usize> = (0..m.value_columns.len()).collect();
+    if m.field_order == FieldOrder::Alphabetical {
+        order.sort_by(|&a, &b| {
+            m.value_columns[a]
+                .csq_field
+                .cmp(&m.value_columns[b].csq_field)
+        });
+    }
+    order
+}
+
 impl PluginRegistry {
     /// Discover plugins under `cache_root` and open each one's shard for `chrom`.
     pub async fn open(cache_root: &Path, chrom: &str) -> Result<Self> {
@@ -35,10 +56,16 @@ impl PluginRegistry {
         let manifests = discover_plugins(cache_root)?;
         let mut plugins = Vec::with_capacity(manifests.len());
         for m in manifests {
-            let csq_fields: Vec<String> = m
-                .value_columns
+            // The emitted field names are permuted, but the shard projection is
+            // NOT: `ProjectionMask::leaves` yields columns in the file's physical
+            // order whatever order the leaves are listed in, so permuting the
+            // projection would move the names while leaving the values put, and
+            // silently pair each field with another field's value. The values are
+            // permuted after probing instead (see `probe_all`).
+            let order = emit_order(&m);
+            let csq_fields: Vec<String> = order
                 .iter()
-                .map(|v| v.csq_field.clone())
+                .map(|&i| m.value_columns[i].csq_field.clone())
                 .collect();
             let value_columns: Vec<String> =
                 m.value_columns.iter().map(|v| v.column.clone()).collect();
@@ -80,6 +107,8 @@ impl PluginRegistry {
             };
             plugins.push(PluginEntry {
                 csq_fields,
+                emit_order: order,
+                allele_match: m.allele_match,
                 match_templates,
                 n_match,
                 n_values,
@@ -102,7 +131,37 @@ impl PluginRegistry {
             .map(|manifests| {
                 manifests
                     .iter()
-                    .flat_map(|m| m.value_columns.iter().map(|v| v.csq_field.clone()))
+                    .flat_map(|m| {
+                        emit_order(m)
+                            .into_iter()
+                            .map(|i| m.value_columns[i].csq_field.clone())
+                            .collect::<Vec<_>>()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// `(csq_field, description)` for every plugin field that declares one, in
+    /// emitted order — the `##<FIELD>=<description>` header lines Ensembl VEP
+    /// writes for its plugin fields. Same discovery path and ordering as
+    /// [`Self::field_names`], so the header cannot drift from the CSQ layout.
+    pub fn field_descriptions(cache_root: &Path) -> Vec<(String, String)> {
+        discover_plugins(cache_root)
+            .map(|manifests| {
+                manifests
+                    .iter()
+                    .flat_map(|m| {
+                        emit_order(m)
+                            .into_iter()
+                            .filter_map(|i| {
+                                let v = &m.value_columns[i];
+                                v.description
+                                    .as_ref()
+                                    .map(|d| (v.csq_field.clone(), d.clone()))
+                            })
+                            .collect::<Vec<_>>()
+                    })
                     .collect()
             })
             .unwrap_or_default()
@@ -133,6 +192,8 @@ impl PluginRegistry {
             };
             entries.push(SliceEntry {
                 csq_fields_len: p.csq_fields.len(),
+                emit_order: p.emit_order.clone(),
+                allele_match: p.allele_match,
                 match_templates: p.match_templates.clone(),
                 slice,
             });
@@ -144,6 +205,8 @@ impl PluginRegistry {
 /// Per-plugin buffer slice plus the metadata `probe_all` needs.
 struct SliceEntry {
     csq_fields_len: usize,
+    emit_order: Vec<usize>,
+    allele_match: AlleleMatch,
     match_templates: Vec<CompiledTemplate>,
     slice: Option<PluginBufferSlice>,
 }
@@ -166,6 +229,7 @@ impl BufferSlices {
         &self,
         start: u32,
         allele_string: &str,
+        fallback_key: Option<(u32, &str)>,
         attrs: &[Option<&str>],
     ) -> Vec<PluginScalar> {
         let mut out = Vec::new();
@@ -175,9 +239,25 @@ impl BufferSlices {
             let hit = e
                 .slice
                 .as_ref()
-                .and_then(|s| s.probe(start, allele_string, &match_values));
+                .and_then(|s| s.probe(start, allele_string, &match_values))
+                .or_else(|| {
+                    // Sources differ in how they spell the same variant: most key
+                    // the parser-level (anchor-trimmed) allele, but a per-base
+                    // source such as CADD's whole-genome SNV file keys the fully
+                    // minimal one, so an untrimmed MNV misses on the primary key.
+                    // Only consulted on a miss, so no existing hit can change.
+                    if e.allele_match != AlleleMatch::Minimised {
+                        return None;
+                    }
+                    let (fb_start, fb_allele) = fallback_key?;
+                    e.slice
+                        .as_ref()
+                        .and_then(|s| s.probe(fb_start, fb_allele, &match_values))
+                });
             match hit {
-                Some(values) => out.extend(values),
+                // `values` arrive in shard-column order; emit them in the same
+                // order as this plugin's `csq_fields`.
+                Some(values) => out.extend(e.emit_order.iter().map(|&i| values[i].clone())),
                 None => out.extend(std::iter::repeat_n(PluginScalar::Null, e.csq_fields_len)),
             }
         }
@@ -214,6 +294,7 @@ mod tests {
             column: "am_pathogenicity".into(),
             csq_field: "am_pathogenicity".into(),
             ty: ValueType::Float32,
+            description: None,
         }];
         let schema = plugin_output_schema(&matches, &vals);
         let batch = RecordBatch::try_new(
@@ -250,6 +331,7 @@ mod tests {
                 column: "am_pathogenicity".into(),
                 csq_field: "am_pathogenicity".into(),
                 ty: "Float32".into(),
+                description: None,
             }],
             chroms: vec![ChromEntry {
                 chrom: "chr22".into(),
@@ -259,6 +341,9 @@ mod tests {
                 cold: 2,
             }],
             cache_source_version: None,
+            allele_match: Default::default(),
+            csq_rank: 0,
+            field_order: Default::default(),
         };
         manifest.write(&plugin_dir).unwrap();
 
@@ -284,7 +369,7 @@ mod tests {
             "A",
             "G",
         );
-        let hit = slices.probe_all(100, "A/G", &ns_hit);
+        let hit = slices.probe_all(100, "A/G", None, &ns_hit);
         match hit[0] {
             PluginScalar::F32(v) => assert!((v - 0.0427).abs() < 1e-6),
             ref other => panic!("{other:?}"),
@@ -307,7 +392,7 @@ mod tests {
             "A",
             "G",
         );
-        let none = slices.probe_all(100, "A/G", &ns_miss);
+        let none = slices.probe_all(100, "A/G", None, &ns_miss);
         assert_eq!(none, vec![PluginScalar::Null]);
     }
 
@@ -333,6 +418,7 @@ mod tests {
                 column: "score".into(),
                 csq_field: "SCORE".into(),
                 ty: "Float32".into(),
+                description: None,
             }],
             // chr22 present in the manifest with rows: 0 and NO file on disk.
             chroms: vec![ChromEntry {
@@ -343,6 +429,9 @@ mod tests {
                 cold: 0,
             }],
             cache_source_version: None,
+            allele_match: Default::default(),
+            csq_rank: 0,
+            field_order: Default::default(),
         };
         manifest.write(&plugin_dir).unwrap();
 
@@ -350,7 +439,10 @@ mod tests {
         assert_eq!(reg.csq_fields(), vec!["SCORE".to_string()]);
         let slices = reg.take_buffer_all(&[100]).await.unwrap();
         // No shard → empty (Null) field, not an error.
-        assert_eq!(slices.probe_all(100, "A/G", &[]), vec![PluginScalar::Null]);
+        assert_eq!(
+            slices.probe_all(100, "A/G", None, &[]),
+            vec![PluginScalar::Null]
+        );
     }
 
     // A per-variant plugin (no match_column) is keyed only on (start,
@@ -369,6 +461,7 @@ mod tests {
             column: "score".into(),
             csq_field: "SCORE".into(),
             ty: ValueType::Float32,
+            description: None,
         }];
         let schema = plugin_output_schema(&[], &vals);
         let batch = RecordBatch::try_new(
@@ -401,6 +494,7 @@ mod tests {
                 column: "score".into(),
                 csq_field: "SCORE".into(),
                 ty: "Float32".into(),
+                description: None,
             }],
             chroms: vec![ChromEntry {
                 chrom: "chr22".into(),
@@ -410,18 +504,24 @@ mod tests {
                 cold: 1,
             }],
             cache_source_version: None,
+            allele_match: Default::default(),
+            csq_rank: 0,
+            field_order: Default::default(),
         };
         manifest.write(&plugin_dir).unwrap();
 
         let reg = PluginRegistry::open(cache_root, "22").await.unwrap();
         let slices = reg.take_buffer_all(&[100]).await.unwrap();
         // Empty namespace (no transcript) still hits the per-variant row.
-        match slices.probe_all(100, "A/G", &[])[0] {
+        match slices.probe_all(100, "A/G", None, &[])[0] {
             PluginScalar::F32(v) => assert!((v - 0.5).abs() < 1e-6),
             ref other => panic!("{other:?}"),
         }
         // Wrong allele still misses.
-        assert_eq!(slices.probe_all(100, "C/T", &[]), vec![PluginScalar::Null]);
+        assert_eq!(
+            slices.probe_all(100, "C/T", None, &[]),
+            vec![PluginScalar::Null]
+        );
     }
 
     // A manifest advertising rows > 0 with no shard on disk is a partial/corrupt
@@ -446,6 +546,7 @@ mod tests {
                 column: "score".into(),
                 csq_field: "SCORE".into(),
                 ty: "Float32".into(),
+                description: None,
             }],
             // rows: 5 but NO chr22.parquet on disk → corrupt cache.
             chroms: vec![ChromEntry {
@@ -456,6 +557,9 @@ mod tests {
                 cold: 5,
             }],
             cache_source_version: None,
+            allele_match: Default::default(),
+            csq_rank: 0,
+            field_order: Default::default(),
         };
         manifest.write(&plugin_dir).unwrap();
 

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -151,57 +151,7 @@ pub struct SourceManifest {
     pub assume_unique: bool,
 }
 
-/// VCF meta-information keys whose declarations belong to the file itself,
-/// not to a plugin's unstructured `##FIELD=description` namespace.
-///
-/// Rejecting these names removes an otherwise irresolvable ambiguity on
-/// re-annotation: for example, `##INFO=<ID=...>` must never be mistaken for a
-/// stale plugin header merely because a plugin also chose `INFO` as a CSQ field.
-const RESERVED_VCF_META_KEYS: &[&str] = &[
-    "fileformat",
-    "fileDate",
-    "source",
-    "reference",
-    "phasing",
-    "assembly",
-    "pedigreeDB",
-    "INFO",
-    "FILTER",
-    "FORMAT",
-    "ALT",
-    "contig",
-    "SAMPLE",
-    "PEDIGREE",
-    "META",
-    "VEP",
-];
-
-pub(crate) fn validate_csq_field_name(plugin_name: &str, field: &str) -> Result<()> {
-    if RESERVED_VCF_META_KEYS.contains(&field)
-        || field == "VEP-command-line"
-        || field == env!("CARGO_PKG_NAME")
-        || field
-            .strip_suffix("-command-line")
-            .is_some_and(|prefix| prefix == env!("CARGO_PKG_NAME"))
-    {
-        return Err(DataFusionError::Execution(format!(
-            "plugin '{plugin_name}' CSQ field '{field}' collides with a reserved VCF \
-             meta-information key"
-        )));
-    }
-    Ok(())
-}
-
 impl SourceManifest {
-    /// Validate constraints that must hold both while building a cache and when
-    /// reading an already-built cache at annotation time.
-    pub fn validate(&self) -> Result<()> {
-        for value in &self.value_columns {
-            validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
-        }
-        Ok(())
-    }
-
     /// Match-column names, in order (the discriminator part of the key).
     pub fn match_column_names(&self) -> Vec<String> {
         self.match_columns
@@ -217,11 +167,9 @@ impl SourceManifest {
         let text = std::fs::read_to_string(path).map_err(|e| {
             DataFusionError::Execution(format!("read source manifest '{}': {e}", path.display()))
         })?;
-        let manifest: Self = toml::from_str(&text).map_err(|e| {
+        toml::from_str(&text).map_err(|e| {
             DataFusionError::Execution(format!("parse source manifest '{}': {e}", path.display()))
-        })?;
-        manifest.validate()?;
-        Ok(manifest)
+        })
     }
 
     /// The ingest view name: `plugin_<name>_ingest`.
@@ -283,29 +231,6 @@ type = "Float32"
         assert_eq!(m.value_columns[0].csq_field, "DEMO_SCORE");
         assert_eq!(m.value_columns[0].ty, ValueType::Float32);
         assert_eq!(m.ingest_view_name(), "plugin_demo_ingest");
-    }
-
-    #[test]
-    fn rejects_csq_fields_that_collide_with_vcf_or_provenance_headers() {
-        let base: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
-        for reserved in RESERVED_VCF_META_KEYS.iter().copied().chain([
-            "VEP-command-line",
-            env!("CARGO_PKG_NAME"),
-            concat!(env!("CARGO_PKG_NAME"), "-command-line"),
-        ]) {
-            let mut manifest = base.clone();
-            manifest.value_columns[0].csq_field = reserved.to_string();
-            let error = manifest.validate().unwrap_err().to_string();
-            assert!(
-                error.contains("reserved VCF meta-information key"),
-                "{error}"
-            );
-        }
-
-        let mut manifest = base;
-        manifest.value_columns[0].csq_field = "SCORE".to_string();
-        manifest.value_columns[0].description = Some("<threshold>".to_string());
-        manifest.validate().unwrap();
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -177,6 +177,17 @@ const RESERVED_VCF_META_KEYS: &[&str] = &[
 ];
 
 pub(crate) fn validate_csq_field_name(plugin_name: &str, field: &str) -> Result<()> {
+    if field.is_empty()
+        || field
+            .chars()
+            .any(|c| matches!(c, '|' | '=') || c.is_control())
+    {
+        return Err(DataFusionError::Execution(format!(
+            "plugin '{plugin_name}' has invalid CSQ field name {field:?}; field names must be \
+             non-empty and cannot contain '|', '=', or control characters"
+        )));
+    }
+
     let engine_key = env!("CARGO_PKG_NAME");
     if RESERVED_VCF_META_KEYS.contains(&field)
         || field == engine_key
@@ -305,6 +316,21 @@ type = "Float32"
         manifest.value_columns[0].csq_field = "SCORE".to_string();
         manifest.value_columns[0].description = Some("<threshold>".to_string());
         manifest.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_delimited_or_control_bearing_csq_field_names() {
+        let base: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
+        for unsafe_name in ["", "A|B", "A=B", "A\nB", "A\rB", "A\tB", "\u{1}SCORE"] {
+            let mut manifest = base.clone();
+            manifest.value_columns[0].csq_field = unsafe_name.to_string();
+            let error = manifest.validate().unwrap_err().to_string();
+            assert!(error.contains("invalid CSQ field name"), "{error}");
+            assert!(
+                !error.contains('\n'),
+                "unsafe name must be escaped: {error:?}"
+            );
+        }
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -151,7 +151,57 @@ pub struct SourceManifest {
     pub assume_unique: bool,
 }
 
+/// VCF meta-information keys whose declarations belong to the file itself,
+/// not to a plugin's unstructured `##FIELD=description` namespace.
+///
+/// Rejecting these names removes an otherwise irresolvable ambiguity on
+/// re-annotation: for example, `##INFO=<ID=...>` must never be mistaken for a
+/// stale plugin header merely because a plugin also chose `INFO` as a CSQ field.
+const RESERVED_VCF_META_KEYS: &[&str] = &[
+    "fileformat",
+    "fileDate",
+    "source",
+    "reference",
+    "phasing",
+    "assembly",
+    "pedigreeDB",
+    "INFO",
+    "FILTER",
+    "FORMAT",
+    "ALT",
+    "contig",
+    "SAMPLE",
+    "PEDIGREE",
+    "META",
+    "VEP",
+];
+
+pub(crate) fn validate_csq_field_name(plugin_name: &str, field: &str) -> Result<()> {
+    if RESERVED_VCF_META_KEYS.contains(&field)
+        || field == "VEP-command-line"
+        || field == env!("CARGO_PKG_NAME")
+        || field
+            .strip_suffix("-command-line")
+            .is_some_and(|prefix| prefix == env!("CARGO_PKG_NAME"))
+    {
+        return Err(DataFusionError::Execution(format!(
+            "plugin '{plugin_name}' CSQ field '{field}' collides with a reserved VCF \
+             meta-information key"
+        )));
+    }
+    Ok(())
+}
+
 impl SourceManifest {
+    /// Validate constraints that must hold both while building a cache and when
+    /// reading an already-built cache at annotation time.
+    pub fn validate(&self) -> Result<()> {
+        for value in &self.value_columns {
+            validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
+        }
+        Ok(())
+    }
+
     /// Match-column names, in order (the discriminator part of the key).
     pub fn match_column_names(&self) -> Vec<String> {
         self.match_columns
@@ -167,9 +217,11 @@ impl SourceManifest {
         let text = std::fs::read_to_string(path).map_err(|e| {
             DataFusionError::Execution(format!("read source manifest '{}': {e}", path.display()))
         })?;
-        toml::from_str(&text).map_err(|e| {
+        let manifest: Self = toml::from_str(&text).map_err(|e| {
             DataFusionError::Execution(format!("parse source manifest '{}': {e}", path.display()))
-        })
+        })?;
+        manifest.validate()?;
+        Ok(manifest)
     }
 
     /// The ingest view name: `plugin_<name>_ingest`.
@@ -231,6 +283,29 @@ type = "Float32"
         assert_eq!(m.value_columns[0].csq_field, "DEMO_SCORE");
         assert_eq!(m.value_columns[0].ty, ValueType::Float32);
         assert_eq!(m.ingest_view_name(), "plugin_demo_ingest");
+    }
+
+    #[test]
+    fn rejects_csq_fields_that_collide_with_vcf_or_provenance_headers() {
+        let base: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
+        for reserved in RESERVED_VCF_META_KEYS.iter().copied().chain([
+            "VEP-command-line",
+            env!("CARGO_PKG_NAME"),
+            concat!(env!("CARGO_PKG_NAME"), "-command-line"),
+        ]) {
+            let mut manifest = base.clone();
+            manifest.value_columns[0].csq_field = reserved.to_string();
+            let error = manifest.validate().unwrap_err().to_string();
+            assert!(
+                error.contains("reserved VCF meta-information key"),
+                "{error}"
+            );
+        }
+
+        let mut manifest = base;
+        manifest.value_columns[0].csq_field = "SCORE".to_string();
+        manifest.value_columns[0].description = Some("<threshold>".to_string());
+        manifest.validate().unwrap();
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -92,6 +92,10 @@ pub struct ValueColumn {
     pub csq_field: String,
     #[serde(rename = "type")]
     pub ty: ValueType,
+    /// Text for this field's `##<CSQ_FIELD>=<description>` VCF header line,
+    /// mirroring what an Ensembl plugin returns from `get_header_info()`.
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 /// A per-transcript match discriminator: an extra key column (produced by
@@ -119,6 +123,18 @@ pub struct SourceManifest {
     /// Optional per-transcript match discriminators (§3.4). Empty = per-variant.
     #[serde(default, rename = "match_column")]
     pub match_columns: Vec<MatchColumn>,
+    /// How this plugin's Ensembl implementation compares a variant to a data
+    /// row. Set `minimised` only for plugins that call
+    /// `get_matched_variant_alleles()` (CADD, AlphaMissense); the default
+    /// `exact` matches SpliceAI's and dbNSFP's verbatim comparison.
+    #[serde(default)]
+    pub allele_match: crate::plugin_cache::cache_manifest::AlleleMatch,
+    /// Position of this plugin's field block in the CSQ string (lower first).
+    #[serde(default = "crate::plugin_cache::cache_manifest::default_csq_rank_pub")]
+    pub csq_rank: u32,
+    /// Field order within this plugin's block.
+    #[serde(default)]
+    pub field_order: crate::plugin_cache::cache_manifest::FieldOrder,
     /// Skip the build-time keep-first dedup pass (`dedup::dedup_keep_first`)
     /// when the source is structurally guaranteed to never emit two rows
     /// sharing a runtime probe key `(start, allele_string, <match cols>)` —

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -151,7 +151,57 @@ pub struct SourceManifest {
     pub assume_unique: bool,
 }
 
+/// Standard VCF meta-information keys and provenance keys owned by this sink.
+/// A plugin field using one would either produce an invalid declaration (for
+/// structured keys such as `INFO`) or replace file-owned scalar metadata (for
+/// keys such as the mandatory `fileformat`). Arbitrary custom keys are valid;
+/// their structured declarations are disambiguated in `vcf_sink` instead.
+const RESERVED_VCF_META_KEYS: &[&str] = &[
+    "fileformat",
+    "fileDate",
+    "source",
+    "reference",
+    "phasing",
+    "assembly",
+    "pedigreeDB",
+    "INFO",
+    "FILTER",
+    "FORMAT",
+    "ALT",
+    "contig",
+    "SAMPLE",
+    "PEDIGREE",
+    "META",
+    "VEP",
+    "VEP-command-line",
+];
+
+pub(crate) fn validate_csq_field_name(plugin_name: &str, field: &str) -> Result<()> {
+    let engine_key = env!("CARGO_PKG_NAME");
+    if RESERVED_VCF_META_KEYS.contains(&field)
+        || field == engine_key
+        || field
+            .strip_suffix("-command-line")
+            .is_some_and(|prefix| prefix == engine_key)
+    {
+        return Err(DataFusionError::Execution(format!(
+            "plugin '{plugin_name}' CSQ field '{field}' collides with a reserved VCF \
+             meta-information key"
+        )));
+    }
+    Ok(())
+}
+
 impl SourceManifest {
+    /// Validate constraints shared by build-time source manifests and runtime
+    /// built-cache manifests.
+    pub fn validate(&self) -> Result<()> {
+        for value in &self.value_columns {
+            validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
+        }
+        Ok(())
+    }
+
     /// Match-column names, in order (the discriminator part of the key).
     pub fn match_column_names(&self) -> Vec<String> {
         self.match_columns
@@ -167,9 +217,11 @@ impl SourceManifest {
         let text = std::fs::read_to_string(path).map_err(|e| {
             DataFusionError::Execution(format!("read source manifest '{}': {e}", path.display()))
         })?;
-        toml::from_str(&text).map_err(|e| {
+        let manifest: Self = toml::from_str(&text).map_err(|e| {
             DataFusionError::Execution(format!("parse source manifest '{}': {e}", path.display()))
-        })
+        })?;
+        manifest.validate()?;
+        Ok(manifest)
     }
 
     /// The ingest view name: `plugin_<name>_ingest`.
@@ -231,6 +283,28 @@ type = "Float32"
         assert_eq!(m.value_columns[0].csq_field, "DEMO_SCORE");
         assert_eq!(m.value_columns[0].ty, ValueType::Float32);
         assert_eq!(m.ingest_view_name(), "plugin_demo_ingest");
+    }
+
+    #[test]
+    fn rejects_reserved_vcf_keys_but_accepts_arbitrary_custom_fields() {
+        let base: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
+        for reserved in RESERVED_VCF_META_KEYS.iter().copied().chain([
+            env!("CARGO_PKG_NAME"),
+            concat!(env!("CARGO_PKG_NAME"), "-command-line"),
+        ]) {
+            let mut manifest = base.clone();
+            manifest.value_columns[0].csq_field = reserved.to_string();
+            let error = manifest.validate().unwrap_err().to_string();
+            assert!(
+                error.contains("reserved VCF meta-information key"),
+                "{error}"
+            );
+        }
+
+        let mut manifest = base;
+        manifest.value_columns[0].csq_field = "SCORE".to_string();
+        manifest.value_columns[0].description = Some("<threshold>".to_string());
+        manifest.validate().unwrap();
     }
 
     #[test]

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -70,6 +70,13 @@ pub struct SourceSpec {
     pub part: Option<String>,
     pub provider: ProviderKind,
     pub path: String,
+    /// For text VCF input, expose the record's INFO/FORMAT key lists as the
+    /// reader's `_vcf_info_keys` / `_vcf_format_keys` columns. Typed VCF values
+    /// alone cannot distinguish an explicit `KEY=.` from an absent key because
+    /// both become Arrow null. Off by default so sources that do not need that
+    /// distinction pay no layout-carry cost.
+    #[serde(default)]
+    pub record_layout: bool,
     #[serde(default)]
     pub csv: Option<CsvParams>,
 }
@@ -209,6 +216,15 @@ impl SourceManifest {
     /// Validate constraints shared by build-time source manifests and runtime
     /// built-cache manifests.
     pub fn validate(&self) -> Result<()> {
+        for source in &self.sources {
+            if source.record_layout && source.provider != ProviderKind::Vcf {
+                return Err(DataFusionError::Execution(format!(
+                    "plugin '{}' requests record_layout for a {:?} source; record layout is \
+                     supported only for text VCF sources",
+                    self.plugin_name, source.provider
+                )));
+            }
+        }
         for value in &self.value_columns {
             validate_csq_field_name(&self.plugin_name, &value.csq_field)?;
         }
@@ -288,6 +304,7 @@ type = "Float32"
         assert_eq!(m.plugin_name, "demo");
         assert_eq!(m.coordinate_system, CoordinateSystem::OneBased);
         assert_eq!(m.sources.len(), 1);
+        assert!(!m.sources[0].record_layout);
         assert_eq!(
             m.sources[0].table_name(&m.plugin_name),
             "plugin_demo_src_snv"
@@ -355,11 +372,27 @@ type = "Float32"
     }
 
     #[test]
+    fn record_layout_is_supported_only_for_vcf_sources() {
+        let mut manifest: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
+        manifest.sources[0].record_layout = true;
+        let error = manifest.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("record layout is supported only for text VCF sources"),
+            "{error}"
+        );
+
+        manifest.sources[0].provider = ProviderKind::Vcf;
+        manifest.sources[0].csv = None;
+        manifest.validate().unwrap();
+    }
+
+    #[test]
     fn single_source_table_name_has_no_part_suffix() {
         let src = SourceSpec {
             part: None,
             provider: ProviderKind::Csv,
             path: "x".into(),
+            record_layout: false,
             csv: None,
         };
         assert_eq!(src.table_name("cadd"), "plugin_cadd_src");

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -119,6 +119,20 @@ pub struct SourceManifest {
     /// Optional per-transcript match discriminators (§3.4). Empty = per-variant.
     #[serde(default, rename = "match_column")]
     pub match_columns: Vec<MatchColumn>,
+    /// Skip the build-time keep-first dedup pass (`dedup::dedup_keep_first`)
+    /// when the source is structurally guaranteed to never emit two rows
+    /// sharing a runtime probe key `(start, allele_string, <match cols>)` —
+    /// e.g. SpliceAI's masked release (one prediction per variant) or CADD's
+    /// SNV+indel files (disjoint allele-string shapes, so they can't collide
+    /// with each other or within themselves). Dedup's `HashSet<String>` costs
+    /// one heap-allocated key per row and is the dominant memory cost on the
+    /// largest chromosomes; skipping it for sources that provably have no
+    /// duplicates avoids that cost entirely. Do NOT set this for sources that
+    /// can legitimately repeat a key (e.g. AlphaMissense's overlapping
+    /// UniProt entries) — the manifest author must justify this per-plugin,
+    /// it is not a generic performance knob.
+    #[serde(default)]
+    pub assume_unique: bool,
 }
 
 impl SourceManifest {

--- a/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
@@ -177,14 +177,16 @@ const RESERVED_VCF_META_KEYS: &[&str] = &[
 ];
 
 pub(crate) fn validate_csq_field_name(plugin_name: &str, field: &str) -> Result<()> {
-    if field.is_empty()
-        || field
-            .chars()
-            .any(|c| matches!(c, '|' | '=') || c.is_control())
-    {
+    let mut chars = field.chars();
+    let valid_first = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+    let valid_rest = chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '+' | '-'));
+    if !valid_first || !valid_rest {
         return Err(DataFusionError::Execution(format!(
-            "plugin '{plugin_name}' has invalid CSQ field name {field:?}; field names must be \
-             non-empty and cannot contain '|', '=', or control characters"
+            "plugin '{plugin_name}' has invalid CSQ field name {field:?}; field names must start \
+             with an ASCII alphanumeric character or '_' and contain only ASCII alphanumeric \
+             characters, '_', '.', '+', or '-'"
         )));
     }
 
@@ -319,9 +321,22 @@ type = "Float32"
     }
 
     #[test]
-    fn rejects_empty_delimited_or_control_bearing_csq_field_names() {
+    fn enforces_vcf_safe_csq_field_identifiers() {
         let base: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
-        for unsafe_name in ["", "A|B", "A=B", "A\nB", "A\rB", "A\tB", "\u{1}SCORE"] {
+        for unsafe_name in [
+            "",
+            " ",
+            "CADD RAW",
+            "A|B",
+            "A=B",
+            "A\nB",
+            "A\rB",
+            "A\tB",
+            "\u{1}SCORE",
+            ".SCORE",
+            "SCORE/RAW",
+            "café",
+        ] {
             let mut manifest = base.clone();
             manifest.value_columns[0].csq_field = unsafe_name.to_string();
             let error = manifest.validate().unwrap_err().to_string();
@@ -330,6 +345,12 @@ type = "Float32"
                 !error.contains('\n'),
                 "unsafe name must be escaped: {error:?}"
             );
+        }
+
+        for safe_name in ["CADD_RAW", "GERP++_RS", "SCORE.1", "CUSTOM-FIELD", "1000G"] {
+            let mut manifest = base.clone();
+            manifest.value_columns[0].csq_field = safe_name.to_string();
+            manifest.validate().unwrap();
         }
     }
 

--- a/datafusion/bio-function-vep/src/plugin_cache/template.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/template.rs
@@ -12,6 +12,7 @@ use datafusion::common::{DataFusionError, Result};
 pub const ATTR_NAMES: &[&str] = &[
     "Consequence",
     "Gene",
+    "SYMBOL",
     "Feature_type",
     "Feature",
     "BIOTYPE",
@@ -95,6 +96,7 @@ impl CompiledTemplate {
 pub fn build_attr_namespace<'a>(
     consequence: &'a str,
     gene: &'a str,
+    symbol: &'a str,
     feature_type: &'a str,
     feature: &'a str,
     biotype: &'a str,
@@ -121,6 +123,7 @@ pub fn build_attr_namespace<'a>(
     [
         non_empty(consequence),
         non_empty(gene),
+        non_empty(symbol),
         non_empty(feature_type),
         non_empty(feature),
         non_empty(biotype),
@@ -146,6 +149,7 @@ mod tests {
         build_attr_namespace(
             "missense_variant",
             "ENSG1",
+            "GENE1",
             "Transcript",
             "ENST1",
             "protein_coding",
@@ -185,6 +189,7 @@ mod tests {
         let ns = build_attr_namespace(
             "synonymous_variant",
             "ENSG1",
+            "GENE1",
             "Transcript",
             "ENST1",
             "protein_coding",
@@ -205,7 +210,7 @@ mod tests {
     #[test]
     fn range_position_and_multi_residue_gate() {
         let range = build_attr_namespace(
-            "inframe", "", "", "", "", "", "", "", "", "550-551", "VV/A", "", "C", "T",
+            "inframe", "", "", "", "", "", "", "", "", "", "550-551", "VV/A", "", "C", "T",
         );
         let t = CompiledTemplate::compile("{ref_aa}{Protein_position}{alt_aa}").unwrap();
         assert_eq!(t.eval(&range), None);

--- a/datafusion/bio-function-vep/src/plugin_cache/write.rs
+++ b/datafusion/bio-function-vep/src/plugin_cache/write.rs
@@ -87,6 +87,7 @@ mod tests {
             column: "am_pathogenicity".into(),
             csq_field: "am_pathogenicity".into(),
             ty: ValueType::Float32,
+            description: None,
         }]
     }
 

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -793,17 +793,18 @@ fn merge_annotation_header_lines(
             if is_stale_provenance_line(line) {
                 return false;
             }
-            let Some((key, value)) = line
+            let Some((key, _)) = line
                 .strip_prefix("##")
                 .and_then(|line| line.split_once('='))
             else {
                 return true;
             };
-            // Structured declarations such as `##INFO=<ID=...>` belong to the
-            // source VCF even when a plugin field happens to use the same
-            // meta-information key. This module only owns unstructured field
-            // description lines.
-            value.starts_with('<') || !emitted_fields.contains(key)
+            // Reserved VCF meta-information keys cannot be plugin CSQ field
+            // names (validated in both source and built-cache manifests), so
+            // every exact emitted-field key is plugin-owned. This remains true
+            // when a legitimate free-text description happens to begin with
+            // `<`, which is not by itself proof of a structured declaration.
+            !emitted_fields.contains(key)
         })
         .collect();
     lines.extend(
@@ -2270,16 +2271,15 @@ mod tests {
             "##NO_DESCRIPTION=stale description".to_string(),
             "##CADD_RAW_EXTRA=unrelated prefix match".to_string(),
             "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">".to_string(),
-            "##INFO=stale plugin description".to_string(),
             "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">".to_string(),
+            "##ANGLE=<stale angle-leading description>".to_string(),
             "##VEP=stale provenance".to_string(),
         ];
         let fields = vec![
             "CADD_RAW".to_string(),
             "CADD_PHRED".to_string(),
             "NO_DESCRIPTION".to_string(),
-            "INFO".to_string(),
-            "FORMAT".to_string(),
+            "ANGLE".to_string(),
         ];
         let descriptions = vec![
             (
@@ -2287,7 +2287,10 @@ mod tests {
                 "Current PHRED\nsecond line\r\ttail\u{7}".to_string(),
             ),
             ("CADD_RAW".to_string(), "Current raw score".to_string()),
-            ("INFO".to_string(), "Current plugin INFO".to_string()),
+            (
+                "ANGLE".to_string(),
+                "<current angle-leading description>".to_string(),
+            ),
         ];
         let provenance = vec!["##datafusion-bio-function-vep=current".to_string()];
 
@@ -2303,7 +2306,7 @@ mod tests {
                 "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
                 "##CADD_PHRED=Current PHRED\\nsecond line\\r\\ttail",
                 "##CADD_RAW=Current raw score",
-                "##INFO=Current plugin INFO",
+                "##ANGLE=<current angle-leading description>",
                 provenance[0].as_str(),
             ]
         );

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -738,6 +738,24 @@ fn escape_header_attribute(value: &str) -> String {
     out
 }
 
+/// Renders an unstructured VCF meta-information value on exactly one physical
+/// line. Unlike [`escape_header_attribute`], quotes and backslashes have no
+/// delimiter meaning here and are preserved; only control characters need an
+/// escaped representation (or, for other controls, removal).
+fn sanitize_unstructured_header_value(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out
+}
+
 /// True when `line` is provenance describing a `CSQ` field that is about to be
 /// replaced, and so must not be carried into the new header.
 ///
@@ -775,19 +793,28 @@ fn merge_annotation_header_lines(
             if is_stale_provenance_line(line) {
                 return false;
             }
-            let Some((key, _)) = line
+            let Some((key, value)) = line
                 .strip_prefix("##")
                 .and_then(|line| line.split_once('='))
             else {
                 return true;
             };
-            !emitted_fields.contains(key)
+            // Structured declarations such as `##INFO=<ID=...>` belong to the
+            // source VCF even when a plugin field happens to use the same
+            // meta-information key. This module only owns unstructured field
+            // description lines.
+            value.starts_with('<') || !emitted_fields.contains(key)
         })
         .collect();
     lines.extend(
         plugin_field_descriptions
             .iter()
-            .map(|(field, description)| format!("##{field}={description}")),
+            .map(|(field, description)| {
+                format!(
+                    "##{field}={}",
+                    sanitize_unstructured_header_value(description)
+                )
+            }),
     );
     lines.extend(provenance);
     lines
@@ -2243,16 +2270,24 @@ mod tests {
             "##NO_DESCRIPTION=stale description".to_string(),
             "##CADD_RAW_EXTRA=unrelated prefix match".to_string(),
             "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">".to_string(),
+            "##INFO=stale plugin description".to_string(),
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">".to_string(),
             "##VEP=stale provenance".to_string(),
         ];
         let fields = vec![
             "CADD_RAW".to_string(),
             "CADD_PHRED".to_string(),
             "NO_DESCRIPTION".to_string(),
+            "INFO".to_string(),
+            "FORMAT".to_string(),
         ];
         let descriptions = vec![
-            ("CADD_PHRED".to_string(), "Current PHRED".to_string()),
+            (
+                "CADD_PHRED".to_string(),
+                "Current PHRED\nsecond line\r\ttail\u{7}".to_string(),
+            ),
             ("CADD_RAW".to_string(), "Current raw score".to_string()),
+            ("INFO".to_string(), "Current plugin INFO".to_string()),
         ];
         let provenance = vec!["##datafusion-bio-function-vep=current".to_string()];
 
@@ -2265,10 +2300,17 @@ mod tests {
                 "##fileformat=VCFv4.2",
                 "##CADD_RAW_EXTRA=unrelated prefix match",
                 "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">",
-                "##CADD_PHRED=Current PHRED",
+                "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "##CADD_PHRED=Current PHRED\\nsecond line\\r\\ttail",
                 "##CADD_RAW=Current raw score",
+                "##INFO=Current plugin INFO",
                 provenance[0].as_str(),
             ]
+        );
+        assert!(
+            merged
+                .iter()
+                .all(|line| !line.chars().any(|c| matches!(c, '\n' | '\r' | '\t')))
         );
         assert_eq!(
             merged

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -739,15 +739,12 @@ fn escape_header_attribute(value: &str) -> String {
 }
 
 /// Renders an unstructured VCF meta-information value on exactly one physical
-/// line. A value beginning with `<` is quoted so it cannot be confused with an
-/// arbitrary structured `##KEY=<...>` declaration during re-annotation; quotes
-/// and backslashes are escaped in that quoted form. Otherwise they have no
-/// delimiter meaning and are preserved. Control characters are escaped (or,
-/// for other controls, removed) in both forms.
+/// line. If the sanitized value begins with `<`, it is quoted so it cannot be
+/// confused with an arbitrary structured `##KEY=<...>` declaration during
+/// re-annotation; quotes and backslashes are escaped in that quoted form.
+/// Otherwise they have no delimiter meaning and are preserved. Control
+/// characters are escaped (or, for other controls, removed) in both forms.
 fn sanitize_unstructured_header_value(value: &str) -> String {
-    if value.starts_with('<') {
-        return format!("\"{}\"", escape_header_attribute(value));
-    }
     let mut out = String::with_capacity(value.len());
     for c in value.chars() {
         match c {
@@ -758,7 +755,11 @@ fn sanitize_unstructured_header_value(value: &str) -> String {
             c => out.push(c),
         }
     }
-    out
+    if out.starts_with('<') {
+        format!("\"{}\"", escape_header_attribute(value))
+    } else {
+        out
+    }
 }
 
 /// True when `line` is provenance describing a `CSQ` field that is about to be
@@ -2295,7 +2296,7 @@ mod tests {
             ("CADD_RAW".to_string(), "Current raw score".to_string()),
             (
                 "ANGLE".to_string(),
-                "<current angle-leading description>".to_string(),
+                "\u{7}<current angle-leading description>".to_string(),
             ),
         ];
         let provenance = vec!["##datafusion-bio-function-vep=current".to_string()];
@@ -2349,7 +2350,8 @@ mod tests {
 
     #[test]
     fn quoted_angle_leading_plugin_description_is_valid_vcf_metadata() {
-        let rendered = sanitize_unstructured_header_value("<threshold \"strict\" \\ calibrated>");
+        let rendered =
+            sanitize_unstructured_header_value("\u{1}<threshold \"strict\" \\ calibrated>");
         assert_eq!(rendered, "\"<threshold \\\"strict\\\" \\\\ calibrated>\"");
 
         let input = format!(

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -3,7 +3,7 @@
 //! Provides [`annotate_to_vcf`] — a single-call function that reads a VCF,
 //! annotates it, and streams results to an output VCF file.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -754,6 +754,45 @@ fn is_stale_provenance_line(line: &str) -> bool {
     .any(|prefix| line.starts_with(prefix.as_str()))
 }
 
+/// Replace metadata owned by this annotation run while preserving unrelated
+/// source header lines byte-for-byte and in their original order.
+///
+/// Plugin field headers use the non-structured `##<FIELD>=<description>` form,
+/// so an already annotated input can contain declarations for the fields this
+/// run is about to emit. Remove every exact emitted-field key first, including
+/// fields whose new manifest intentionally has no description, then append the
+/// current descriptions and provenance exactly once.
+fn merge_annotation_header_lines(
+    existing: Vec<String>,
+    plugin_field_names: &[String],
+    plugin_field_descriptions: &[(String, String)],
+    provenance: Vec<String>,
+) -> Vec<String> {
+    let emitted_fields: HashSet<&str> = plugin_field_names.iter().map(String::as_str).collect();
+    let mut lines: Vec<String> = existing
+        .into_iter()
+        .filter(|line| {
+            if is_stale_provenance_line(line) {
+                return false;
+            }
+            let Some((key, _)) = line
+                .strip_prefix("##")
+                .and_then(|line| line.split_once('='))
+            else {
+                return true;
+            };
+            !emitted_fields.contains(key)
+        })
+        .collect();
+    lines.extend(
+        plugin_field_descriptions
+            .iter()
+            .map(|(field, description)| format!("##{field}={description}")),
+    );
+    lines.extend(provenance);
+    lines
+}
+
 fn provenance_header_lines(
     input_vcf: &str,
     cache_source: &str,
@@ -1472,28 +1511,38 @@ pub async fn annotate_to_vcf(
     if let Some(raw_json) = write_metadata.get(VCF_HEADER_RAW_LINES_KEY)
         && let Ok(existing) = serde_json::from_str::<Vec<String>>(raw_json)
     {
-        let mut lines: Vec<String> = existing
-            .into_iter()
-            .filter(|line| !is_stale_provenance_line(line))
-            .collect();
         // Ensembl VEP writes one `##<FIELD>=<description>` line per plugin field
         // (from the plugin's `get_header_info()`), ahead of its provenance.
         #[cfg(feature = "parquet-cache")]
-        if let Some(root) = &config.plugin_cache_root {
-            for (field, description) in
-                crate::plugin_cache::registry::PluginRegistry::field_descriptions(root)
-            {
-                lines.push(format!("##{field}={description}"));
-            }
-        }
-        lines.extend(provenance_header_lines(
-            input_vcf,
-            cache_source,
-            backend,
-            output_vcf,
-            config,
-            cache_source_type,
-        ));
+        let (plugin_field_names, plugin_field_descriptions) = config
+            .plugin_cache_root
+            .as_ref()
+            .map(|root| {
+                (
+                    crate::plugin_cache::registry::PluginRegistry::field_names(root),
+                    crate::plugin_cache::registry::PluginRegistry::field_descriptions(root),
+                )
+            })
+            .unwrap_or_default();
+        #[cfg(not(feature = "parquet-cache"))]
+        let (plugin_field_names, plugin_field_descriptions): (
+            Vec<String>,
+            Vec<(String, String)>,
+        ) = Default::default();
+
+        let lines = merge_annotation_header_lines(
+            existing,
+            &plugin_field_names,
+            &plugin_field_descriptions,
+            provenance_header_lines(
+                input_vcf,
+                cache_source,
+                backend,
+                output_vcf,
+                config,
+                cache_source_type,
+            ),
+        );
         if let Ok(json) = serde_json::to_string(&lines) {
             write_metadata.insert(VCF_HEADER_RAW_LINES_KEY.to_string(), json);
         }
@@ -2183,6 +2232,57 @@ mod tests {
         ] {
             assert!(!is_stale_provenance_line(line), "{line}");
         }
+    }
+
+    #[test]
+    fn plugin_header_merge_replaces_stale_field_lines_exactly_once() {
+        let existing = vec![
+            "##fileformat=VCFv4.2".to_string(),
+            "##CADD_RAW=stale description".to_string(),
+            "##CADD_RAW=duplicate stale description".to_string(),
+            "##NO_DESCRIPTION=stale description".to_string(),
+            "##CADD_RAW_EXTRA=unrelated prefix match".to_string(),
+            "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">".to_string(),
+            "##VEP=stale provenance".to_string(),
+        ];
+        let fields = vec![
+            "CADD_RAW".to_string(),
+            "CADD_PHRED".to_string(),
+            "NO_DESCRIPTION".to_string(),
+        ];
+        let descriptions = vec![
+            ("CADD_PHRED".to_string(), "Current PHRED".to_string()),
+            ("CADD_RAW".to_string(), "Current raw score".to_string()),
+        ];
+        let provenance = vec!["##datafusion-bio-function-vep=current".to_string()];
+
+        let merged =
+            merge_annotation_header_lines(existing, &fields, &descriptions, provenance.clone());
+
+        assert_eq!(
+            merged,
+            vec![
+                "##fileformat=VCFv4.2",
+                "##CADD_RAW_EXTRA=unrelated prefix match",
+                "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">",
+                "##CADD_PHRED=Current PHRED",
+                "##CADD_RAW=Current raw score",
+                provenance[0].as_str(),
+            ]
+        );
+        assert_eq!(
+            merged
+                .iter()
+                .filter(|line| line.starts_with("##CADD_RAW="))
+                .count(),
+            1
+        );
+        assert!(
+            !merged
+                .iter()
+                .any(|line| line.starts_with("##NO_DESCRIPTION=")),
+            "a current field without a description must not retain a stale one"
+        );
     }
 
     fn provenance_with_cache(config: &AnnotateVcfConfig, cache: &str) -> Vec<String> {

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -739,10 +739,15 @@ fn escape_header_attribute(value: &str) -> String {
 }
 
 /// Renders an unstructured VCF meta-information value on exactly one physical
-/// line. Unlike [`escape_header_attribute`], quotes and backslashes have no
-/// delimiter meaning here and are preserved; only control characters need an
-/// escaped representation (or, for other controls, removal).
+/// line. A value beginning with `<` is quoted so it cannot be confused with an
+/// arbitrary structured `##KEY=<...>` declaration during re-annotation; quotes
+/// and backslashes are escaped in that quoted form. Otherwise they have no
+/// delimiter meaning and are preserved. Control characters are escaped (or,
+/// for other controls, removed) in both forms.
 fn sanitize_unstructured_header_value(value: &str) -> String {
+    if value.starts_with('<') {
+        return format!("\"{}\"", escape_header_attribute(value));
+    }
     let mut out = String::with_capacity(value.len());
     for c in value.chars() {
         match c {
@@ -777,8 +782,9 @@ fn is_stale_provenance_line(line: &str) -> bool {
 ///
 /// Plugin field headers use the non-structured `##<FIELD>=<description>` form,
 /// so an already annotated input can contain declarations for the fields this
-/// run is about to emit. Remove every exact emitted-field key first, including
-/// fields whose new manifest intentionally has no description, then append the
+/// run is about to emit. Remove every exact unstructured emitted-field key
+/// first, including fields whose new manifest intentionally has no description,
+/// while preserving arbitrary structured source declarations; then append the
 /// current descriptions and provenance exactly once.
 fn merge_annotation_header_lines(
     existing: Vec<String>,
@@ -793,18 +799,17 @@ fn merge_annotation_header_lines(
             if is_stale_provenance_line(line) {
                 return false;
             }
-            let Some((key, _)) = line
+            let Some((key, value)) = line
                 .strip_prefix("##")
                 .and_then(|line| line.split_once('='))
             else {
                 return true;
             };
-            // Reserved VCF meta-information keys cannot be plugin CSQ field
-            // names (validated in both source and built-cache manifests), so
-            // every exact emitted-field key is plugin-owned. This remains true
-            // when a legitimate free-text description happens to begin with
-            // `<`, which is not by itself proof of a structured declaration.
-            !emitted_fields.contains(key)
+            // VCF permits arbitrary structured meta-information keys, not just
+            // INFO/FORMAT/etc. Preserve every structured declaration. Plugin
+            // descriptions that naturally begin with `<` are emitted quoted
+            // above, so a plugin-owned line can never enter this branch.
+            value.starts_with('<') || !emitted_fields.contains(key)
         })
         .collect();
     lines.extend(
@@ -2271,8 +2276,10 @@ mod tests {
             "##NO_DESCRIPTION=stale description".to_string(),
             "##CADD_RAW_EXTRA=unrelated prefix match".to_string(),
             "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">".to_string(),
+            "##INFO=stale plugin description".to_string(),
             "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">".to_string(),
-            "##ANGLE=<stale angle-leading description>".to_string(),
+            "##ANGLE=<ID=calibration,Description=\"custom structured metadata\">".to_string(),
+            "##ANGLE=\"<stale angle-leading description>\"".to_string(),
             "##VEP=stale provenance".to_string(),
         ];
         let fields = vec![
@@ -2280,6 +2287,7 @@ mod tests {
             "CADD_PHRED".to_string(),
             "NO_DESCRIPTION".to_string(),
             "ANGLE".to_string(),
+            "INFO".to_string(),
         ];
         let descriptions = vec![
             (
@@ -2291,6 +2299,7 @@ mod tests {
                 "ANGLE".to_string(),
                 "<current angle-leading description>".to_string(),
             ),
+            ("INFO".to_string(), "Current plugin INFO".to_string()),
         ];
         let provenance = vec!["##datafusion-bio-function-vep=current".to_string()];
 
@@ -2304,11 +2313,23 @@ mod tests {
                 "##CADD_RAW_EXTRA=unrelated prefix match",
                 "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">",
                 "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">",
+                "##ANGLE=<ID=calibration,Description=\"custom structured metadata\">",
                 "##CADD_PHRED=Current PHRED\\nsecond line\\r\\ttail",
                 "##CADD_RAW=Current raw score",
-                "##ANGLE=<current angle-leading description>",
+                "##ANGLE=\"<current angle-leading description>\"",
+                "##INFO=Current plugin INFO",
                 provenance[0].as_str(),
             ]
+        );
+        assert_eq!(
+            merge_annotation_header_lines(
+                merged.clone(),
+                &fields,
+                &descriptions,
+                provenance.clone(),
+            ),
+            merged,
+            "re-annotation must neither lose structured metadata nor accumulate plugin headers"
         );
         assert!(
             merged
@@ -2328,6 +2349,20 @@ mod tests {
                 .any(|line| line.starts_with("##NO_DESCRIPTION=")),
             "a current field without a description must not retain a stale one"
         );
+    }
+
+    #[test]
+    fn quoted_angle_leading_plugin_description_is_valid_vcf_metadata() {
+        let rendered = sanitize_unstructured_header_value("<threshold \"strict\" \\ calibrated>");
+        assert_eq!(rendered, "\"<threshold \\\"strict\\\" \\\\ calibrated>\"");
+
+        let input = format!(
+            "##fileformat=VCFv4.2\n##ANGLE={rendered}\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        );
+        let mut reader = noodles_vcf::io::reader::Builder::default()
+            .build_from_reader(std::io::Cursor::new(input.into_bytes()))
+            .unwrap();
+        reader.read_header().unwrap();
     }
 
     fn provenance_with_cache(config: &AnnotateVcfConfig, cache: &str) -> Vec<String> {

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -2276,7 +2276,6 @@ mod tests {
             "##NO_DESCRIPTION=stale description".to_string(),
             "##CADD_RAW_EXTRA=unrelated prefix match".to_string(),
             "##INFO=<ID=CADD_RAW,Number=1,Type=String,Description=\"ordinary INFO\">".to_string(),
-            "##INFO=stale plugin description".to_string(),
             "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">".to_string(),
             "##ANGLE=<ID=calibration,Description=\"custom structured metadata\">".to_string(),
             "##ANGLE=\"<stale angle-leading description>\"".to_string(),
@@ -2287,7 +2286,6 @@ mod tests {
             "CADD_PHRED".to_string(),
             "NO_DESCRIPTION".to_string(),
             "ANGLE".to_string(),
-            "INFO".to_string(),
         ];
         let descriptions = vec![
             (
@@ -2299,7 +2297,6 @@ mod tests {
                 "ANGLE".to_string(),
                 "<current angle-leading description>".to_string(),
             ),
-            ("INFO".to_string(), "Current plugin INFO".to_string()),
         ];
         let provenance = vec!["##datafusion-bio-function-vep=current".to_string()];
 
@@ -2317,7 +2314,6 @@ mod tests {
                 "##CADD_PHRED=Current PHRED\\nsecond line\\r\\ttail",
                 "##CADD_RAW=Current raw score",
                 "##ANGLE=\"<current angle-leading description>\"",
-                "##INFO=Current plugin INFO",
                 provenance[0].as_str(),
             ]
         );

--- a/datafusion/bio-function-vep/src/vcf_sink.rs
+++ b/datafusion/bio-function-vep/src/vcf_sink.rs
@@ -1476,6 +1476,16 @@ pub async fn annotate_to_vcf(
             .into_iter()
             .filter(|line| !is_stale_provenance_line(line))
             .collect();
+        // Ensembl VEP writes one `##<FIELD>=<description>` line per plugin field
+        // (from the plugin's `get_header_info()`), ahead of its provenance.
+        #[cfg(feature = "parquet-cache")]
+        if let Some(root) = &config.plugin_cache_root {
+            for (field, description) in
+                crate::plugin_cache::registry::PluginRegistry::field_descriptions(root)
+            {
+                lines.push(format!("##{field}={description}"));
+            }
+        }
         lines.extend(provenance_header_lines(
             input_vcf,
             cache_source,

--- a/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
+++ b/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
@@ -21,8 +21,9 @@ use datafusion_bio_function_vep::plugin_cache::source_manifest::{
 use datafusion_bio_function_vep::plugin_cache::template::build_attr_namespace;
 
 /// Namespace for a `C/G` variant with the given amino-acid change (rest empty).
-fn ns_aa<'a>(amino_acids: &'a str, protein_pos: &'a str) -> [Option<&'a str>; 16] {
+fn ns_aa<'a>(amino_acids: &'a str, protein_pos: &'a str) -> [Option<&'a str>; 17] {
     build_attr_namespace(
+        "",
         "",
         "",
         "",

--- a/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
+++ b/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
@@ -54,11 +54,13 @@ fn build_alphamissense_shard(cache_root: &std::path::Path) {
             column: "am_pathogenicity".into(),
             csq_field: "am_pathogenicity".into(),
             ty: ValueType::Float32,
+            description: None,
         },
         ValueColumn {
             column: "am_class".into(),
             csq_field: "am_class".into(),
             ty: ValueType::Utf8,
+            description: None,
         },
     ];
     let schema = plugin_output_schema(&matches, &vals);
@@ -99,11 +101,13 @@ fn build_alphamissense_shard(cache_root: &std::path::Path) {
                 column: "am_pathogenicity".into(),
                 csq_field: "am_pathogenicity".into(),
                 ty: "Float32".into(),
+                description: None,
             },
             ValueColumnRecord {
                 column: "am_class".into(),
                 csq_field: "am_class".into(),
                 ty: "Utf8".into(),
+                description: None,
             },
         ],
         chroms: vec![ChromEntry {
@@ -114,6 +118,9 @@ fn build_alphamissense_shard(cache_root: &std::path::Path) {
             cold: 1,
         }],
         cache_source_version: None,
+        allele_match: Default::default(),
+        csq_rank: 0,
+        field_order: Default::default(),
     };
     manifest.write(&plugin_dir).unwrap();
 }
@@ -135,24 +142,24 @@ async fn plugin_csq_gates_per_transcript() {
 
     // Transcript line 1: missense C17W (Amino_acids "C/W", Protein_position "17").
     let ns_missense = ns_aa("C/W", "17");
-    let missense = slices.probe_all(22893742, "C/G", &ns_missense);
+    let missense = slices.probe_all(22893742, "C/G", None, &ns_missense);
     assert_eq!(field_suffix(&missense), "|0.4833|ambiguous");
 
     // Transcript line 2: intron (no amino-acid change) → gate → empty fields.
     let ns_intron = ns_aa("", "");
-    let intron = slices.probe_all(22893742, "C/G", &ns_intron);
+    let intron = slices.probe_all(22893742, "C/G", None, &ns_intron);
     assert_eq!(field_suffix(&intron), empty_suffix(n));
     assert_eq!(field_suffix(&intron), "||");
 
     // A different protein change at the same position (wrong isoform) → miss.
     let ns_wrong = ns_aa("C/Y", "17");
     assert_eq!(
-        field_suffix(&slices.probe_all(22893742, "C/G", &ns_wrong)),
+        field_suffix(&slices.probe_all(22893742, "C/G", None, &ns_wrong)),
         "||"
     );
 
     // A variant with no shard row (different position) → empty fields.
-    let none_here = slices.probe_all(99999999, "A/G", &ns_missense);
+    let none_here = slices.probe_all(99999999, "A/G", None, &ns_missense);
     assert_eq!(field_suffix(&none_here), "||");
 }
 
@@ -174,6 +181,7 @@ async fn indel_probe_uses_normalized_start() {
         column: "score".into(),
         csq_field: "SCORE".into(),
         ty: ValueType::Float32,
+        description: None,
     }];
     let schema = plugin_output_schema(&matches, &vals);
     // One row at the NORMALIZED coordinates: start 101, allele "-/TG".
@@ -207,6 +215,7 @@ async fn indel_probe_uses_normalized_start() {
             column: "score".into(),
             csq_field: "SCORE".into(),
             ty: "Float32".into(),
+            description: None,
         }],
         chroms: vec![ChromEntry {
             chrom: "chr1".into(),
@@ -216,6 +225,9 @@ async fn indel_probe_uses_normalized_start() {
             cold: 1,
         }],
         cache_source_version: None,
+        allele_match: Default::default(),
+        csq_rank: 0,
+        field_order: Default::default(),
     };
     manifest.write(&plugin_dir).unwrap();
 
@@ -223,11 +235,14 @@ async fn indel_probe_uses_normalized_start() {
 
     // Normalized start (101) hits.
     let hit = reg.take_buffer_all(&[101]).await.unwrap();
-    assert_eq!(field_suffix(&hit.probe_all(101, "-/TG", &[])), "|0.75");
+    assert_eq!(
+        field_suffix(&hit.probe_all(101, "-/TG", None, &[])),
+        "|0.75"
+    );
     // Raw VCF POS (100) misses — this is what the pre-fix code used.
     let miss = reg.take_buffer_all(&[100]).await.unwrap();
     assert_eq!(
-        field_suffix(&miss.probe_all(100, "-/TG", &[])),
+        field_suffix(&miss.probe_all(100, "-/TG", None, &[])),
         empty_suffix(1)
     );
 }

--- a/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
+++ b/datafusion/bio-function-vep/tests/plugin_csq_emission.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use datafusion::arrow::array::{Float32Array, Int8Array, StringArray, UInt32Array};
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion_bio_function_vep::plugin_cache::cache_manifest::{
-    CacheManifest, ChromEntry, MatchColumnRecord, ValueColumnRecord,
+    AlleleMatch, CacheManifest, ChromEntry, FieldOrder, MatchColumnRecord, ValueColumnRecord,
 };
 use datafusion_bio_function_vep::plugin_cache::csq::{empty_suffix, field_suffix};
 use datafusion_bio_function_vep::plugin_cache::registry::PluginRegistry;
@@ -244,5 +244,109 @@ async fn indel_probe_uses_normalized_start() {
     assert_eq!(
         field_suffix(&miss.probe_all(100, "-/TG", None, &[])),
         empty_suffix(1)
+    );
+}
+
+/// Exercise both non-default manifest controls through the full Parquet lookup
+/// path. The primary unminimised key must miss, the minimised fallback must hit,
+/// and values must be permuted *after* projection so alphabetical CSQ field
+/// names remain paired with their physical shard values.
+#[tokio::test(flavor = "multi_thread")]
+async fn minimised_fallback_and_alphabetical_fields_preserve_name_value_pairs() {
+    let dir = tempfile::tempdir().unwrap();
+    let cache_root = dir.path();
+    let plugin_dir = cache_root.join("plugin").join("demo");
+    std::fs::create_dir_all(&plugin_dir).unwrap();
+
+    let vals = vec![
+        ValueColumn {
+            column: "z_value".into(),
+            csq_field: "Z_FIELD".into(),
+            ty: ValueType::Utf8,
+            description: Some("Z description".into()),
+        },
+        ValueColumn {
+            column: "a_value".into(),
+            csq_field: "A_FIELD".into(),
+            ty: ValueType::Utf8,
+            description: Some("A description".into()),
+        },
+    ];
+    let schema = plugin_output_schema(&[], &vals);
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["1"])),
+            Arc::new(UInt32Array::from(vec![101u32])),
+            Arc::new(UInt32Array::from(vec![101u32])),
+            Arc::new(StringArray::from(vec!["A/G"])),
+            Arc::new(StringArray::from(vec!["z-value"])),
+            Arc::new(StringArray::from(vec!["a-value"])),
+            Arc::new(Int8Array::from(vec![1i8])),
+        ],
+    )
+    .unwrap();
+    let mut writer = PluginShardWriter::create(&plugin_dir.join("chr1.parquet"), schema).unwrap();
+    writer.write(&batch).unwrap();
+    writer.finish().unwrap();
+
+    let manifest = CacheManifest {
+        plugin_name: "demo".into(),
+        source_manifest: "demo.source.toml".into(),
+        key_columns: vec![
+            "chrom".into(),
+            "start".into(),
+            "end".into(),
+            "allele_string".into(),
+        ],
+        match_columns: vec![],
+        value_columns: vec![
+            ValueColumnRecord {
+                column: "z_value".into(),
+                csq_field: "Z_FIELD".into(),
+                ty: "Utf8".into(),
+                description: Some("Z description".into()),
+            },
+            ValueColumnRecord {
+                column: "a_value".into(),
+                csq_field: "A_FIELD".into(),
+                ty: "Utf8".into(),
+                description: Some("A description".into()),
+            },
+        ],
+        chroms: vec![ChromEntry {
+            chrom: "chr1".into(),
+            file: "chr1.parquet".into(),
+            rows: 1,
+            warm: 0,
+            cold: 1,
+        }],
+        cache_source_version: None,
+        allele_match: AlleleMatch::Minimised,
+        csq_rank: 0,
+        field_order: FieldOrder::Alphabetical,
+    };
+    manifest.write(&plugin_dir).unwrap();
+
+    let registry = PluginRegistry::open(cache_root, "1").await.unwrap();
+    assert_eq!(registry.csq_fields(), vec!["A_FIELD", "Z_FIELD"]);
+    assert_eq!(
+        PluginRegistry::field_descriptions(cache_root),
+        vec![
+            ("A_FIELD".to_string(), "A description".to_string()),
+            ("Z_FIELD".to_string(), "Z description".to_string()),
+        ]
+    );
+
+    let slices = registry.take_buffer_all(&[101]).await.unwrap();
+    assert_eq!(
+        field_suffix(&slices.probe_all(100, "AA/GA", None, &[])),
+        "||",
+        "the unreduced primary key must miss"
+    );
+    assert_eq!(
+        field_suffix(&slices.probe_all(100, "AA/GA", Some((101, "A/G")), &[])),
+        "|a-value|z-value",
+        "the minimised fallback must hit and preserve alphabetical name/value pairing"
     );
 }

--- a/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md
+++ b/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md
@@ -1,24 +1,46 @@
-# CADD tier-join reservation leak — deep-debug handover (2026-08-24)
+# CADD tier-join reservation leak — RESOLVED (2026-08-25)
 
-`build_plugin_chrom` cannot build CADD chr21. The tier join reserves **exactly
-whatever memory pool it is given** — 8.02 GB at an 8 GiB pool, 20.00 GB at
-20 GiB — to collect a build side that is **~180 MB**, while process RSS stays
-flat at 16.9 GB. The memory is reserved but never allocated, so no pool size
-works. Something calls `MemoryReservation::try_grow` without a matching
-`shrink`; it has not been located.
+> **Status: fixed in `92f55f9`.** All 5 plugins build chr21 and validate.
+> CADD: 121,809,062 rows in 2.1 min, `HashJoinInput` peak **0.70 GB** (was
+> 8.02 GB at an 8 GiB pool and 20.00 GB at 20 GiB). Kept as a record of the
+> mechanism and of what was ruled out — §5 in particular is worth reading
+> before touching this join again.
 
-Everything else works: **4 of 5 plugins build chr21 clean** (clinvar,
-alphamissense, spliceai, dbnsfp).
+## 0. What it was, and the piece that was missing
 
----
+The tier join reserved **exactly whatever memory pool it was given** to collect
+a build side of **~180 MB**, while RSS stayed flat — memory reserved but never
+allocated, so no pool size helped.
 
-## 0. The one test that kills a hypothesis
+The cause was `get_record_batch_memory_size` charging a *shared* Arrow buffer
+once per batch that references it (it de-duplicates only *within* one batch).
+Two layers of sharing had to be removed, and only finding both fixes it:
 
-The collected side is **~180 MB** (10.8M rows x 4 narrow columns, 11 batches).
-The reservation reaches **20 GB**. Any explanation must account for a **~110x
-gap that never appears in RSS**. Three plausible theories already died on that
-test — see §5. Measure before theorising; this bug has been unusually good at
-producing convincing wrong answers.
+1. **`GROUP BY` output batches share buffers** (2d6c01d). Measured 31.7x
+   over-count — see §4. Fixed by materializing the probe with a `concat` per
+   batch. This dropped the increment from 592.7 MB to 18.2 MB but did **not**
+   fix the build.
+2. **The MemTable scan re-splits oversized batches** (92f55f9). DataFusion 53
+   wraps a MemTable in `BatchSplitStream`, which slices any parent larger than
+   the execution batch size into **zero-copy children**. The materialized probe
+   was chunked at 1M rows, so its 11 owned parents became ~1300 slices that all
+   shared 11 buffers, and the over-count returned — that is precisely what the
+   18.2 MB increment was: one parent's buffer, charged per 8192-row slice.
+   Fixed by chunking to `ctx.copied_config().batch_size()` so the scan has
+   nothing left to split, plus forcing a real copy in
+   `concat_probe_parts_owned` (Arrow's single-input `concat_batches` is
+   zero-copy and would otherwise keep the sharing).
+
+The lesson worth keeping: **an over-count that shrinks but does not vanish means
+a second sharing layer, not a partial fix.** The 18.2 MB figure was measured
+and recorded a full round before anyone recognised it as "one parent per
+execution-sized slice".
+
+## 0b. The test that killed hypotheses
+
+Any explanation had to account for a large reservation/RSS gap. Three plausible
+theories died on it before the real one survived — see §5. Measure before
+theorising; this bug was unusually good at producing convincing wrong answers.
 
 ---
 
@@ -186,7 +208,7 @@ sharing.
 | It is a scale problem | SpliceAI retries at 31.7M rows and succeeds; dbNSFP fails at 836k |
 | A bigger pool fixes it | 2 / 8 / 20 GiB all fail; the reservation grows to match the pool exactly |
 | `Utf8View` width is the cause | Disabling view types halved the increment, pattern unchanged |
-| `GROUP BY` buffer sharing is the whole cause | Fixed in 2d6c01d; increment fell to 18.2 MB but the leak persists |
+| `GROUP BY` buffer sharing is the whole cause | Fixed in 2d6c01d; increment fell to 18.2 MB but the leak persisted — it was one of **two** sharing layers (§0) |
 | The semi-join (b561629) is the consumer | `HashJoinInput#0` is 0.95 GB and **stable** across pool sizes |
 
 ---
@@ -227,13 +249,17 @@ break on shifted-ness (unshifted first). See `vepyr-plugins` PR #4.
 **chr21, built and validated** (`(tier, start)` ascending per shard; SpliceAI's
 `assume_unique` checked exhaustively over all 31.7M keys):
 
-| plugin | rows | shard |
-|---|---:|---:|
-| clinvar | 49,937 | 1 MB |
-| alphamissense | 698,535 | 6 MB |
-| spliceai | 31,683,675 | 238 MB |
-| dbnsfp | 836,391 | — |
-| **cadd** | — | **blocked** |
+| plugin | rows | shard | notes |
+|---|---:|---:|---|
+| clinvar | 49,937 | 1 MB | |
+| alphamissense | 698,535 | 6 MB | |
+| spliceai | 31,683,675 | 238 MB | `assume_unique` exhaustively verified |
+| dbnsfp | 836,391 | 41 MB | |
+| cadd | 121,809,062 | 1040 MB | `assume_unique` exhaustively verified over all 121.8M keys |
+
+CADD chr21 post-fix: 124.8 s total (16.1 s read+normalize+dedup, 105.1 s
+tier-join+write including the sorted retry), peak RSS 17.0 GB. Reservation
+peaks: `ExternalSorter` 7.29 GB (real, spillable work), `HashJoinInput` 0.70 GB.
 
 Full-genome runs have not been attempted. `notebooks/build_plugin_caches.ipynb`
 in the vepyr branch drives the whole matrix; note it still downloads sources

--- a/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md
+++ b/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md
@@ -1,10 +1,13 @@
 # CADD tier-join reservation leak — RESOLVED (2026-08-25)
 
-> **Status: fixed in `92f55f9`.** All 5 plugins build chr21 and validate.
-> CADD: 121,809,062 rows in 2.1 min, `HashJoinInput` peak **0.70 GB** (was
-> 8.02 GB at an 8 GiB pool and 20.00 GB at 20 GiB). Kept as a record of the
-> mechanism and of what was ruled out — §5 in particular is worth reading
-> before touching this join again.
+> **Status: original leak fixed in `92f55f9`; follow-up production
+> implementation completed in `490cb8f` and `80bb9b8`.** All 5 plugins build
+> and validate on chr21, and the final adaptive parallel path builds all 5 on
+> chr1 at both 4 and 8 target
+> partitions. CADD chr21: 121,809,062 rows in 2.1 min, `HashJoinInput` peak
+> **0.70 GB** (was 8.02 GB at an 8 GiB pool and 20.00 GB at 20 GiB). Kept as a
+> record of the mechanism, the ruled-out theories, and the follow-up production
+> fixes; see §§8–10 for the current implementation and validation.
 
 ## 0. What it was, and the piece that was missing
 
@@ -48,8 +51,9 @@ theorising; this bug was unusually good at producing convincing wrong answers.
 
 | Thing | Path / ref |
 |---|---|
-| Engine worktree (the bug lives here) | `datafusion-bio-functions`, branch `plugins-fixes`, PR #217, HEAD `2d6c01d` |
+| Engine worktree | `datafusion-bio-functions`, branch `plugins-fixes`, PR #217, validated HEAD `80bb9b8` |
 | Tier join | `datafusion/bio-function-vep/src/plugin_cache/join.rs` |
+| Adaptive selector | `datafusion/bio-function-vep/src/plugin_cache/join_strategy.rs` |
 | Build driver + retry | `datafusion/bio-function-vep/src/plugin_cache/build.rs` |
 | Memory tracer | `datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs` |
 | vepyr (PyO3 consumer, pins the engine by rev) | `vepyr`, branch `plugin-cache-build-validation`, PR #49 |
@@ -93,7 +97,7 @@ tabix http://localhost:18080/cadd/gnomad.genomes.r4.0.indel.tsv.gz 21 > $S/cadd_
 
 ~3.5 GB + 58 MB, ~60 s total.
 
-### 2.3 Build (fails)
+### 2.3 Historical pre-fix reproduction (fails before `92f55f9`)
 
 ```bash
 cd <vepyr worktree>
@@ -122,7 +126,7 @@ VEPYR_EXPLAIN_TIER_JOIN=1             # physical plan (join.rs)
 
 ---
 
-## 3. Established, with evidence
+## 3. Original incident findings, with evidence
 
 **The retry path is where it fails, and the retry is not the cause.**
 `tiered_stream` and `tiered_stream_sorted` are the same `tiered_stream_impl`
@@ -213,7 +217,12 @@ sharing.
 
 ---
 
-## 6. Where to look next
+## 6. Historical investigation queue (closed by `92f55f9`)
+
+This was the next-step list while the incident was open. The
+`BatchSplitStream` zero-copy re-slicing described in §0 answered it; these are
+retained to show which paths were still untested at the handover point, not as
+current work items.
 
 `collect_left_input` (`datafusion-physical-plan-53.0.0/src/joins/hash_join/exec.rs`)
 grows the reservation once per build batch (`:1874`) and once for the hash map
@@ -244,7 +253,7 @@ break on shifted-ness (unshifted first). See `vepyr-plugins` PR #4.
 
 ---
 
-## 7. Working state
+## 7. Post-leak-fix chr21 state
 
 **chr21, built and validated** (`(tier, start)` ascending per shard; SpliceAI's
 `assume_unique` checked exhaustively over all 31.7M keys):
@@ -313,3 +322,128 @@ All five new shards match the previous p4 shards on row count plus both XOR and
 sum aggregates of DuckDB whole-row hashes. Warm/cold manifest counts also match
 exactly. Logs and outputs are under
 `/Users/mwiewior/workspace/data_vepyr/plugin_partition_bench_direct_p4`.
+
+Implemented in `80bb9b8` on top of the adaptive parallel work in `490cb8f`.
+
+---
+
+## 9. Implemented production architecture (`490cb8f`)
+
+The follow-up work did not replace DataFusion's join implementations. It added
+the small policy and data-layout layer that DataFusion 53 does not provide:
+
+1. **Ordered parallel source ingestion.** File-scan repartitioning remains
+   enabled. All physical source partitions are collected concurrently, then
+   replayed in partition/range order before keep-first dedup. This preserves
+   VEP's first-in-file duplicate semantics without forcing parsing through one
+   stream. Providers that cannot physically split an input still expose one
+   partition naturally; there is no caller-side `target_partitions=1`
+   restriction.
+2. **Partitioned owned MemTables.** Execution-sized, independently owned Arrow
+   batches are distributed greedily by bytes across the available partitions.
+   This prevents both the original shared-buffer accounting problem and a
+   single MemTable scan bottleneck.
+3. **Pool-aware join selection.** For both the variation-filter join and the
+   final tier join, the code first asks DataFusion to optimize a CollectLeft
+   HashJoin candidate. It inspects the *actual physical build child* selected
+   by DataFusion and reads its row and byte statistics. The estimate includes
+   input batches, DataFusion's real hash-map structure, and the outer-join
+   visited bitmap, then compares that total with currently available bytes in
+   the finite pool.
+4. **Conservative automatic fallback.** A fitting estimate executes the exact
+   HashJoin plan. Missing statistics, an unknown pool limit, an unexpected hash
+   mode, or an estimate larger than the available pool causes replanning with
+   only `prefer_hash_join=false`; DataFusion supplies the repartitioning,
+   sorting, spilling, and SortMergeJoin. If an estimated-safe HashJoin is still
+   rejected at runtime, retry occurs only when the root error is
+   `ResourcesExhausted` and the tracing pool attributes it to `HashJoinInput`.
+5. **Parallel-safe output contract.** Parallel joins do not preserve useful
+   global order, so the final query explicitly requests `ORDER BY tier, start`.
+   Every emitted key is checked at the storage boundary before writing the
+   atomic temporary shard.
+
+The selector contains **no plugin names, chromosome names/sizes, row-count
+cutoffs, partition-count thresholds, or forced join algorithm**. Production
+uses DataFusion's runtime partition default with a two-worker minimum; the
+`VEPYR_PLUGIN_TARGET_PARTITIONS` override is retained for controlled tests and
+operator tuning. The memory pool remains configurable through
+`VEPYR_PLUGIN_RETRY_MEMORY_MIB` (the legacy name now covers the whole adaptive
+plan).
+
+Because each build already operates on one chromosome file, `chrom` was also
+removed from both physical join keys. It is a constant within the build and
+cannot improve selectivity. Removing it saves one string comparison and one
+column's key/hash/sort footprint per row, though it is a secondary memory win,
+not the root-cause fix.
+
+The resulting current flow is:
+
+```text
+parallel ordered source scan -> normalize -> ordered keep-first dedup
+    -> narrow (start, allele_string) key MemTable
+    -> adaptive LEFT SEMI JOIN against variation
+    -> GROUP BY matched variation keys with MIN(tier)
+    -> owned execution-sized variation-probe MemTable
+    -> adaptive LEFT tier join on (start, allele_string)
+    -> ORDER BY (tier, start)
+    -> checked single Parquet encode -> atomic rename
+```
+
+---
+
+## 10. Final chr1 validation and scaling result
+
+All measurements used a release build with `target-cpu=native` and the same
+8 GiB adaptive-plan pool. The p4 and p8 runs both completed for all plugins:
+
+| plugin | rows | p4 wall | p8 wall | p4 → p8 | probe / tier strategy |
+|---|---:|---:|---:|---:|---|
+| ClinVar | 401,099 | 4.08 s | 2.15 s | -47.3% | Hash / Hash |
+| AlphaMissense | 7,151,767 | 8.08 s | 6.72 s | -16.8% | Hash / Hash |
+| dbNSFP | 8,788,707 | 57.84 s | 53.42 s | -7.6% | Hash / Hash |
+| SpliceAI | 300,634,726 | 230.27 s | 175.09 s | -24.0% | SortMerge / Hash |
+| CADD | 699,768,898 | 221.89 s | 194.05 s | -12.5% | SortMerge / Hash |
+
+For SpliceAI and CADD's probe stage, DataFusion reports a row estimate but no
+projected byte estimate for the physical build child. The policy therefore
+selects SortMerge before execution; neither plugin pays for a doomed HashJoin
+attempt. Their materialized final tier probes have exact statistics and fit the
+pool, so DataFusion's selected final HashJoin is retained. At p8 the estimated
+final hash builds were about 0.86 GiB for SpliceAI and 2.89 GiB for CADD.
+
+The p8 shards match the validated p4 results on row count, warm/cold counts,
+and XOR plus sum aggregates of DuckDB whole-row hashes. Logs and outputs are
+under `/Users/mwiewior/workspace/data_vepyr/plugin_partition_bench_direct_p8`.
+
+### Why dbNSFP scales poorly
+
+dbNSFP is no longer join-bound. At p8, both adaptive decisions choose HashJoin;
+the probe estimate is about 0.39 GiB and the final tier build about 27 MiB. The
+two joins therefore complete without a fallback. Most time is spent parsing and
+materializing its roughly 37.7 GB, 505-column TSV source, followed by the one
+ordered final Parquet writer:
+
+| run | read + normalize + dedup | remaining tier join + sort + write | wall |
+|---|---:|---:|---:|
+| p4 | 44.2 s | 13.2 s | 57.84 s |
+| p8 | 39.2 s | 13.7 s | 53.42 s |
+
+Repeat p8 diagnostics varied from 43.1 to 44.7 s total when comparing normal
+dedup with a temporary `assume_unique` manifest. The absence of a meaningful
+`assume_unique` advantage, together with the tiny measured join builds, rules
+out dedup and adaptive join selection as the primary scaling limit. The wide
+delimited decode/materialization and final single ordered writer dominate;
+additional join partitions cannot make those serial or bandwidth-bound parts
+scale linearly.
+
+### Verification at `80bb9b8`
+
+- 942 library tests passed, 1 ignored.
+- 6 plugin-cache integration tests passed.
+- `cargo fmt` and Clippy passed.
+- chr1 p4 and p8: all five plugins completed and produced logically identical
+  shards by row count, warm/cold counts, and two independent whole-row hash
+  aggregates.
+
+Full-genome validation is still outstanding; the evidence above covers chr21
+for the original reservation fix and chr1 for the final p4/p8 production path.

--- a/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md
+++ b/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md
@@ -264,3 +264,52 @@ peaks: `ExternalSorter` 7.29 GB (real, spillable work), `HashJoinInput` 0.70 GB.
 Full-genome runs have not been attempted. `notebooks/build_plugin_caches.ipynb`
 in the vepyr branch drives the whole matrix; note it still downloads sources
 rather than using the `rclone serve http` trick in §2.1, which is worth porting.
+
+---
+
+## 8. 2026-08-25 follow-up: remove the false HashJoin input and final merge
+
+Two independent costs remained in the chr1 partition matrix:
+
+1. The probe filter used an inner join against
+   `SELECT DISTINCT start, allele_string FROM plugin`. The distinct aggregate
+   emitted shared-buffer batches immediately below `HashJoinExec`, so its exact
+   0.25 GiB AlphaMissense estimate became a 7.9 GiB runtime reservation and an
+   inevitable Hash-to-SortMerge retry.
+2. The final `(tier, start)` shard was encoded as warm and cold temporary
+   Parquet files, then both files were decoded and encoded again into the final
+   shard. That serial tail cost about 129 seconds for SpliceAI and 142 seconds
+   for CADD at `target_partitions=4`.
+
+The production path now registers a narrow `(start, allele_string)` plugin-key
+MemTable and filters variation with a true `LEFT SEMI JOIN`. A semi join cannot
+fan out variation rows when plugin keys repeat, so the distinct aggregate is
+unnecessary. DataFusion still selects Hash or SortMerge from actual plan
+statistics; no plugin, chromosome, partition-count, or join-strategy threshold
+was added.
+
+The final query now uses `ORDER BY tier, start` and streams directly into one
+atomic `.build.tmp` shard. The storage-boundary check validates every emitted
+key lexicographically before the batch is written. This removes the two tier
+filters, two intermediate encodes, two intermediate decodes, and final
+re-encode.
+
+Release + `target-cpu=native`, chr1, `target_partitions=4`:
+
+| plugin | before | after | wall delta | RSS before → after |
+|---|---:|---:|---:|---:|
+| ClinVar | 4.26 s | 4.08 s | -4.2% | 1.98 → 1.95 GiB |
+| AlphaMissense | 15.35 s | 8.08 s | -47.4% | 5.71 → 3.01 GiB |
+| dbNSFP | 75.29 s | 57.84 s | -23.2% | 11.83 → 11.81 GiB |
+| SpliceAI | 357.38 s | 230.27 s | -35.6% | 31.75 → 27.09 GiB |
+| CADD | 382.34 s | 221.89 s | -42.0% | 29.12 → 28.90 GiB |
+
+AlphaMissense's probe HashJoin now reserves 0.23 GiB and completes on the first
+plan. dbNSFP likewise completes its first HashJoin at 0.39 GiB. SpliceAI and
+CADD report missing projected byte statistics and select SortMerge before
+execution, so neither wastes time on a doomed HashJoin.
+
+All five new shards match the previous p4 shards on row count plus both XOR and
+sum aggregates of DuckDB whole-row hashes. Warm/cold manifest counts also match
+exactly. Logs and outputs are under
+`/Users/mwiewior/workspace/data_vepyr/plugin_partition_bench_direct_p4`.

--- a/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak.md
+++ b/docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak.md
@@ -1,0 +1,240 @@
+# CADD tier-join reservation leak — deep-debug handover (2026-08-24)
+
+`build_plugin_chrom` cannot build CADD chr21. The tier join reserves **exactly
+whatever memory pool it is given** — 8.02 GB at an 8 GiB pool, 20.00 GB at
+20 GiB — to collect a build side that is **~180 MB**, while process RSS stays
+flat at 16.9 GB. The memory is reserved but never allocated, so no pool size
+works. Something calls `MemoryReservation::try_grow` without a matching
+`shrink`; it has not been located.
+
+Everything else works: **4 of 5 plugins build chr21 clean** (clinvar,
+alphamissense, spliceai, dbnsfp).
+
+---
+
+## 0. The one test that kills a hypothesis
+
+The collected side is **~180 MB** (10.8M rows x 4 narrow columns, 11 batches).
+The reservation reaches **20 GB**. Any explanation must account for a **~110x
+gap that never appears in RSS**. Three plausible theories already died on that
+test — see §5. Measure before theorising; this bug has been unusually good at
+producing convincing wrong answers.
+
+---
+
+## 1. Locations
+
+| Thing | Path / ref |
+|---|---|
+| Engine worktree (the bug lives here) | `datafusion-bio-functions`, branch `plugins-fixes`, PR #217, HEAD `2d6c01d` |
+| Tier join | `datafusion/bio-function-vep/src/plugin_cache/join.rs` |
+| Build driver + retry | `datafusion/bio-function-vep/src/plugin_cache/build.rs` |
+| Memory tracer | `datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs` |
+| vepyr (PyO3 consumer, pins the engine by rev) | `vepyr`, branch `plugin-cache-build-validation`, PR #49 |
+| Plugin manifests | `vepyr-plugins`, branch `fix/adding-a-plugin-sort-guidance`, PR #4 |
+| Repro scripts | `scripts/debug/` (this repo) |
+| Variation cache | `~/workspace/data_vepyr/cache/116_GRCh38_merged` |
+| Raw plugin sources | Google Drive folder `1ZT3g31I0LXepORF_dusy47AuXOnbRlZ_`, rclone remote `gdrive-mw` |
+
+`vepyr` pins the engine by git rev, so **every engine change needs a rev bump +
+`uv sync --reinstall-package vepyr`** (~3 min). Bare `cargo build` on vepyr fails
+to link (PyO3, no Python symbols) — that is expected, not a regression.
+
+---
+
+## 2. Reproduce
+
+### 2.1 Sources without downloading 168 GB
+
+All six source files are bgzip+tabix indexed. `rclone serve http` exposes Drive
+over local HTTP with range support, so tabix pulls one chromosome out of an
+87 GB file in ~50 s:
+
+```bash
+rclone serve http gdrive-mw: \
+  --drive-root-folder-id 1ZT3g31I0LXepORF_dusy47AuXOnbRlZ_ \
+  --addr localhost:18080 --read-only &
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:18080/   # expect 200
+```
+
+Contig naming differs per source and a wrong prefix yields a silently empty
+slice: **`chr`-prefixed for alphamissense, bare for the other four.** Verify with
+`tabix -l <url> | head -3`.
+
+### 2.2 Slice chr21
+
+```bash
+S=~/workspace/data_vepyr/plugin_input/_slices; mkdir -p $S
+tabix http://localhost:18080/cadd/whole_genome_SNVs.tsv.gz 21 > $S/cadd_chr21_snv.tsv
+tabix http://localhost:18080/cadd/gnomad.genomes.r4.0.indel.tsv.gz 21 > $S/cadd_chr21_indel.tsv
+```
+
+~3.5 GB + 58 MB, ~60 s total.
+
+### 2.3 Build (fails)
+
+```bash
+cd <vepyr worktree>
+VIRTUAL_ENV= RUST_LOG=info VEPYR_TRACE_MEMORY=1 VEPYR_EXPLAIN_TIER_JOIN=1 \
+  ./.venv/bin/python <engine>/scripts/debug/build_plugin_chrom.py cadd 21
+```
+
+Expected failure:
+
+```
+plugin_cache[cadd/21]: tier join did not preserve row order (121809062 plugin
+                       rows this chrom) -- retrying with an explicit sort
+Resources exhausted: Failed to allocate additional 18.2 MB for HashJoinInput
+with 8.0 GB already allocated - 1420.1 KB remain available for the total pool
+```
+
+`RUST_LOG=info` is required or the instrumentation prints nothing.
+
+### 2.4 Turn the dials
+
+```bash
+VEPYR_PLUGIN_RETRY_MEMORY_MIB=20480   # pool size; it will take exactly this much
+VEPYR_TRACE_MEMORY=1                  # per-reservation peaks (mem_trace.rs)
+VEPYR_EXPLAIN_TIER_JOIN=1             # physical plan (join.rs)
+```
+
+---
+
+## 3. Established, with evidence
+
+**The retry path is where it fails, and the retry is not the cause.**
+`tiered_stream` and `tiered_stream_sorted` are the same `tiered_stream_impl`
+differing only by `ORDER BY` (`join.rs:41-58`). The fast path
+(`build.rs`, `SessionContext::new_with_config`) uses the default **unbounded**
+pool; the retry (`new_with_config_rt`) is the only path with a bound. So the
+retry does not use more memory — it is the only path that counts.
+
+CADD reaches the retry legitimately: its two `[[source]]` parts are `UNION ALL`ed,
+so the join sees one sorted block after another and `assert_start_monotonic`
+trips. That is the guard working.
+
+**The collected side is the probe, and it is small.** Measured directly
+(`scripts/debug/measure_probe_size.py`):
+
+```
+variation rows:      14,574,753
+plugin rows (SNV):  120,265,857
+PROBE VIEW rows:     10,806,229   <- 4 narrow columns, ~180 MB
+```
+
+Plan after the 2d6c01d fix:
+
+```
+HashJoinExec: mode=CollectLeft, join_type=Right
+  <projection> -> DataSourceExec: partitions=1, partition_sizes=[11]   <- LEFT, COLLECTED (probe)
+  DataSourceExec: partitions=1, partition_sizes=[14870]                <- RIGHT (plugin)
+```
+
+`CollectLeft` collects the left input. 11 batches, ~180 MB.
+
+**The reservation tracks the ceiling, not the data.**
+
+| pool | `HashJoinInput#3` peak | peak RSS |
+|---:|---:|---:|
+| 8 GiB | 8.02 GB | 16.9 GB |
+| 20 GiB | **20.00 GB** (exactly the pool) | 16.9 GB |
+
+Reserved memory exceeds RSS, so it is not backed by allocation.
+
+**Only CADD is affected, because only CADD's plan swaps.** `join_type=Right`
+appears because 120M plugin rows dwarf the 10.8M-row probe. dbNSFP plans
+`join_type=Left` and collects its own rows — a genuine 1557 MB working set that
+the 8 GiB default fixes properly.
+
+---
+
+## 4. Fixed along the way (keep these)
+
+**`GROUP BY` cross-batch buffer over-count — 2d6c01d.**
+`GroupedHashAggregateStream` emits batches sharing underlying buffers.
+`HashJoinExec` reserves per batch via `get_record_batch_memory_size`, which
+de-duplicates buffers only *within* one batch, so a shared buffer is charged once
+per referencing batch. Measured (`scripts/debug/measure_batch_buffer_sharing.py`):
+
+| source | batches | accounted | distinct buffers | over-count |
+|---|---:|---:|---:|---:|
+| raw parquet scan | 1793 | 277.9 MB | 277.9 MB | 1.0x |
+| same scan + `GROUP BY` | 1791 | 5756.8 MB | 181.4 MB | **31.7x** |
+
+Materializing the probe (a `concat` per batch → unshared buffers) dropped CADD's
+increment from a repeated **592.7 MB** to a smooth **18.2 MB** and cut the probe
+from 1791 batches to 11. Related upstream: arrow-rs#6439, which DataFusion's own
+comment cites as why `get_record_batch_memory_size` exists — it does not cover
+the cross-batch case.
+
+**Retry pool budget — 39fc35c.** 2 GiB → 8 GiB default, plus
+`VEPYR_PLUGIN_RETRY_MEMORY_MIB`. Fixes dbNSFP. Does not and cannot fix CADD.
+
+**`schema_force_view_types=false` — aa877f3.** Halves the shared buffer
+(592.7 → 304.2 MB) and drops `CAST(... AS Utf8View)` from the join keys. A real
+improvement, but it was **not** the fix — it changed the buffer's width, not the
+sharing.
+
+---
+
+## 5. Ruled out — do not re-tread
+
+| Theory | Killed by |
+|---|---|
+| The `ORDER BY` sort is expensive | Retry plan == fast plan + `ORDER BY`; the error names `HashJoinInput`, not a sort reservation |
+| The plugin is always the collected side | Plan dumps: `Left` for dbNSFP (plugin collected), `Right` for CADD (probe collected) |
+| It is a scale problem | SpliceAI retries at 31.7M rows and succeeds; dbNSFP fails at 836k |
+| A bigger pool fixes it | 2 / 8 / 20 GiB all fail; the reservation grows to match the pool exactly |
+| `Utf8View` width is the cause | Disabling view types halved the increment, pattern unchanged |
+| `GROUP BY` buffer sharing is the whole cause | Fixed in 2d6c01d; increment fell to 18.2 MB but the leak persists |
+| The semi-join (b561629) is the consumer | `HashJoinInput#0` is 0.95 GB and **stable** across pool sizes |
+
+---
+
+## 6. Where to look next
+
+`collect_left_input` (`datafusion-physical-plan-53.0.0/src/joins/hash_join/exec.rs`)
+grows the reservation once per build batch (`:1874`) and once for the hash map
+(`:~1935`), and `left_fut.try_once` (`:1299`) should make the collect happen once.
+That accounts for ~180 MB and cannot account for 20 GB — so the extra growth
+comes from somewhere else. Unexplored angles:
+
+1. **Is `collect_left_input` running more than once?** Log entry/exit, or count
+   `MemoryConsumer::new("HashJoinInput")` registrations. `mem_trace` keys on
+   consumer identity, so a second collect would appear as a *new* `#n` — it does
+   not, which argues against this but does not exclude a reused consumer.
+2. **Is the probe side reserving under the build's consumer?** `stream.rs` is
+   the probe loop; check whether anything there touches the build reservation.
+3. **`join_type=Right` + `CollectLeft` specifically.** CADD is the only plugin
+   that plans this combination and the only one that leaks. Force the swap off
+   (make the probe look larger, or disable the optimizer's join-selection rule)
+   and see whether the leak follows the swap. **This is the highest-value test.**
+4. **Reproduce outside vepyr.** Drive the same plan from a small Rust test or
+   `datafusion-cli` against `variation/chr21.parquet` + the CADD slice, under a
+   `FairSpillPool`. If it reproduces, this is an upstream DataFusion bug and
+   should be filed with that reproducer.
+
+If it is upstream, the near-term workaround is to keep CADD off the retry path —
+feed the join pre-sorted input so `assert_start_monotonic` never trips. Note the
+correct sort is **not** `sort -k2,2n`: CADD's `ingest_sql` anchor-shifts indels to
+`start = pos+1` while the SNVs at that position stay at `pos`, so the tie must
+break on shifted-ness (unshifted first). See `vepyr-plugins` PR #4.
+
+---
+
+## 7. Working state
+
+**chr21, built and validated** (`(tier, start)` ascending per shard; SpliceAI's
+`assume_unique` checked exhaustively over all 31.7M keys):
+
+| plugin | rows | shard |
+|---|---:|---:|
+| clinvar | 49,937 | 1 MB |
+| alphamissense | 698,535 | 6 MB |
+| spliceai | 31,683,675 | 238 MB |
+| dbnsfp | 836,391 | — |
+| **cadd** | — | **blocked** |
+
+Full-genome runs have not been attempted. `notebooks/build_plugin_caches.ipynb`
+in the vepyr branch drives the whole matrix; note it still downloads sources
+rather than using the `rclone serve http` trick in §2.1, which is worth porting.

--- a/docs/superpowers/handovers/2026-08-25-plugin-cache-testing-handover.md
+++ b/docs/superpowers/handovers/2026-08-25-plugin-cache-testing-handover.md
@@ -1,0 +1,148 @@
+# Plugin-cache build validation — testing handover (2026-08-25)
+
+How the five plugin caches get built from their raw sources and checked, what
+has actually been run, and what is left. The engine-side memory investigation
+that this testing uncovered lives in
+`2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md`; this doc is the
+*testing* half and does not repeat it.
+
+---
+
+## 1. Why this exists
+
+`datafusion-bio-functions` PR #217 rewrote the plugin-cache build path
+(streaming shard write, `assume_unique`, VCF/BED providers). Unit tests cover
+the invariants in isolation; they cannot tell you whether a real 120M-row
+chromosome builds, or whether the shard it writes is correct. Two reviews on
+#217 asked for a real-chromosome check before merge. This is that check.
+
+It is also the only exercise that touches several of the PR's changes on real
+data at all — the VCF provider, `assume_unique`, the ordering guard and its
+retry, and the streaming write at chromosome scale.
+
+## 2. State
+
+| scope | status |
+|---|---|
+| chr21, all 5 plugins | **done** — build + shard invariants pass |
+| chr1, all 5 plugins | **done** — at `target_partitions` 4 and 8, shard equivalence verified (see the leak doc §8) |
+| chr2–22, X | **not started** |
+| Golden-VEP CSQ parity | **not started** — see §6, this is the real acceptance gate |
+
+chr21 shard invariants (this session):
+
+| plugin | rows | shard | `(tier,start)` | `assume_unique` |
+|---|---:|---:|---|---|
+| clinvar | 49,937 | 1 MB | OK | — |
+| alphamissense | 698,535 | 6 MB | OK | — |
+| spliceai | 31,683,675 | 238 MB | OK | exhaustive, 31.7M keys |
+| dbnsfp | 836,391 | 41 MB | OK | — |
+| cadd | 121,809,062 | 1040 MB | OK | exhaustive, 121.8M keys |
+
+## 3. Getting the sources without downloading 168 GB
+
+All six source files are bgzip+tabix indexed, so a chromosome can be pulled
+without fetching the file. `rclone serve http` makes Drive range-readable:
+
+```bash
+rclone serve http gdrive-mw: \
+  --drive-root-folder-id 1ZT3g31I0LXepORF_dusy47AuXOnbRlZ_ \
+  --addr localhost:18080 --read-only &
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:18080/    # expect 200
+tabix http://localhost:18080/cadd/whole_genome_SNVs.tsv.gz 21 > cadd_chr21_snv.tsv
+```
+
+CADD's chr21 slice comes out of an 87 GB remote file in ~50 s. The full source
+set is ~168 GB against ~230 GB free, so **without this you cannot hold two large
+sources at once** and the whole matrix becomes a disk-juggling exercise.
+
+**Contig naming differs per source and a wrong prefix yields a silently empty
+slice, not an error.** `chr`-prefixed for alphamissense; bare for clinvar, cadd,
+dbnsfp, spliceai. Verify with `tabix -l <url> | head -3`.
+
+## 4. Building and checking one chromosome
+
+```bash
+python scripts/debug/build_plugin_chrom.py <plugin> <chrom>
+```
+
+Env: `RUST_LOG=info` (**required** — all instrumentation logs at info),
+`VEPYR_TRACE_MEMORY=1` (per-reservation peaks + batch buffer-sharing stats),
+`VEPYR_EXPLAIN_TIER_JOIN=1` (physical plan),
+`VEPYR_PLUGIN_RETRY_MEMORY_MIB=<n>`.
+
+Every shard must satisfy, and these are what the checks assert:
+
+1. **`start` ascending within each tier.** `PageDir::resolve_ranges` binary
+   searches inside a tier, so an unsorted run silently misses rows that are
+   present — a wrong-answer bug, not a crash.
+2. **Tiers grouped** warm-then-cold.
+3. **No duplicate probe keys** for an `assume_unique` plugin. A duplicate means
+   the manifest flag is wrong and the runtime `HashMap` keeps the *last* row,
+   inverting VEP's first-in-file rule. Check this **exhaustively** — the
+   builder's own check samples only the first 2M distinct keys, so a build
+   passing is not evidence the flag is right.
+
+`scripts/debug/measure_probe_size.py` and
+`measure_batch_buffer_sharing.py` are the two measurement tools that the memory
+investigation needed; keep them for the next scale problem.
+
+## 5. Running the matrix
+
+`notebooks/build_plugin_caches.ipynb` (vepyr branch
+`plugin-cache-build-validation`) drives all five, smallest first
+(clinvar 192 MB → cadd 88 GB), downloading each source, building, then deleting
+it. **It predates the `rclone serve http` approach in §3 and still downloads —
+porting that in is the single biggest improvement available to it.**
+
+Order matters and is not arbitrary: clinvar is 192 MB and exercises the VCF
+provider, so a broken pipeline surfaces in minutes rather than after an 88 GB
+download.
+
+Two mistakes from this session worth not repeating:
+
+- **Do not pipe per-plugin output through `tail -N`.** I did, and it truncated
+  the retry/slice diagnostics, which cost a wrong conclusion ("the retry never
+  fired") that took a rerun to correct.
+- **The peak-reservation table does not print when a build fails inside
+  `tiered_stream_sorted`** rather than the write — the report call sits after
+  it. Worth moving if you are debugging a failure there.
+
+## 6. The gate that has not been run
+
+Everything above checks that a shard is *internally* well-formed. None of it
+checks that the annotations are *right*. The real acceptance gate is the
+golden-VEP CSQ comparison: build the caches, annotate HG002 with all five
+plugins attached, and compare per-field against an Ensembl VEP run with the
+same plugins.
+
+That harness already exists — `run_comparison.py --profile merged_plugins` on
+vepyr `plugins-fixes` (PR #48), which adds the profile and the representation-
+only field equality the plugin fields need. **`merged_plugins` has never been
+run.** Until it is, "the plugin cache builds" is the only claim supported.
+
+Note `verify_parity_gate.py` deliberately refuses plugin profiles: it pins the
+Ensembl core CSQ contract, and a plugin run emits fields outside it. Extending
+the gate to plugin fields is unstarted work.
+
+## 7. Open items
+
+1. **Golden-VEP parity for `merged_plugins`** (§6) — the actual gate.
+2. **chr2–22, X.** chr1 and chr21 are the extremes of size; the middle is
+   presumably uneventful but unverified.
+3. **Port `rclone serve http` into the notebook** (§3).
+4. **Plugin-field parity gate** — `verify_parity_gate.py` cannot cover plugin
+   profiles today.
+5. **BED provider has no real-data coverage.** No BED manifest exists in
+   vepyr-plugins, so `ProviderKind::Bed` is exercised only by the schema-pin
+   unit test added in `84e5cfe`.
+
+## 8. Related
+
+| what | where |
+|---|---|
+| Engine + memory investigation | `datafusion-bio-functions` PR #217, branch `plugins-fixes` |
+| Multi-part `source_path`, notebook | `vepyr` PR #49, branch `plugin-cache-build-validation` |
+| Comparator + `merged_plugins` profile | `vepyr` PR #48, branch `plugins-fixes` |
+| CADD as two `[[source]]` parts | `vepyr-plugins` PR #4 |
+| Memory/leak investigation | `2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md` |

--- a/docs/superpowers/handovers/2026-08-26-plugin-golden-vep-parity.md
+++ b/docs/superpowers/handovers/2026-08-26-plugin-golden-vep-parity.md
@@ -1,0 +1,297 @@
+# Golden-VEP plugin parity — findings handover (2026-08-26)
+
+The acceptance gate from `2026-08-25-plugin-cache-testing-handover.md` §6 has been
+run. This records what was analysed, what was run, what mismatched, and the
+traps — several of which fail silently and will cost the next person a day.
+
+Engine: `86fd72d` (this repo, `plugins-fixes`).
+Manifests: `vepyr-plugins` `c9fe785`, `f9cfa30`, `2545530` (local, unpushed).
+Docs + reference script: `vepyr` `plugins-fixes` (local, unpushed).
+Narrative report: <https://claude.ai/code/artifact/28178c87-b954-40b0-adee-dfd2933681de>
+
+---
+
+## 1. Result
+
+All 38 plugin CSQ fields report **100.00%** on both contigs.
+
+| contig | variants | CSQ entries/field | mismatch rows | format-only | unpaired | CSQ count/order |
+|---|---:|---:|---:|---:|---:|---:|
+| chr21 | 55,812 | 895,482 | **2** | 0 | 0 | 0 |
+| chr1 | 323,430 | 5,688,867 | **78** | 0 | 0 | 0 |
+
+Byte parity (chr21, `md5_concordance.py`): **55,811 of 55,812 records byte-identical**.
+Header 272 vs 266 lines — see §7.
+
+Every remaining row is the upstream VEP HGVS-shift defect (§5.4), not ours.
+
+**The caches were never wrong.** In every failing case the correct value was
+physically present in the shard and the lookup asked the wrong question. No
+shard was rebuilt for correctness — only to change column *types* (§5.5).
+
+---
+
+## 2. Files analysed
+
+### Ensembl (ground truth — read, not inferred)
+
+Extract from the image with
+`docker run --rm ensemblorg/ensembl-vep:release_116.0 bash -lc 'sed -n "/^sub X/,/^}/p" <file>'`.
+
+| file | why it mattered |
+|---|---|
+| `Bio/EnsEMBL/Variation/Utils/Sequence.pm` → `get_matched_variant_alleles` | the actual matcher: minimises **both** sides, compares `(ref, alt, pos)` |
+| … → `trim_sequences` | prefix-then-suffix vs suffix-then-prefix; `empty_to_dash` |
+| … → `_get_trim_directions` | returns `[0,1]` when either allele is longer than 1 |
+| `Plugins/CADD.pm` `run`/`parse_data` | delegates to `get_matched_variant_alleles`; fetches `[start-2, end]`; anchor-shifts data rows |
+| `Plugins/SpliceAI.pm` `run` | **imports** the matcher but never calls it — exact `eq` comparison |
+| `Plugins/dbNSFP.pm` `run` | exact `pos`+`alt`; `return {} unless $vf->{start} == $vf->{end}` (SNV-only) |
+| `Plugins/AlphaMissense.pm` `run` | calls `get_matched_variant_alleles` |
+
+Plugin `.pm` files are also mirrored in the Drive sources folder, which is where
+they were taken from for the container's `--dir_plugins`.
+
+### Engine
+
+`src/allele.rs` (already contained a full `get_matched_variant_alleles` port —
+`trim_sequences_ensembl`, `trim_directions`), `plugin_cache/{registry,lookup,
+cache_manifest,source_manifest,build,normalize}.rs`, `annotate_provider.rs`
+(probe call sites ~6425/6473, buffer take-set ~5470), `vcf_sink.rs`
+(`csq_header_description`, raw header lines).
+
+### Comparator (`vepyr` PR #48)
+
+`comparison/{compare,profiles,report,cli}.py`, `md5_concordance.py`,
+`verify_parity_gate.py`.
+
+---
+
+## 3. Commands run
+
+### Reference (the part that did not exist)
+
+`e2e-testing/scripts/build_vep_plugin_reference.sh <chrom>` in `vepyr` captures
+this end to end. Core call:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" -v "$DATA":/data \
+  ensemblorg/ensembl-vep:release_116.0 \
+  vep --cache --cache_version 116 --dir_cache /data --offline --merged \
+      --everything --no_stats --force_overwrite --vcf \
+      --fasta /data/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
+      --input_file /data/vep116_chr21/input/HG002_norm_chr21.vcf.gz \
+      --output_file /data/vep116_chr21/output/HG002_chr21_5plugins_vep116.vcf \
+      --dir_plugins /data/vep116_chr21/plugins \
+      --custom …/clinvar_chr21.vcf.gz,ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN,CLNVC,CLNVI \
+      --plugin SpliceAI,snv=…/spliceai_chr21.vcf.gz,indel=…/spliceai_chr21.vcf.gz \
+      --plugin CADD,snv=…/cadd_all_chr21.tsv,indels=…/cadd_all_chr21.tsv \
+      --plugin AlphaMissense,file=…/alphamissense_chr21.tsv.gz \
+      --plugin dbNSFP,…/dbNSFP5.3.1a_grch38_chr21.gz,<19 cols>
+```
+
+Runtime: chr21 ~14 min, chr1 ~75 min (native arm64, no emulation).
+
+Source slices via `rclone serve http` + `tabix` (handover 2026-08-25 §3).
+Contig naming: `chr21` for AlphaMissense, bare `21` for the rest.
+
+### Shard rebuilds (only for the `Utf8` retype)
+
+```python
+vepyr.build_plugin_cache("cadd", "f9cfa30", source_path=".../cadd_all_chr21.tsv",
+    cache_dir="$DATA/cache/116_GRCh38_merged", plugin_cache_root="$DATA/plugin_cache",
+    chroms=["21"], plugins_repo="$HOME/workspace/vepyr-plugins", overwrite=True)
+```
+
+`version` is a **git ref** materialised via `git worktree`, so manifest edits
+must be **committed** first — working-tree edits are invisible.
+
+Times: spliceai chr21 17 s / chr1 209 s; cadd chr21 45 s / chr1 296 s.
+Row counts reproduced the originals exactly (cadd chr21 121,809,062 / warm
+399,098; chr1 699,768,898 / warm 1,929,017).
+
+### Comparison
+
+```bash
+uv run python run_comparison.py --release 116 --profile merged_plugins \
+  --chroms 21 --plugin-cache $DATA/plugin_cache \
+  --vep $DATA/vep116_chr21/output/HG002_chr21_5plugins_vep116.vcf.gz \
+  --workers 4 --force
+
+python md5_concordance.py --pair <vep>.vcf <vepyr>.vcf --mode strict --explain
+```
+
+Isolating an upstream behaviour — run VEP on a handful of variants with
+`--fields Location,Allele,Feature,Consequence,CADD_RAW` and bisect flags. This
+is how §5.4 was pinned; do this before theorising.
+
+---
+
+## 4. Mismatches found
+
+### chr21 (per CADD field, before fixes: 232)
+
+| # | variant | shape | entries | cause |
+|---|---|---|---:|---|
+| 1 | chr21:13973877 `TTGTGTGTGTGTG>GTGTGTGTGTGTG` | equal-length MNV | 85 | A |
+| 2 | chr21:26032805 `AAT>TAT` | equal-length MNV | 68 | A |
+| 3 | chr21:26062230 `AAC>ACAC` | insertion | 66 | A (indel) |
+| 4 | chr21:28149937 `CGT>TGT` | MNV | 5 | A |
+| 5 | chr21:39327921 `AAATG>GAATG` | MNV | 3 | A |
+| 6 | chr21:27136796 `CA>AA` | MNV | 2 | A |
+| 7 | chr21:18829623 `AATAT>TATAT` | MNV | 1 | A |
+| 8 | chr21:26989261 `CTC…>TTC…` (33 bp) | MNV | 1 | A |
+| 9 | chr21:33549183 `A>ATTGT` | insertion | 1 | **upstream** |
+
+Plus 1,533,782 format-only entries over six `Float32` fields, and 32 missing
+header lines. **Now: 2 rows (variant 9 only).**
+
+### chr1 (before the ClinVar fix: 138 rows)
+
+| field group | rows | variants | cause |
+|---|---:|---:|---|
+| CADD_RAW/PHRED | 39 each | 5 insertions (13779899, 77558660, 152709213, 111290866, 217771848) | **upstream** |
+| ClinVar ×6 | 10 each | chr1:65364614 `GT>TT` | misclassified `allele_match` |
+
+**Now: 78 rows (CADD only).**
+
+---
+
+## 5. Causes, and what fixed them
+
+### 5.1 Probe key not reduced — and trim *order* decides the row
+
+`vcf_to_vep_input_allele` strips only a single anchor base. `bcftools norm
+-m -both` splits multi-allelics **without re-trimming**, so non-minimal records
+are routine. Added `allele::plugin_probe_allele` (left-first `trim_sequences`),
+consulted **only on a miss** so no existing hit can change.
+
+Order is load-bearing, not cosmetic:
+
+| VCF | left-first (Ensembl) | right-first |
+|---|---|---|
+| `CGTGTGT/CGTGT` | `GT/-` @ 13836153 — no row, empty (correct) | `GT/-` @ 13836149 — another variant's score |
+| `AAC/ACAC` | `-/C` @ 26062231 — the row VEP reports | same |
+
+### 5.2 Allele semantics are per-plugin
+
+`AlleleMatch::{Exact,Minimised}` in the manifest. CADD, AlphaMissense and
+`--custom` (ClinVar) minimise; SpliceAI and dbNSFP compare verbatim.
+
+> The `exact` in `--custom <file>,ClinVar,vcf,exact,0,…` is the **overlap mode,
+> not the allele rule**. VEP matches `chr1:65364614 GT>TT` to ClinVar's `G>T`
+> row 1258041. Misreading this cost 10 variants × 6 fields on chr1.
+
+### 5.3 CSQ field order
+
+Ensembl emits plugin blocks in **command-line order**, each plugin's fields
+**sorted by name**, `--custom` last in declared order. We emitted plugins
+alphabetically in declaration order → 99.3% of records differed, invisible to
+the name-keyed comparator. Pinned via `csq_rank` + `field_order`.
+
+### 5.4 Upstream: HGVS shifting breaks CADD's fetch window
+
+`CADD.pm` fetches `[VF.start-2, VF.end]` from the tabix file. HGVS 3′ shifting
+mutates those VF coordinates, so the window moves off the row and the score
+vanishes — for the shifted (frameshift) transcript only.
+
+```
+--hgvs                 → chr1 80/139 hits   (39 lost = exactly our mismatches)
+--hgvs --shift_hgvs 0  → chr1 119/139 hits
+plain (no --hgvs)      → chr1 119/139 hits
+```
+
+A cosmetic naming feature corrupting a data lookup. vepyr matches
+`--shift_hgvs 0` and matches CADD being a per-variant score. **Not reproduced.**
+Worth reporting upstream.
+
+### 5.5 Float re-formatting — retyping alone is not enough
+
+Six `Float32` columns (CADD RAW/PHRED, SpliceAI DS_×4) were re-rendered with
+Rust's shortest round-trip. Setting them to `Utf8` changed the stored type but
+**not the value**, because `ingest_sql` still did `CAST(raw_score AS FLOAT)` —
+the padding was destroyed before storage. Selecting the raw columns verbatim
+fixed it. Now 0 on both contigs.
+
+Not "avoid Float32": `am_pathogenicity` stays `Float32` and is clean, because
+AlphaMissense doesn't zero-pad. **Don't re-format a source that pads.**
+
+### 5.6 Missing plugin header lines
+
+`description` per value column, emitted as `##<FIELD>=…` from `vcf_sink.rs`.
+All 32 byte-identical.
+
+---
+
+## 6. Observations — silent failure modes
+
+Ranked by how long each cost.
+
+1. **`ProjectionMask::leaves` ignores leaf order.** Permuting the projection to
+   match reordered field names moves the names and leaves the values put; every
+   field pairs with a sibling's value. CADD fell to 0.73%, ledger 4.6M rows.
+   **Permute the returned values, not the projection.**
+2. **A rebuild silently reverts anything only patched into `manifest.json`.**
+   `allele_match` was hand-patched, lost on the next build, and CADD jumped back
+   to 232. Settings belong in the source TOML.
+3. **dbNSFP parses its version from the *filename*.** A slice named
+   `dbnsfp_chr21.tsv.gz` is rejected, all 19 fields disappear from the CSQ
+   header, and VEP still **exits 0**. The name must contain e.g. `5.3.1a`.
+   The reference script now asserts 38 plugin fields for this reason.
+4. **`--database 0` is not valid input.** It appears in VEP's own
+   `##VEP-command-line` header but parses as a stray positional. `--offline`
+   covers it.
+5. **CADD's slice must be plain text and comment-free.** Its manifest declares
+   no `compression` (a `.gz` is read as binary), and `tabix -h` leaves a
+   `## CADD` line that breaks the CSV reader. Concatenate SNV+indel with
+   comments stripped. chr1 combined = 20 GB — watch disk.
+6. **The summary markdown hides format-only and order-only counts.**
+   `report.py:512` / `cli.py:571` compute "fields at 100%" from real mismatches
+   alone. Read plugin results from the **per-contig JSON**
+   (`field_format_mismatch_counts`). This is very likely how the earlier
+   "37/38 at 100%" chr22 figure arose — that run also predates identity pairing.
+7. **`build_plugin_cache(version=…)` is a git ref**, materialised via
+   `git worktree`. Uncommitted manifest edits are invisible.
+8. **A chrom-scoped rebuild rewrites the whole manifest**, dropping other
+   chroms' entries. Re-add them, or the sibling contig silently disappears.
+
+### Method note
+
+Five of my explanations were overturned by the next measurement: the
+`vcf_to_vep_allele` one-liner (a no-op — it doesn't suffix-trim MNVs), the
+"equal-length only" restriction (the real rule was trim order), "cause B is a
+start-convention bug" (it was the same defect as A), "VEP is just inconsistent"
+(it's HGVS shifting), and ClinVar's `exact`. Each died to reading Ensembl's
+source or running VEP directly. **Read the `.pm`, or run the flag bisection.
+Do not reason from mismatch shapes.**
+
+Also: chr1 caught a defect chr21 could not. Two contigs found four defects.
+
+---
+
+## 7. Open items
+
+1. **Header parity** — 272 vs 266. The gap is six `##INFO=<ID=ClinVar…>`
+   definitions VEP writes for `--custom`, each embedding the **absolute source
+   path**, so no implementation can match them portably. They also declare INFO
+   keys that never appear as INFO fields (values ride in CSQ). Suggest
+   `md5_concordance.py` treat them as provenance rather than emitting untrue
+   INFO definitions to win a digest.
+2. **chr2–20, 22, X** — untouched. Given chr1's yield, expect more.
+3. **Push the companion commits** — `vepyr-plugins` (3) and `vepyr` (docs +
+   `build_vep_plugin_reference.sh`) are local only.
+4. **`verify_parity_gate.py` still refuses plugin profiles** by design; the
+   plugin field contract is unpinned there.
+5. **Report the HGVS-shift/CADD-window bug upstream.**
+6. **Other contigs' shards still carry the old `Float32` columns** — any contig
+   beyond chr1/chr21 must be rebuilt from the current manifests, or its
+   manifest will disagree with its columns.
+
+## 8. Artifacts on disk
+
+| what | where |
+|---|---|
+| chr21 / chr1 references (+ `.gz`, `.tbi`) | `$DATA/vep116_chr{21,1}/output/` |
+| normalized inputs | `$DATA/vep116_chr21/input/HG002_norm.vcf.gz` (whole-genome), per-contig slices alongside |
+| plugin caches (all 5, chr1+chr21) | `$DATA/plugin_cache/plugin/<name>/` |
+| reports + mismatch ledgers | `vepyr/e2e-testing/reports/fast_chr{1,21}_merged_plugins_116_*` |
+| prior-session plain slices (reusable) | `$DATA/plugin_input/_slices/` |

--- a/docs/superpowers/handovers/2026-08-26-plugin-golden-vep-parity.md
+++ b/docs/superpowers/handovers/2026-08-26-plugin-golden-vep-parity.md
@@ -11,6 +11,60 @@ Narrative report: <https://claude.ai/code/artifact/28178c87-b954-40b0-adee-dfd29
 
 ---
 
+## Superseding full-autosome closure (later 2026-08-26)
+
+The earlier chr1/chr21-only state documented below has now been superseded by
+a complete VEP 116 autosome run. The fixed-CADD references and vepyr outputs
+cover 22 chromosomes, 4,096,123 VCF records, and 69,299,753 CSQ entries.
+
+The first full strict pass found exactly two additional mismatch classes:
+
+1. The generic plugin CSQ formatter did not encode `=` as `%3D`, unlike VEP.
+   This affected seven ClinVar records (six on chr13 and one on chr17), or 556
+   `ClinVar_CLNVI` CSQ entries, all containing a BIC `base_change=...` value.
+2. Typed VCF columns collapse an explicit `INFO_KEY=.` and an absent INFO key
+   to the same Arrow null. At `chr22:28800769 G>C`, VEP preserved the explicit
+   ClinVar `CLNDN=.` in 39 CSQ entries while vepyr emitted an empty field.
+
+The `=` class affected `chr13:32316435 G>A`, `32337751 A>G`, `32341273 CAATT>C`,
+`32355095 A>G`, `32362509 T>C`, `32379251 T>C`, and `chr17:43099914 G>A`.
+The uncapped pre-fix ledger hashes are respectively
+`dfdf65a4b7b32982cdebe78d6f48f775207841f2b736d61b5df6179ea056fe85`
+(135 rows) and
+`ffea4318ed5c1920d21bad1bd73eddf3260a2e4179ea3b51a70de488d1deb7ef`
+(421 rows). The chr22 difference was format-only and therefore had no semantic
+ledger row.
+
+Both are fixed without variant-specific or chromosome-specific hardcoding:
+
+- plugin strings now escape `=` generically;
+- VCF source manifests can opt into `record_layout`, exposing
+  `_vcf_info_keys` so a manifest can distinguish explicit missing markers from
+  absent keys;
+- the ClinVar manifest enables that layout and restores `.` only for selected
+  INFO keys that were actually present. A blanket null-to-dot conversion would
+  be wrong: chr22 contains 4,534 records with no `CLNDN` key and only two with
+  an explicit `CLNDN=.`. This manifest is versioned in `vepyr-plugins` commit
+  `4c92563adb49389ce1569a77681274f8f37c9fd8`.
+
+After release/native rebuilds of chr13, chr17, and chr22, both the targeted
+strict reruns and an independent 22-chromosome strict body-MD5 pass are green:
+
+- 22/22 strict exits are zero;
+- all 4,096,123 record bodies are byte-identical to VEP;
+- aggregate variant-set, CSQ-count, CSQ-set, CSQ-order, field-value,
+  field-format, and field-order mismatch counts are zero;
+- all mismatch ledgers are empty.
+
+Headers still intentionally differ in provenance, absolute paths, and custom
+field declaration text; they are outside the body parity target. Detailed
+baseline variants, ledger hashes, implementation notes, and post-fix evidence
+are in `vepyr/e2e-testing/reports/full_autosome_mismatch_catalog_116.md`.
+Everything below this section records the earlier investigative history and
+should not be read as the current parity status.
+
+---
+
 ## 1. Result
 
 All 38 plugin CSQ fields report **100.00%** on both contigs.

--- a/docs/superpowers/plans/2026-08-25-adaptive-parallel-plugin-tier-join.md
+++ b/docs/superpowers/plans/2026-08-25-adaptive-parallel-plugin-tier-join.md
@@ -89,7 +89,7 @@ Adaptive decision B: final LEFT tier join
         `-- SortMergeJoin context (parallel, bounded/spillable)
         |
         v
-explicit ORDER BY start -> warm/cold writers
+explicit ORDER BY tier, start -> direct atomic Parquet writer
 ```
 
 The two decisions are mandatory. Adapting only the final join leaves the probe

--- a/docs/superpowers/plans/2026-08-25-adaptive-parallel-plugin-tier-join.md
+++ b/docs/superpowers/plans/2026-08-25-adaptive-parallel-plugin-tier-join.md
@@ -1,0 +1,522 @@
+# Adaptive Parallel Plugin Tier Join — Implementation Plan
+
+**Date:** 2026-08-25
+**Status:** Full design retained for reference; the user selected the minimal
+custom implementation on 2026-08-25.
+**Root-cause evidence:** `docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md` and `.planning/debug/cadd-tier-join-algorithm-selection.md`
+
+## Minimal implementation selected
+
+The implemented first slice intentionally avoids the separate statistics
+catalog and context-factory layers proposed later in this document. It:
+
+- asks DataFusion to build an optimized CollectLeft HashJoin candidate;
+- reads row and byte statistics from the physical build child DataFusion
+  actually chose;
+- compares DataFusion 53's estimated input/hash-table/bitmap reservation with
+  the active pool's currently available bytes;
+- executes that exact HashJoin plan when it fits, otherwise flips only
+  `prefer_hash_join` and verifies DataFusion emitted SortMergeJoin;
+- applies the decision independently to probe construction and the final tier
+  join, using runtime-default parallelism with a minimum of two partitions;
+- retries once with SMJ only for a `ResourcesExhausted` root error that both
+  names and is traced to `HashJoinInput`; and
+- always requests explicit final ordering for parallel output.
+
+Unknown statistics select SMJ. Inexact statistics remain advisory and are
+protected by the attributed runtime fallback. The richer projected-Parquet
+statistics model and real CADD benchmark matrix below remain possible follow-up
+work, not claims about this minimal slice.
+
+## Goal
+
+Make both joins in the per-chromosome plugin-cache tiering pipeline run with
+DataFusion parallelism and automatically select the fastest strategy that is
+safe for the active memory pool:
+
+- use HashJoin when its non-spillable build side is predicted to fit;
+- use SortMergeJoin when the hash build cannot be shown to fit;
+- retry once with SortMergeJoin if an estimated-safe HashJoin is rejected by
+  the memory pool at runtime;
+- base every decision on input statistics, the runtime memory limit, and the
+  runtime's default parallelism — never on chromosome names or chromosome-row
+  thresholds.
+
+"Best" has a precise meaning in this plan: prefer the linear-time HashJoin when
+it satisfies the memory proof; otherwise use the bounded/spillable SMJ. The real
+chr21 comparison supports that policy: HashJoin took 118.2 s, while SMJ produced
+identical output under the same 8 GiB pool in 123.7 s (+4.7%).
+
+## Non-goals
+
+- Do not bump DataFusion. DataFusion 55 fixes the shared-buffer-accounting bug,
+  but does not add the adaptive HashJoin-vs-SMJ decision required here.
+- Do not declare either input sorted. Neither current input is globally ordered
+  on `(chrom, start, allele_string)`.
+- Do not select strategies by plugin name, chromosome, file name, or fixed row
+  count.
+- Do not run multiple chromosomes concurrently in the first implementation.
+  Parallelism is within each chromosome. Cross-chromosome concurrency needs a
+  separate global memory-permit scheduler or it can multiply the memory budget.
+- Do not use Partitioned HashJoin as the memory fallback. It parallelizes work
+  but remains non-spillable and does not reduce total live build bytes.
+
+## Required architectural change
+
+The current `tier_join_config()` applies one session configuration to probe
+construction, aggregation, the final join, and the output sort. With
+`target_partitions=1`, DataFusion 53 always creates CollectLeft HashJoin;
+`prefer_hash_join=false` and the collection thresholds cannot change that.
+
+Replace that single context with two independently planned stages:
+
+```text
+deduped plugin RecordBatches
+        |
+        | exact projected batch statistics
+        v
+Adaptive decision A: build variation probe
+        |-- HashJoin context (parallel, bounded pool)
+        `-- SortMergeJoin context (parallel, bounded/spillable)
+        |
+        v
+owned, execution-sized probe RecordBatches
+        |
+        | exact plugin + probe statistics
+        v
+Adaptive decision B: final LEFT tier join
+        |-- HashJoin context (parallel, bounded pool)
+        `-- SortMergeJoin context (parallel, bounded/spillable)
+        |
+        v
+explicit ORDER BY start -> warm/cold writers
+```
+
+The two decisions are mandatory. Adapting only the final join leaves the probe
+construction HashJoin able to collect the raw variation shard: 0.95 GiB on
+chr21, projected to about 9.44 GiB on chr1 and 10.04 GiB on chr2.
+
+## Strategy model
+
+Create `datafusion/bio-function-vep/src/plugin_cache/join_strategy.rs` with a
+pure, deterministic selector. It must not read environment variables, inspect
+chromosome labels, or create a DataFusion context.
+
+```rust
+enum JoinAlgorithm {
+    Hash,
+    SortMerge,
+}
+
+enum StatsConfidence {
+    Exact,
+    Estimated,
+    Unknown,
+}
+
+struct JoinInputStats {
+    rows: Option<usize>,
+    arrow_bytes: Option<usize>,
+    largest_batch_bytes: Option<usize>,
+    confidence: StatsConfidence,
+}
+
+struct JoinResources {
+    memory_limit_bytes: Option<usize>,
+    memory_reserved_bytes: usize,
+    target_partitions: usize,
+    execution_batch_rows: usize,
+}
+
+struct JoinDecision {
+    algorithm: JoinAlgorithm,
+    target_partitions: usize,
+    estimated_hash_build_bytes: Option<usize>,
+    available_bytes: Option<usize>,
+    reason: JoinDecisionReason,
+}
+```
+
+### Statistics inputs
+
+1. **Deduped plugin MemTable:** compute exact rows and Arrow bytes from the
+   projected join-key batches with DataFusion/Arrow's own memory-size functions.
+   Do not use the plugin's output row width for the probe-construction join.
+   Materialize `plugin_variation_keys` before probe construction so the
+   physical join sees those exact statistics too. When there are no match
+   columns, the existing keep-first dedup already makes the projected variation
+   key unique. When match columns exist, run `SELECT DISTINCT chrom, start,
+   allele_string` under the finite spill pool, collect it, and rechunk it into
+   owned execution-sized batches.
+2. **Raw variation Parquet:** obtain exact row count from Parquet metadata and
+   projected byte statistics for `chrom`, `start`, `allele_string`, and `tier`.
+   If projected Arrow bytes are not exact, scan an execution batch to derive a
+   per-row Arrow-width estimate and mark it `Estimated`.
+3. **Materialized variation probe:** compute exact rows and bytes after
+   `rechunk_probe_owned`; these batches already own their buffers.
+4. **Runtime resources:** read `MemoryPool::memory_limit()` and `reserved()`.
+   Use `SessionConfig::new().target_partitions()` for machine-default
+   parallelism. Hash may cap the count by non-empty probe batches/scan
+   partitions. SMJ must use `max(2, runtime_default)` logical partitions because
+   DataFusion 53 otherwise silently emits CollectLeft HashJoin; a one-core
+   runtime still gets a correct SMJ plan even though the scheduler cannot run
+   its two tasks simultaneously. Do not introduce a row-count threshold.
+
+### Hash-build estimate
+
+Hash mode deliberately uses one shared CollectLeft build plus parallel probing,
+not Partitioned HashJoin. The materialized inputs have exact physical
+statistics; raw Parquet may still have only a sampled Arrow-width estimate. Set
+both Auto-to-CollectLeft thresholds to `usize::MAX`, let
+JoinSelection swap the smaller side, create the optimized physical plan, and
+inspect it before execution. The plan is executable as Hash only if it contains
+`HashJoinExec(mode=CollectLeft)` and its physical left/build child can be
+identified as one of the measured inputs. Recompute the hash estimate for that
+actual child (using exact MemTable bytes or the Parquet Arrow-width estimate)
+and execute only if that actual build fits. Unknown build identity/statistics or
+an actual build that does not fit is a pre-execution reason to replan as SMJ.
+
+Physical validation is confidence-aware:
+
+- exact MemTable input: require relation/schema identity plus exact row and byte
+  equality with the measured batches;
+- sampled Parquet input: require relation/schema identity and exact metadata row
+  count, retain the external Arrow-byte estimate and `Estimated` confidence,
+  and do not compare that estimate with Parquet file-byte statistics.
+
+Calculate the estimate from that confirmed physical build child using the same
+components reserved by DataFusion 53's `collect_left_input`:
+
+```text
+input RecordBatch memory
++ datafusion_common::utils::memory::estimate_memory_size<(u32, u64)>(
+    rows,
+    size_of::<JoinHashMapU32>(),
+  )
+  (or the u64-index variant above u32::MAX rows)
++ visited-index bitmap for outer joins
++ one data-derived execution-batch workspace per active partition
+```
+
+All arithmetic must be checked/saturating. The selector compares the smaller
+valid candidate estimate with:
+
+```text
+available = finite_pool_limit - currently_reserved
+```
+
+Decision rules, in order:
+
+1. Empty input: HashJoin.
+2. Infinite pool with usable statistics: HashJoin.
+3. Unknown pool limit, missing row count, or missing byte estimate:
+   SortMergeJoin — an unspillable build cannot be proven safe.
+4. Estimated hash build plus streaming workspace fits available memory:
+   HashJoin.
+5. Otherwise: SortMergeJoin.
+
+No percentage or per-chromosome safety threshold is needed. Runtime fallback is
+the guard against sampling error, Parquet-vs-Arrow size differences, and future
+DataFusion hash-table accounting changes.
+
+`JoinHashMapU32` and `JoinHashMapU64` are available from DataFusion 53's public
+`physical_plan::joins::join_hash_map` module. Using their actual `size_of`
+matches DataFusion's fixed map-structure overhead without a copied numeric
+constant.
+
+### DataFusion configuration
+
+Build a fresh context for each selected stage over the same finite
+`FairSpillPool`:
+
+| Decision | Required configuration | Expected physical join |
+|---|---|---|
+| Hash | runtime `target_partitions > 1`, `prefer_hash_join=true`, Auto collection thresholds set to `usize::MAX` | verified `HashJoinExec(mode=CollectLeft)` with one shared smaller build and parallel probing |
+| SortMerge | `target_partitions=max(2, runtime_default)`, `prefer_hash_join=false` | verified `SortMergeJoinExec` with required repartition/sorts |
+
+Keep `schema_force_view_types=false` in both configurations; it prevents the
+already-proven shared Utf8View accounting problem. Remove the ineffective zero
+collection-threshold settings.
+
+## Parallel data layout and output ordering
+
+- Register plugin and materialized-probe MemTables with multiple partitions.
+  Assign complete owned batches to partitions by accumulated batch bytes, using
+  the selected target partition count. Do not slice batches or share newly
+  created parent buffers.
+- Let DataFusion repartition Parquet scans and join inputs using its runtime
+  target partition count.
+- Parallel execution invalidates the current implicit-order fast path. Always
+  use the explicit `ORDER BY p.start` stream for parallel contexts. The sort is
+  spillable and preserves the writer's `(tier, start)` invariant after the
+  stream is split into warm and cold runs.
+- Remove the fast-attempt/order-violation/retry double execution once the
+  parallel sorted path is verified. Keep `assert_start_monotonic` as a final
+  corruption guard, not as strategy control flow.
+
+## Runtime fallback
+
+Preflight statistics are advisory; the memory pool remains authoritative.
+
+For each stage selected as HashJoin:
+
+1. Execute it against the finite pool.
+2. Have the stage-local pool wrapper record the stable consumer label whenever
+   its inner pool rejects `try_grow`. If `DataFusionError::find_root()` is
+   `ResourcesExhausted`, retry only when that recorded label is the stage's
+   `HashJoinInput` reservation. Aggregate, sorter, repartition, disk, and other
+   resource failures propagate unchanged.
+3. Re-register the same immutable owned input batches in the new context.
+4. Propagate all non-memory errors unchanged.
+5. Never fall back from SMJ to HashJoin.
+
+For the final tier write, the existing `ScratchGuard` and truncating temporary
+writers make replay safe. Probe construction must similarly discard a partially
+collected probe before retrying.
+
+Add an optional diagnostic override `auto | hash | sort_merge`, defaulting to
+`auto`. It is for tests and benchmarking only; it must not accept chromosome
+rules. Forced HashJoin still runs inside the finite pool and fails rather than
+silently escaping the memory bound.
+
+`TracingPool` must forward `memory_limit()` to the wrapped pool. Enabling
+`VEPYR_TRACE_MEMORY` must not change the strategy decision.
+
+## Worktree preservation gate
+
+This worktree already contains user-owned experimental edits in `build.rs` and
+`mem_trace.rs`. Before implementation:
+
+1. Record `git status --short` and capture the exact diff of both files in the
+   execution notes.
+2. Do not use `git reset`, `git restore`, or `git checkout` on either file.
+3. Supersede only the known-invalid configuration experiment: the comments
+   claiming both inputs are sorted, `prefer_hash_join=false` under
+   `target_partitions=1`, and the two zero collection thresholds.
+4. Preserve and integrate `mem_trace::describe_batches` and its call site. If a
+   new statistics helper replaces it, retain equivalent charged-vs-distinct
+   diagnostics and tests rather than deleting the capability.
+5. Compare the final overlapping-file diff with the captured baseline before
+   committing.
+
+## Observability
+
+Emit one `info` record per decision and one per fallback:
+
+```text
+plugin_cache[cadd/chr21]: join_strategy stage=probe_build algorithm=hash
+  left_rows=14574753 left_bytes=... right_rows=121809062 right_bytes=...
+  hash_build_estimate=... pool_available=... partitions=... confidence=estimated
+  reason=hash_build_fits
+```
+
+The log fields must include stage, both input statistics and their confidence,
+pool limit/reserved/available, target partitions, chosen algorithm, estimated
+hash bytes, decision reason, and whether the choice is an automatic fallback.
+Keep `VEPYR_EXPLAIN_TIER_JOIN` and `VEPYR_TRACE_MEMORY` as opt-in deeper evidence.
+
+## Implementation tasks
+
+### Task 1: Pure statistics and strategy selector
+
+**Files:**
+- Create `datafusion/bio-function-vep/src/plugin_cache/join_strategy.rs`
+- Modify `datafusion/bio-function-vep/src/plugin_cache/mod.rs`
+
+**Work:**
+- Add the types and pure decision function above.
+- Mirror DataFusion's hash-build reservation components using public
+  `datafusion_common::utils::memory` helpers.
+- Represent exact, estimated, and unknown statistics explicitly.
+- Add structured decision reasons; do not store free-form policy strings.
+
+**Tests:**
+- Same inputs under two pool sizes choose Hash then SMJ.
+- Swapping input sizes picks the smaller hash-build estimate.
+- Unknown/inexact-without-sample statistics choose SMJ.
+- Existing reservations reduce available memory.
+- Partition count derives from runtime default and available input partitions.
+- Tests never pass a chromosome or plugin name to the selector.
+
+### Task 2: Collect projected input statistics
+
+**Files:**
+- Modify `datafusion/bio-function-vep/src/plugin_cache/join_strategy.rs`
+- Modify `datafusion/bio-function-vep/src/plugin_cache/join.rs`
+
+**Work:**
+- Add exact `RecordBatch`/MemTable statistics collection by projection.
+- Materialize the plugin's variation-key projection as owned MemTable batches;
+  apply spillable `DISTINCT` only when match columns make duplicate variation
+  keys possible.
+- Add Parquet row-count/projected-width collection and bounded sampling when
+  Arrow byte size is not exact.
+- Calculate statistics before planning probe construction, then recalculate
+  exact statistics after probe materialization.
+- Verify the sampled scan does not materialize the full shard and uses only the
+  join-key projection.
+
+**Tests:**
+- Synthetic Parquet metadata reports the exact row count.
+- Variable-width strings produce a non-zero projected Arrow estimate.
+- Projection excludes plugin value columns.
+- Owned probe statistics equal the sum of batch memory sizes.
+- The physical `plugin_variation_keys` table reports exact rows and bytes.
+
+### Task 3: Strategy-specific parallel contexts
+
+**Files:**
+- Modify `datafusion/bio-function-vep/src/plugin_cache/build.rs`
+- Modify `datafusion/bio-function-vep/src/plugin_cache/join.rs`
+
+**Work:**
+- Replace `tier_join_config()` with a constructor accepting `JoinAlgorithm` and
+  runtime target partitions.
+- Keep `schema_force_view_types=false` for every strategy.
+- Use one finite `FairSpillPool` for the tiering stages; remove the unbounded
+  fast join context.
+- Partition MemTable batches by accumulated bytes without copying or slicing.
+- Configure Hash and SMJ exactly as specified in the configuration table.
+- Inspect the optimized Hash physical plan and reject it before execution unless
+  it is CollectLeft, its build child maps to a measured input, and the
+  recomputed estimate for that actual child fits.
+
+**Plan tests:**
+- Hash decision yields verified `HashJoinExec(mode=CollectLeft)` with an
+  identified/measured build schema and parallel probe partitions.
+- SMJ decision yields `SortMergeJoinExec`, hash repartitioning, and input sorts.
+- One-batch inputs and a configured runtime default of one still yield genuine
+  `SortMergeJoinExec` with two logical partitions.
+- Neither plan claims pre-existing full-key ordering.
+
+### Task 4: Apply selection to both joins
+
+**Files:**
+- Modify `datafusion/bio-function-vep/src/plugin_cache/join.rs`
+- Modify `datafusion/bio-function-vep/src/plugin_cache/build.rs`
+
+**Work:**
+- Split probe creation from final tier streaming so each accepts its own
+  `JoinDecision` and context.
+- Select the probe-build strategy from raw variation plus projected plugin-key
+  statistics.
+- Materialize/rechunk the probe, then select the final tier strategy from exact
+  probe plus exact plugin MemTable statistics.
+- Log both decisions independently.
+- Inspect physical plans before execution and in tests to ensure the requested
+  algorithm, Hash partition mode, build-side identity, and recomputed build
+  estimate match the decision.
+
+**Tests:**
+- A large variation/small pool fixture selects SMJ while a smaller fixture on
+  the same code path selects Hash.
+- Probe-build and final-tier decisions can differ.
+- Duplicate/conflicting variation tiers still collapse with `MIN(tier)` and
+  warm wins.
+- Output rows and tier counts match the current implementation.
+
+### Task 5: One-pass sorted writer and memory fallback
+
+**Files:**
+- Modify `datafusion/bio-function-vep/src/plugin_cache/build.rs`
+- Modify `datafusion/bio-function-vep/src/plugin_cache/join.rs`
+
+**Work:**
+- Use explicit sorted output for all parallel final-join plans.
+- Retain `assert_start_monotonic` as an invariant check.
+- Remove order-violation-driven replay and replace it with an attributed
+  `HashJoinInput`-rejection-driven Hash-to-SMJ retry around both adaptive stages.
+- Ensure failed streams, reservations, temporary probe batches, and writer
+  handles are dropped before replay.
+- Allow at most one fallback per stage.
+
+**Tests:**
+- Inject deliberately optimistic statistics in a test so auto selects Hash,
+  then use a stage-local test pool to reject the `HashJoinInput` reservation;
+  assert SMJ replay succeeds with identical rows.
+- Aggregate and sorter `ResourcesExhausted` errors do not trigger join fallback.
+- Non-memory errors do not trigger fallback.
+- Warm and cold temporary outputs are safely overwritten after replay.
+- Final shard remains sorted by `(tier, start)` and page lookup returns every
+  written row.
+
+### Task 6: Diagnostics and regression coverage
+
+**Files:**
+- Modify `datafusion/bio-function-vep/src/plugin_cache/mem_trace.rs`
+- Modify tests in `build.rs` and `join.rs`
+
+**Work:**
+- Add stable structured decision logging and forced-strategy test override.
+- Forward `memory_limit()` through `TracingPool` and record the consumer label
+  for rejected reservations.
+- Preserve the owned execution-sized probe regression from `92f55f9`.
+- Supersede only the current invalid configuration experiment claiming that
+  `prefer_hash_join=false` works with `target_partitions=1` and that both inputs
+  are already sorted; preserve/integrate `describe_batches` per the worktree
+  preservation gate.
+
+**Tests:**
+- Selector log formatting contains all required fields.
+- Tracing enabled and disabled produce identical `JoinDecision` values.
+- A rejected aggregate/sorter reservation records a non-Hash consumer label and
+  is propagated unchanged.
+- `cargo test -p datafusion-bio-function-vep plugin_cache --lib` passes.
+- `cargo clippy -p datafusion-bio-function-vep --all-targets --all-features -- -D warnings`
+  passes.
+
+### Task 7: Real-data gate and tuning evidence
+
+Run two separate gates:
+
+1. CADD chr21 under the same 8 GiB pool: forced Hash, forced SMJ, and auto must
+   all succeed and produce equivalent output.
+2. One large chromosome under a constrained pool: auto and forced SMJ must
+   succeed; forced Hash must fail specifically with an attributed
+   `HashJoinInput` exhaustion. Optionally rerun forced Hash under a separately
+   documented larger pool for output parity.
+
+Acceptance criteria:
+
+- Auto selects Hash for chr21 if the computed estimate fits.
+- Auto selects SMJ before allocation when a large chromosome's estimated hash
+  build exceeds the pool.
+- If an estimate is optimistic, automatic fallback completes without manual
+  rerun.
+- All successful modes produce identical total/warm/cold counts and
+  byte-equivalent plugin values.
+- `HashJoinInput` never exceeds the finite pool; the large-input SMJ path shows
+  spillable sort reservations instead.
+- Parallel plans have more than one output partition before the final global
+  ordering merge.
+- Record wall time, peak RSS, spill bytes, chosen strategies, input estimates,
+  and actual peak reservations in the handover.
+- Auto chr21 wall time is no more than 10% above the recorded 118.2-second
+  HashJoin baseline on the same host/input, or the regression is investigated
+  before rollout.
+
+## Executable plan split
+
+Execute this design as three reviewable plans; overlapping Rust files are owned
+serially, while the implemented DataFusion pipeline is parallel at runtime.
+
+| Plan | Tasks | Result |
+|---|---|---|
+| A — statistics contract | 1, 2 | Pure selector, exact projected keys, Parquet estimates |
+| B — execution contract | 3, 4, 5 | Verified physical operator/build side, both joins adaptive, attributed replay |
+| C — integration gate | 6, 7 | Worktree-safe diagnostics, regression suite, real-data validation |
+
+## Definition of done
+
+- No production strategy branch contains a chromosome or plugin-name match.
+- No fixed row-count threshold controls HashJoin vs SMJ.
+- Both joins use finite-pool, parallel contexts.
+- The decision is reproducible from logged statistics and pool state.
+- Unknown statistics choose the bounded path.
+- An attributed HashJoin memory exhaustion automatically retries once with SMJ;
+  other resource errors do not.
+- Output order, tier semantics, dedup behavior, cache schema, and point lookup
+  remain unchanged.
+- CADD chr21 auto mode stays within 10% of the 118.2-second baseline on the
+  same host/input; a large chromosome completes under the configured pool
+  without manual strategy changes.

--- a/docs/superpowers/plans/2026-08-25-plugin-parity-kickoff.md
+++ b/docs/superpowers/plans/2026-08-25-plugin-parity-kickoff.md
@@ -1,0 +1,78 @@
+# Kickoff — golden-VEP parity for the plugin caches
+
+## Task
+
+Run the `merged_plugins` comparison profile against the golden Ensembl VEP
+output and report per-field CSQ match rates for the five plugin fields sets
+(ClinVar, SpliceAI, CADD, AlphaMissense, dbNSFP).
+
+**This has never been run.** Everything validated so far checks that a shard is
+*internally well-formed* — sorted within tier, tiers grouped, no duplicate probe
+keys. Nothing yet checks that the annotations are **correct**. That is this task.
+
+## Why it matters
+
+The plugin caches exist so vepyr reproduces Ensembl VEP's plugin output. A cache
+can be perfectly well-formed and still carry wrong values — wrong key
+normalization, a bad `ingest_sql` transform, a mis-set `assume_unique`, an
+anchor-shift off by one. Only a field-level comparison against real VEP output
+catches that.
+
+## Start here
+
+| thing | where |
+|---|---|
+| Comparison harness + `merged_plugins` profile | `vepyr` PR #48, branch `plugins-fixes` |
+| Engine + built caches | `datafusion-bio-functions` PR #217, branch `plugins-fixes` |
+| Multi-part sources, build notebook | `vepyr` PR #49, branch `plugin-cache-build-validation` |
+| Manifests (CADD is two `[[source]]` parts) | `vepyr-plugins` PR #4 |
+| How to build/slice a chromosome | `docs/superpowers/handovers/2026-08-25-plugin-cache-testing-handover.md` |
+| Engine memory investigation (context only) | `docs/superpowers/handovers/2026-08-24-cadd-tier-join-reservation-leak-RESOLVED.md` |
+
+Roughly:
+
+```bash
+cd <vepyr>/e2e-testing/scripts
+uv run python run_comparison.py --release 116 --profile merged_plugins --chroms 21
+```
+
+`merged_plugins` attaches the plugin cache and compares against a VEP reference
+built with the same five plugins; `merged_plugins_base` attaches nothing and
+isolates whether a core-field difference predates the plugin machinery. Confirm
+the profile resolves before running anything long — it needs the plugin cache at
+`$DATA/cache/plugin_cache_116` (or `--plugin-cache`) and the reference at
+`output/116/HG002_annotated_wgs_everything_hgvs_merged_clinvar_spliceai_cadd_am_dbnsfp.vcf[.gz]`.
+
+## Watch out for
+
+1. **chr21 first, then chr1.** Both are already built and validated, so a
+   mismatch is a comparison or annotation problem, not a cache-build problem.
+2. **`verify_parity_gate.py` refuses plugin profiles by design** — it pins the
+   Ensembl core CSQ contract and a plugin run emits fields outside it. Use the
+   comparison report, not the gate. Extending the gate is separate work.
+3. **Representation-only differences are expected and already handled.** PR #48
+   counts decimal padding (`0` vs `0.00`) and VEP's `.` marker separately from
+   real mismatches. If plugin float fields show ~0% match, check you are on that
+   branch before investigating the cache.
+4. **Do not pipe per-plugin output through `tail -N`** — it truncates the
+   diagnostics and has already produced one wrong conclusion here.
+5. **A prior 5-plugin chr22 run reported 37/38 fields at 100%**, but with a
+   different comparator (the old index-pairing one). Treat those numbers as
+   unverified until reproduced on the current pairing logic.
+
+## Done when
+
+- `merged_plugins` runs clean on chr21 and chr1, with per-field match rates
+  reported for every plugin CSQ field.
+- Every field below 100% is explained: a real cache defect, a known VEP
+  inconsistency, or a comparator artifact — named, not hand-waved.
+- Findings posted to PR #217 (the caches) and/or #48 (the comparator),
+  whichever the cause implicates.
+
+## Ground rules
+
+Measure before concluding. The engine-side investigation in this repo burned
+five plausible-but-wrong hypotheses that each died to the next measurement; the
+ones that survived came from instrumenting and reading numbers. If a parity gap
+appears, find the specific variant and inspect it in the raw source and the
+shard before theorising about the transform.

--- a/docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md
+++ b/docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md
@@ -304,18 +304,18 @@ verbatim. Concrete parameters:
 
 **Sort-key contract.** The PageDir search key is `start` within a tier run —
 **identical to variation's `(tier, start)`**. `allele_string` is **not** a PageDir
-search key: rows sharing a `start` are additionally ordered by `allele_string` for
-deterministic, byte-stable output, but allele disambiguation happens in the
-`scan` decode step (probe filters the candidate rows by `allele_string`), exactly
-as the variation lookup filters alleles after resolving position. Only `tier` and
-`start` are declared as `SortingColumn`s. All sort keys are top-level primitives,
-so leaf index == field index (the `point_lookup_writer_properties` assumption
-holds).
+search key: rows sharing a `start` need no additional physical ordering because
+allele disambiguation happens in the `scan` decode step (the probe filters
+candidate rows by `allele_string`), exactly as the variation lookup filters
+alleles after resolving position. Only `tier` and `start` are declared as
+`SortingColumn`s. All sort keys are top-level primitives, so leaf index == field
+index (the `point_lookup_writer_properties` assumption holds).
 
-The physical shape mirrors variation's two-pass write: warm run (tier 0) first,
-cold run (tier 1) second, each written in `start`-ascending order by the source
-`ORDER BY` — the writer never re-sorts across the run boundary, which is what
-gives the PageDir its two monotonic segments.
+The tier query emits the final physical order directly with
+`ORDER BY tier, start`: warm run (tier 0) first, cold run (tier 1) second, and
+`start` ascending within each run. The result is streamed once into a sibling
+`.build.tmp` Parquet file and atomically renamed after its footer is flushed.
+There are no per-tier Parquet intermediates and no decode/re-encode merge pass.
 
 ## 5. Runtime lookup & CSQ injection
 


### PR DESCRIPTION
Rebase of #196 onto current `master`. #196 branched from `86bd907` (v0.14.0); `master` is now at `e937e49` (v0.18.0), 14 commits ahead. All 10 commits replay; the content is unchanged apart from the dependency resolution described below.

## What #196 does

- **`build.rs`** — stream the tiered join output straight into per-tier temp shards instead of collecting the whole chromosome into one `Vec<RecordBatch>` and concat-sorting in memory. Peak memory goes from O(chromosome) to O(batch); that collect+concat+sort was still OOM-ing on CADD chr6-8 and chrX.
- **`source_manifest.rs`** — `assume_unique` lets a source that structurally cannot repeat a runtime probe key skip the build-time keep-first dedup pass, whose `HashSet<String>` was the other dominant memory cost.
- **`provider.rs`** — wire `ProviderKind::Vcf` and `ProviderKind::Bed` (both previously `NotImplemented`) so VCF and BED sources can be queried directly via `ingest_sql`, no `bcftools`-flatten preprocessing step.
- **`join.rs`** — `GROUP BY ... MIN(tier)` instead of `SELECT DISTINCT` when building the variation-tier probe view, so a key whose variation rows disagree on tier can no longer fan out the join; plus a semi-join that narrows the aggregation to keys the plugin actually has.

Plus the safety work from #196's own review rounds: `assert_start_monotonic` with a sorted-retry fallback when the tier join loses row order, `check_assume_unique_sample()` validating the assumption instead of trusting it, atomic final-shard rename, tier-bounds accounting, and per-stage timing logs.

## Rebase notes

Only the last commit conflicted, and only on the dependency pins:

- #196 pinned `datafusion-bio-formats` at `tag = "v1.8.8"` and added `datafusion-bio-format-bed` at that tag. `master` has since moved every `bio-formats` dependency to `rev = 80f3a6c` (v1.11.0) in #211. **Resolved in favour of master's pin** — `bio-format-bed` now rides the same rev as `vcf`/`core`/`ensembl-cache` rather than dragging a second, older checkout of the same repo into the build.
- `Cargo.lock` regenerated from that resolution (+38 lines, the `bio-format-bed` entry). The unrelated `tag=v1.8.0` entries are pre-existing on master.

`master` has not touched `src/plugin_cache/` at all since #196 branched, so there is no semantic conflict to resolve beyond the pins.

**The bio-formats bump is the one thing worth attention.** #196's I4 commit deliberately pinned the VCF provider's multi-allelic ALT shape in a test (it is `'|'`-joined, not the `','` the VCF spec would suggest) precisely so a version bump that changed it would fail loudly here rather than silently produce `allele_string`s that never match the variation key. That test passes at v1.11.0, so the shape is unchanged — the guard did its job.

## Test plan

- [x] `cargo build -p datafusion-bio-function-vep --all-features` — clean against bio-formats v1.11.0.
- [x] `cargo test -p datafusion-bio-function-vep --all-features` — 942 lib + 2 + 4 integration passed, 0 failed.
- [x] `cargo test ... plugin_cache` — 46 passed, including `vcf_source_multiallelic_alt_shape_is_pinned` and the `assert_start_monotonic` / `assume_unique` / sorted-retry regression tests.
- [x] `cargo fmt --all -- --check` clean (one violation introduced by the rebase, fixed), `cargo clippy --all-features --all-targets -- -D warnings` clean.
- [ ] Not re-run here: #196's production validation against real chromosome builds (CADD chr6/7, SpliceAI chr1-3, ClinVar chr22 via both the VCF and BED providers). Those were run on the pre-rebase branch against bio-formats v1.8.8; a spot-check on one chromosome at v1.11.0 would be worth doing before merge.

Paired with `biodatageeks/vepyr-plugins#2`, which sets `assume_unique = true` on the CADD/SpliceAI manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
